### PR TITLE
feat: HOST configurable, resume de sesión Claude y fix permisos

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -1,5 +1,11 @@
-# Bot de Telegram para desarrollo
+# Configuración del servidor
 # Copiar este archivo a .env y completar los valores
+
+# Host y puerto del servidor
+HOST=0.0.0.0
+PORT=3001
+
+# Bot de Telegram para desarrollo
 # El servidor crea bots.json automáticamente en el primer arranque
 # si bots.json no existe y BOT_TOKEN está definido.
 

--- a/server/index.js
+++ b/server/index.js
@@ -736,11 +736,12 @@ if (fs.existsSync(clientDist)) {
 // ─── Servidor ─────────────────────────────────────────────────────────────────
 
 const PORT = process.env.PORT || 3001;
-logger.info(`Iniciando servidor en puerto ${PORT}...`);
-server.listen(PORT, async () => {
-  logger.info(`Servidor escuchando en http://localhost:${PORT}`);
-  console.log(`Servidor escuchando en http://localhost:${PORT}`);
-  console.log(`HTTP API disponible en http://localhost:${PORT}/api/sessions`);
+const HOST = process.env.HOST || '0.0.0.0';
+logger.info(`Iniciando servidor en ${HOST}:${PORT}...`);
+server.listen(PORT, HOST, async () => {
+  logger.info(`Servidor escuchando en http://${HOST}:${PORT}`);
+  console.log(`Servidor escuchando en http://${HOST}:${PORT}`);
+  console.log(`HTTP API disponible en http://${HOST}:${PORT}/api/sessions`);
 
   logger.info('Iniciando bots de Telegram...');
   try {

--- a/server/telegram.js
+++ b/server/telegram.js
@@ -192,7 +192,12 @@ class ClaudePrintSession {
       claudeArgs.unshift('--permission-mode', modeMap[this.permissionMode] || 'default');
     }
     if (this.model) claudeArgs.push('--model', this.model);
-    if (this.messageCount > 0) claudeArgs.push('--continue');
+    // Reanudar sesión existente usando session_id explícito para no perder contexto
+    if (this.messageCount > 0 && this.claudeSessionId) {
+      claudeArgs.push('--resume', this.claudeSessionId);
+    } else if (this.messageCount > 0) {
+      claudeArgs.push('--continue');
+    }
 
     return new Promise((resolve, reject) => {
       const env = { ...process.env };
@@ -1156,7 +1161,7 @@ class TelegramBot {
       // ── Permisos Claude ───────────────────────────────────────────────────
       case 'permisos':
       case 'modo-permisos': {
-        if (!this._isClaudeBased(chat.provider)) {
+        if (!this._isClaudeBased() && !(chat.provider || '').includes('claude')) {
           await this.sendText(chatId, '❌ Solo disponible con Claude Code.');
           break;
         }


### PR DESCRIPTION
## Summary
- Añadir variables HOST/PORT al .env.example y binding configurable en index.js
- Usar --resume con session_id explícito para mantener contexto entre mensajes en Telegram
- Corregir verificación _isClaudeBased en comando de permisos

## Test plan
- [ ] Verificar que el servidor arranca con HOST/PORT custom
- [ ] Verificar que --resume mantiene contexto entre mensajes
- [ ] Verificar comando de permisos con provider Claude