### PR TITLE
fix: inyectar transcriber completo + normalizar model ID

### DIFF
--- a/server/bootstrap.js
+++ b/server/bootstrap.js
@@ -65,11 +65,10 @@ function createContainer() {
   try { providers     = require('./providers');      } catch {}
   try { providerConfig = require('./provider-config'); } catch {}
 
-  let transcriber = { httpsDownload: null, transcribe: null };
+  let transcriber = null;
   try {
-    const t = require('./transcriber');
-    transcriber = { httpsDownload: t.httpsDownload, transcribe: t.transcribe };
-    t.preload();
+    transcriber = require('./transcriber');
+    transcriber.preload();
   } catch {}
 
   let mcps = null;

--- a/server/transcriber.js
+++ b/server/transcriber.js
@@ -26,6 +26,10 @@ const DEFAULTS = {
 // Cargar config persistida al iniciar
 try {
   const saved = JSON.parse(fs.readFileSync(CONFIG_FILE, 'utf8'));
+  // Normalizar modelo: si solo dice "medium", convertir a "Xenova/whisper-medium"
+  if (saved.model && !saved.model.includes('/')) {
+    saved.model = `Xenova/whisper-${saved.model}`;
+  }
   Object.assign(DEFAULTS, saved);
 } catch {}
 


### PR DESCRIPTION
## Summary
- **bootstrap.js**: el refactor modular (`318c899`) recortó el transcriber a solo `httpsDownload` y `transcribe`, dejando fuera `getConfig`, `setModel`, `setLanguage`, `VALID_MODELS` y `VALID_LANGUAGES`. Esto causaba `getConfig is not a function` al usar `/whisper` en Telegram.
- **transcriber.js**: `whisper-config.json` podía tener `"model": "medium"` (formato faster-whisper) en vez de `"Xenova/whisper-medium"`, causando un 401 en HuggingFace al intentar resolver `https://huggingface.co/medium/...`.

## Cambios
- `bootstrap.js`: pasar `require('./transcriber')` completo en vez de un objeto con 2 funciones
- `transcriber.js`: normalizar model ID al cargar config (`"medium"` → `"Xenova/whisper-medium"`)

## Test plan
- [ ] Iniciar server y verificar que el modelo Whisper carga sin error 401
- [ ] Enviar `/whisper` en Telegram y verificar que muestra la UI con botones
- [ ] Cambiar modelo e idioma desde los botones inline
- [ ] Enviar audio y verificar que transcribe correctamente