### PR TITLE
fix: fallback Markdown en editMessageText de Telegram

### DIFF
--- a/server/telegram.js
+++ b/server/telegram.js
@@ -1754,7 +1754,15 @@ class TelegramBot {
         if (chat) chat.lastButtonsMsgId = editMsgId;
         return result;
       }
-      catch (e) { if (!e.message?.includes('not modified')) throw e; }
+      catch (e) {
+        if (e.message?.includes('not modified')) return;
+        // Fallback sin Markdown si Telegram rechaza el parse
+        try {
+          const result = await this._apiCall('editMessageText', { ...body, message_id: editMsgId, parse_mode: undefined });
+          if (chat) chat.lastButtonsMsgId = editMsgId;
+          return result;
+        } catch {}
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary
- Añade fallback sin `parse_mode` en `sendWithButtons` cuando `editMessageText` falla por Markdown mal formado
- Corrige error `can't parse entities` que aparecía al responder desde Claude

## Test plan
- [ ] Enviar mensaje al bot que genere respuesta con Markdown especial (backticks, underscores)
- [ ] Verificar que no aparece el error de parse entities en logs