### PR TITLE
feat: unificar cwd en todas las sesiones de Telegram

### DIFF
--- a/server/channels/telegram/CallbackHandler.js
+++ b/server/channels/telegram/CallbackHandler.js
@@ -442,8 +442,7 @@ class CallbackHandler {
         await bot._sendToSession(chatId, 'continúa', chat);
       } else if (action === 'new') {
         if (bot._isClaudeBased()) {
-          const model = chat.claudeSession?.model || null;
-          chat.claudeSession = new ClaudePrintSession({ model, permissionMode: chat.claudeMode || 'ask' });
+          chat.claudeSession = new ClaudePrintSession(bot._claudeSessionOpts(chat));
           await bot.sendText(chatId, '✅ Nueva conversación iniciada.');
         } else {
           chat.aiHistory = [];
@@ -491,7 +490,7 @@ class CallbackHandler {
       const provider   = chat.provider || 'claude-code';
       if (provider === 'claude-code') {
         const model = newModel === 'default' ? null : newModel;
-        chat.claudeSession = new ClaudePrintSession({ model, permissionMode: chat.claudeMode || 'ask' });
+        chat.claudeSession = new ClaudePrintSession({ ...bot._claudeSessionOpts(chat), model });
         await bot.sendText(chatId, `✅ Modelo: \`${newModel}\`\n_Nueva sesión iniciada._`);
       } else {
         chat.model = newModel;
@@ -606,7 +605,7 @@ class CallbackHandler {
       const agentKey = data.slice(6);
       const agentDef = this.agents ? this.agents.get(agentKey) : null;
       if (agentDef?.prompt) {
-        chat.claudeSession = new ClaudePrintSession({ permissionMode: chat.claudeMode || 'ask' });
+        chat.claudeSession = new ClaudePrintSession(bot._claudeSessionOpts(chat));
         chat.activeAgent = { key: agentDef.key, prompt: agentDef.prompt };
         const fullPrompt = this.skills ? this.skills.buildAgentPrompt(agentDef) : agentDef.prompt;
         await bot._sendToSession(chatId, fullPrompt, chat);
@@ -660,8 +659,7 @@ class CallbackHandler {
       case 'nueva':
       case 'reset': {
         if (bot._isClaudeBased()) {
-          const model = chat.claudeSession?.model || null;
-          chat.claudeSession = new ClaudePrintSession({ model, permissionMode: chat.claudeMode || 'ask' });
+          chat.claudeSession = new ClaudePrintSession(bot._claudeSessionOpts(chat));
           await bot.sendWithButtons(chatId,
             `✅ Nueva conversación *${bot.defaultAgent}* iniciada (\`${chat.claudeSession.id.slice(0,8)}…\`)`,
             [[{ text: '🤖 Menú', callback_data: 'menu' }]]
@@ -734,7 +732,7 @@ class CallbackHandler {
 
       case 'basta_action': {
         chat.activeAgent = null;
-        chat.claudeSession = new ClaudePrintSession({ permissionMode: chat.claudeMode || 'ask' });
+        chat.claudeSession = new ClaudePrintSession({ ...bot._claudeSessionOpts(chat), model: null });
         const def = this.getMenuDef('menu:agentes', { bot });
         const text    = typeof def.text    === 'function' ? def.text(chat)    : def.text;
         const rawRows = typeof def.buttons === 'function' ? def.buttons(chat) : def.buttons;

--- a/server/channels/telegram/CommandHandler.js
+++ b/server/channels/telegram/CommandHandler.js
@@ -118,8 +118,7 @@ class CommandHandler {
       case 'reset':
       case 'clear': {
         if (bot._isClaudeBased()) {
-          const model = chat.claudeSession?.model || null;
-          chat.claudeSession = new ClaudePrintSession({ model, permissionMode: chat.claudeMode || 'ask' });
+          chat.claudeSession = new ClaudePrintSession(bot._claudeSessionOpts(chat));
           await bot.sendWithButtons(chatId,
             `✅ Nueva conversación *${bot.defaultAgent}* iniciada (\`${chat.claudeSession.id.slice(0,8)}…\`)`,
             [[{ text: '🤖 Menú', callback_data: 'menu' }]]
@@ -218,7 +217,7 @@ class CommandHandler {
           );
         } else {
           const nuevoModelo = args[0];
-          chat.claudeSession = new ClaudePrintSession({ model: nuevoModelo, permissionMode: chat.claudeMode || 'ask' });
+          chat.claudeSession = new ClaudePrintSession({ ...bot._claudeSessionOpts(chat), model: nuevoModelo });
           await bot.sendText(chatId, `✅ Modelo cambiado a \`${nuevoModelo}\`\nNueva sesión iniciada (\`${chat.claudeSession.id.slice(0,8)}…\`).`);
         }
         break;
@@ -399,18 +398,35 @@ class CommandHandler {
       }
 
       // ── Directorio ────────────────────────────────────────────────────────
+      case 'cd': {
+        const target = args.join(' ').trim() || process.env.HOME;
+        const resolved = target === '~' ? process.env.HOME
+          : target.startsWith('/') ? target
+          : path.resolve(chat.monitorCwd || process.env.HOME, target);
+        try {
+          const stat = fs.statSync(resolved);
+          if (!stat.isDirectory()) throw new Error('no es un directorio');
+          chat.monitorCwd = resolved;
+          const short = resolved.replace(process.env.HOME, '~');
+          await bot.sendText(chatId, `📁 Directorio cambiado a \`${short}\``);
+        } catch (err) {
+          await bot.sendText(chatId, `❌ cd: ${err.message}`);
+        }
+        break;
+      }
+
       case 'dir':
       case 'pwd':
       case 'cwd':
       case 'directorio': {
-        const sessionCwd = bot._isClaudeBased() && chat.claudeSession
-          ? chat.claudeSession.cwd : null;
         const monitorCwd = chat.monitorCwd || process.env.HOME;
-        await bot.sendText(chatId,
-          `📁 *Directorio de trabajo*\n\n` +
-          `Sesión Claude: \`${sessionCwd || 'sin sesión activa'}\`\n` +
-          `Monitor: \`${monitorCwd}\``
-        );
+        const short = monitorCwd.replace(process.env.HOME, '~');
+        let lines = `📁 *Directorio de trabajo*: \`${short}\``;
+        if (bot._isClaudeBased() && chat.claudeSession && chat.claudeSession.cwd !== monitorCwd) {
+          const sesShort = chat.claudeSession.cwd.replace(process.env.HOME, '~');
+          lines += `\n⚠️ Sesión Claude usa \`${sesShort}\` (se actualizará al resetear)`;
+        }
+        await bot.sendText(chatId, lines);
         break;
       }
 
@@ -440,7 +456,7 @@ class CommandHandler {
       case 'basta': {
         const prevKey = chat.activeAgent?.key;
         chat.activeAgent = null;
-        chat.claudeSession = new ClaudePrintSession({ permissionMode: chat.claudeMode || 'ask' });
+        chat.claudeSession = new ClaudePrintSession({ ...bot._claudeSessionOpts(chat), model: null });
         await bot.sendText(chatId, prevKey
           ? `✅ Agente *${prevKey}* desactivado. Claude normal restaurado.`
           : 'No había agente activo.');
@@ -898,7 +914,7 @@ class CommandHandler {
         // Detectar /{key} de agente con prompt de rol
         const agentDef = this.agents.get(cmd);
         if (agentDef?.prompt) {
-          chat.claudeSession = new ClaudePrintSession({ permissionMode: chat.claudeMode || 'ask' });
+          chat.claudeSession = new ClaudePrintSession(bot._claudeSessionOpts(chat));
           chat.activeAgent = { key: agentDef.key, prompt: agentDef.prompt };
           const fullPrompt = this.skills.buildAgentPrompt(agentDef);
           await bot._sendToSession(chatId, fullPrompt, chat);

--- a/server/channels/telegram/TelegramChannel.js
+++ b/server/channels/telegram/TelegramChannel.js
@@ -224,6 +224,14 @@ class TelegramBot {
     return !!(def && def.command && def.command.includes('claude'));
   }
 
+  _claudeSessionOpts(chat) {
+    return {
+      model: chat.claudeSession?.model || null,
+      permissionMode: chat.claudeMode || 'ask',
+      cwd: chat.monitorCwd || process.env.HOME,
+    };
+  }
+
   // ── Telegram API ─────────────────────────────────────────────────────────
 
   async _apiCall(method, body = {}) {
@@ -738,7 +746,7 @@ class TelegramBot {
     const agentKey = agentKeyOverride || this.defaultAgent;
     const agent    = this._agents ? this._agents.get(agentKey) : null;
     const command  = agent ? agent.command : agentKey === 'bash' ? null : agentKey;
-    const session  = this._sessionManager.create({ type: 'pty', command, cols: 80, rows: 24 });
+    const session  = this._sessionManager.create({ type: 'pty', command, cols: 80, rows: 24, cwd: chat.monitorCwd || process.env.HOME });
     chat.sessionId = session.id;
     return session;
   }

--- a/server/core/ClaudePrintSession.js
+++ b/server/core/ClaudePrintSession.js
@@ -11,7 +11,7 @@ function cpdbg(scope, ...args) { if (_cpDbg()) console.log(`[CPS:DBG:${scope}]`,
  * Extraído de telegram.js para reutilización por cualquier canal (Telegram, Discord, HTTP).
  */
 class ClaudePrintSession {
-  constructor({ model = null, permissionMode = 'ask' } = {}) {
+  constructor({ model = null, permissionMode = 'ask', cwd = null } = {}) {
     this.id = crypto.randomUUID();
     this.createdAt = Date.now();
     this.active = true;
@@ -22,7 +22,7 @@ class ClaudePrintSession {
     this.totalCostUsd = 0;        // costo acumulado de la sesión
     this.lastCostUsd = 0;         // costo del último mensaje
     this.claudeSessionId = null;  // session_id interno de claude
-    this.cwd = process.env.HOME;  // directorio de trabajo de la sesión
+    this.cwd = cwd || process.env.HOME;  // directorio de trabajo de la sesión
   }
 
   async sendMessage(text, onChunk = null) {
@@ -51,7 +51,7 @@ class ClaudePrintSession {
       delete env.CLAUDE_CODE_ENTRYPOINT;
 
       const child = spawn('claude', claudeArgs, {
-        cwd: process.env.HOME,
+        cwd: this.cwd,
         env,
         stdio: [isWin ? 'pipe' : 'ignore', 'pipe', 'ignore'],
         shell: isWin,


### PR DESCRIPTION
## Summary

- `chat.monitorCwd` es ahora la fuente de verdad del cwd para todas las sesiones creadas desde Telegram
- `ClaudePrintSession` acepta `cwd` en el constructor y lo usa en el spawn
- Helper `_claudeSessionOpts(chat)` en `TelegramChannel` centraliza model, permissionMode y cwd
- Todas las instanciaciones de `ClaudePrintSession` (9 en CommandHandler + CallbackHandler) usan el helper
- `getOrCreateSession` pasa `monitorCwd` al crear sesiones PTY
- Nuevo comando `/cd` para cambiar directorio (soporta paths absolutos, relativos y `~`)
- `/dir` actualizado: muestra cwd principal y avisa si la sesión Claude divergió

## Test plan

- [ ] `/cd /tmp` → confirmar respuesta con el path
- [ ] `/dir` → verificar que muestra `/tmp`
- [ ] Enviar mensaje a Claude → verificar que `claude -p` se ejecuta con `cwd: /tmp`
- [ ] `/consola` + `pwd` → confirmar que muestra `/tmp`
- [ ] `/reset` → verificar que la nueva sesión Claude conserva el cwd