### PR TITLE
feat: comando /whisper para gestionar transcripción

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ clawmint/
 │   ├── agents.js         # CRUD de agentes
 │   ├── skills.js         # Skills locales + búsqueda ClawHub
 │   ├── memory.js         # Memoria persistente por agente
+│   ├── transcriber.js    # Transcripción audio con faster-whisper
 │   └── events.js         # EventEmitter global
 └── client/
     └── src/

--- a/docs/servidor.md
+++ b/docs/servidor.md
@@ -1,4 +1,4 @@
-> Última modificación: 2026-03-16
+> Última modificación: 2026-03-18
 
 # Módulo Servidor
 
@@ -144,6 +144,32 @@ Skills locales en `server/skills/<slug>/SKILL.md`. Se inyectan como contexto adi
 ### memory.js — Memoria por agente
 
 Archivos de texto en `server/memory/<agentKey>/`. Se inyectan al inicio de cada conversación. El agente puede escribir en memoria usando la sintaxis `<memory:write file="nombre">contenido</memory:write>` en su respuesta.
+
+### transcriber.js — Transcripción de audio
+
+Transcribe audio (OGG/MP3/WAV) a texto usando **faster-whisper** (CTranslate2) con un venv Python local.
+
+| Parámetro | Default | Descripción |
+|---|---|---|
+| `model` | `medium` | Modelo Whisper (`tiny`, `base`, `small`, `medium`, `large-v2`, `large-v3`) |
+| `device` | `cpu` | Dispositivo de inferencia (`cpu` o `cuda`) |
+| `computeType` | `int8` | Tipo de cómputo (cuantización) |
+| `language` | `es` | Idioma de transcripción |
+| `beamSize` | `5` | Beam search size |
+| `timeout` | `300000` | Timeout en ms (5 min) |
+
+**Requisitos:**
+- Python venv en `~/.venvs/whisper/` con `faster-whisper` instalado
+- `ffmpeg` en PATH para decodificar audio OGG de Telegram
+
+**Funciones exportadas:**
+- `transcribe(filePath, opts)` — transcribe un archivo de audio
+- `getConfig()` — devuelve la configuración actual
+- `setModel(model)` — cambia el modelo en runtime
+- `VALID_MODELS` — array con los modelos disponibles
+- `httpsDownload(url, destPath)` — descarga un archivo por HTTPS
+
+**Comando Telegram:** `/whisper [modelo]` — ver config actual o cambiar modelo.
 
 ### events.js — EventEmitter global
 
@@ -292,6 +318,7 @@ El servidor responde con `{ type: "session_id", id: "uuid" }`. El cliente debe g
 | `/estado` | Estado de la sesión actual |
 | `/costo` | Costo acumulado de la sesión |
 | `/memoria` | Ver archivos de memoria del agente activo |
+| `/whisper [modelo]` | Ver o cambiar modelo de transcripción Whisper |
 | `/status-vps` | CPU, RAM y disco del servidor |
 | `/ls [path]` | Navegar el sistema de archivos |
 | `/dir [path]` | Alias de `/ls` |

--- a/server/telegram.js
+++ b/server/telegram.js
@@ -437,6 +437,7 @@ class TelegramBot {
           { command: 'estado', description: 'Estado detallado' },
           { command: 'agentes', description: 'Listar agentes' },
           { command: 'skills', description: 'Skills instalados' },
+          { command: 'whisper', description: 'Ver o cambiar modelo de transcripción' },
           { command: 'consola', description: 'Modo consola bash' },
           { command: 'recordar', description: 'Crear recordatorio' },
           { command: 'ayuda', description: 'Todos los comandos' },
@@ -529,7 +530,8 @@ class TelegramBot {
       await httpsDownload(fileUrl, tmpFile);
 
       // 3. Transcribir con Whisper local
-      await this.sendText(chatId, '🎙️ Transcribiendo audio...');
+      const whisperModel = require('./transcriber').DEFAULTS.model;
+      await this.sendText(chatId, `🎙️ Transcribiendo audio (whisper:${whisperModel})...`);
       const text = await transcribe(tmpFile);
 
       // 4. Limpiar archivo temporal
@@ -920,6 +922,7 @@ class TelegramBot {
           `/consola — modo consola bash (toggle)\n` +
           `/status-vps — CPU, RAM y disco\n\n` +
           `*Audio:*\n` +
+          `/whisper [modelo] — ver/cambiar modelo Whisper\n` +
           `🎙️ Enviá un audio de voz y se transcribe automáticamente\n\n` +
           `*Bot:*\n` +
           `/agente [key] — ver/cambiar agente\n` +
@@ -1192,6 +1195,34 @@ class TelegramBot {
             `✅ Modo cambiado a *${labels[newMode]}*\n` +
             `_El contexto de conversación se mantiene._`
           );
+        }
+        break;
+      }
+
+      // ── Whisper (transcripción de audio) ────────────────────────────
+      case 'whisper': {
+        const { getConfig, setModel, VALID_MODELS } = require('./transcriber');
+        if (args.length === 0) {
+          const cfg = getConfig();
+          await this.sendWithButtons(chatId,
+            `🎙️ *Whisper — Transcripción de audio*\n\n` +
+            `• Modelo: \`${cfg.model}\`\n` +
+            `• Device: \`${cfg.device}\`\n` +
+            `• Compute: \`${cfg.computeType}\`\n` +
+            `• Idioma: \`${cfg.language}\`\n` +
+            `• Beam size: \`${cfg.beamSize}\`\n` +
+            `• Timeout: \`${cfg.timeout / 1000}s\`\n\n` +
+            `Modelos: ${VALID_MODELS.map(m => `\`${m}\``).join(', ')}\n` +
+            `Usá /whisper <modelo> para cambiar.`,
+            VALID_MODELS.map(m => [{ text: cfg.model === m ? `✅ ${m}` : m, callback_data: `whisper:${m}` }])
+          );
+        } else {
+          const newModel = args[0].toLowerCase();
+          if (!setModel(newModel)) {
+            await this.sendText(chatId, `❌ Modelo inválido: \`${newModel}\`\nDisponibles: ${VALID_MODELS.join(', ')}`);
+          } else {
+            await this.sendText(chatId, `✅ Modelo Whisper cambiado a \`${newModel}\``);
+          }
         }
         break;
       }
@@ -2227,6 +2258,15 @@ class TelegramBot {
       return;
     }
 
+    if (data.startsWith('whisper:')) {
+      const { setModel } = require('./transcriber');
+      const newModel = data.slice(7);
+      if (setModel(newModel)) {
+        await this.sendText(chatId, `✅ Modelo Whisper cambiado a \`${newModel}\``);
+      }
+      return;
+    }
+
     if (data.startsWith('provider:') && providersModule) {
       const newProvider = data.slice(9);
       const available = providersModule.list().map(p => p.name);
@@ -2384,6 +2424,7 @@ class TelegramBot {
           `/consola — modo consola bash (toggle)\n` +
           `/status-vps — CPU, RAM y disco\n\n` +
           `*Audio:*\n` +
+          `/whisper [modelo] — ver/cambiar modelo Whisper\n` +
           `🎙️ Enviá un audio de voz y se transcribe automáticamente\n\n` +
           `*Bot:*\n` +
           `/agente [key] — ver/cambiar agente\n` +

--- a/server/transcriber.js
+++ b/server/transcriber.js
@@ -96,4 +96,14 @@ print(" ".join(s.text.strip() for s in segments))
   });
 }
 
-module.exports = { httpsDownload, transcribe, DEFAULTS };
+const VALID_MODELS = ['tiny', 'base', 'small', 'medium', 'large-v2', 'large-v3'];
+
+function getConfig() { return { ...DEFAULTS }; }
+
+function setModel(model) {
+  if (!VALID_MODELS.includes(model)) return false;
+  DEFAULTS.model = model;
+  return true;
+}
+
+module.exports = { httpsDownload, transcribe, DEFAULTS, VALID_MODELS, getConfig, setModel };


### PR DESCRIPTION
## Summary
- Nuevo comando `/whisper [modelo]` en Telegram para ver config y cambiar modelo Whisper en runtime
- Botones inline para seleccionar entre: tiny, base, small, medium, large-v2, large-v3
- Mensaje de transcripción ahora muestra el modelo activo (ej. `whisper:medium`)
- Documentación completa de `transcriber.js` en docs/servidor.md

## Test plan
- [ ] Ejecutar `/whisper` sin args → muestra config actual con botones
- [ ] Tocar botón de modelo → cambia y confirma
- [ ] Ejecutar `/whisper small` → cambia por texto
- [ ] Enviar audio → verificar que dice `(whisper:small)` en el placeholder