### PR TITLE
feat: persistir cwd en SQLite para restaurar al reconectar

### DIFF
--- a/server/channels/telegram/CommandHandler.js
+++ b/server/channels/telegram/CommandHandler.js
@@ -26,6 +26,7 @@ class CommandHandler {
     providers    = null,
     providerConfig = null,
     transcriber  = null,
+    chatSettings = null,
     logger       = console,
   }) {
     this.agents        = agents;
@@ -38,7 +39,12 @@ class CommandHandler {
     this.providers     = providers;
     this.providerConfig = providerConfig;
     this.transcriber   = transcriber;
+    this.chatSettings  = chatSettings;
     this.logger        = logger;
+  }
+
+  _persistCwd(botKey, chatId, cwd) {
+    if (this.chatSettings) this.chatSettings.saveCwd(String(botKey), String(chatId), cwd);
   }
 
   _getSystemStats() { return getSystemStats(); }
@@ -407,6 +413,7 @@ class CommandHandler {
           const stat = fs.statSync(resolved);
           if (!stat.isDirectory()) throw new Error('no es un directorio');
           chat.monitorCwd = resolved;
+          this._persistCwd(bot.key, chatId, resolved);
           const short = resolved.replace(process.env.HOME, '~');
           await bot.sendText(chatId, `📁 Directorio cambiado a \`${short}\``);
         } catch (err) {
@@ -652,6 +659,7 @@ class CommandHandler {
             await bot.sendText(chatId, `📄 ${path.basename(dir)}\n\n${content.slice(0, 3500)}${note}`);
           } else {
             chat.monitorCwd = dir;
+            this._persistCwd(bot.key, chatId, dir);
             await bot.sendText(chatId, this._buildLsText(dir));
           }
         } catch (err) {
@@ -669,6 +677,7 @@ class CommandHandler {
           const stat = fs.statSync(filePath);
           if (stat.isDirectory()) {
             chat.monitorCwd = filePath;
+            this._persistCwd(bot.key, chatId, filePath);
             await bot.sendText(chatId, this._buildLsText(filePath));
           } else {
             let content;

--- a/server/channels/telegram/TelegramChannel.js
+++ b/server/channels/telegram/TelegramChannel.js
@@ -470,7 +470,7 @@ class TelegramBot {
         lastPreview:    '',
         rateLimited:    false,
         rateLimitedUntil: 0,
-        monitorCwd:     process.env.HOME,
+        monitorCwd:     saved?.cwd || process.env.HOME,
         busy:           false,
         provider:       saved?.provider || 'claude-code',
         model:          saved?.model    || null,
@@ -791,6 +791,7 @@ class TelegramBot {
       const target = trimmed.slice(2).trim();
       const result = session.changeDirectory(target);
       chat.monitorCwd = session.cwd;
+      if (this._chatSettings) this._chatSettings.saveCwd(this.key, chatId, session.cwd);
       const msg = result.ok ? '' : `❌ cd: ${result.error}`;
       await this._sendConsolePrompt(chatId, msg, chat);
       return;
@@ -952,6 +953,7 @@ class TelegramChannel extends BaseChannel {
       sessionManager: this._sessionManager,
       providers:     this._providers,
       providerConfig: this._providerConfig,
+      chatSettings:  this._chatSettings,
       transcriber:   this._transcriber,
       logger:        this._logger,
     });

--- a/server/storage/ChatSettingsRepository.js
+++ b/server/storage/ChatSettingsRepository.js
@@ -12,46 +12,67 @@ class ChatSettingsRepository {
       chat_id  TEXT NOT NULL,
       provider TEXT NOT NULL DEFAULT 'claude-code',
       model    TEXT,
+      cwd      TEXT,
       PRIMARY KEY (bot_key, chat_id)
     )
   `;
+
+  static MIGRATIONS = [
+    `ALTER TABLE chat_settings ADD COLUMN cwd TEXT`,
+  ];
 
   constructor(db) {
     this._db = db || null;
   }
 
-  /** Crea la tabla si no existe. Idempotente. */
+  /** Crea la tabla si no existe y aplica migraciones. Idempotente. */
   init() {
     if (!this._db) return;
     this._db.exec(ChatSettingsRepository.SCHEMA);
+    for (const sql of ChatSettingsRepository.MIGRATIONS) {
+      try { this._db.exec(sql); } catch {}
+    }
   }
 
   /**
    * @param {string} botKey
    * @param {number|string} chatId
-   * @returns {{ provider: string, model: string|null } | null}
+   * @returns {{ provider: string, model: string|null, cwd: string|null } | null}
    */
   load(botKey, chatId) {
     if (!this._db) return null;
     return this._db.prepare(
-      'SELECT provider, model FROM chat_settings WHERE bot_key = ? AND chat_id = ?'
+      'SELECT provider, model, cwd FROM chat_settings WHERE bot_key = ? AND chat_id = ?'
     ).get(String(botKey), String(chatId)) || null;
   }
 
   /**
    * @param {string} botKey
    * @param {number|string} chatId
-   * @param {{ provider: string, model?: string|null }} settings
+   * @param {{ provider: string, model?: string|null, cwd?: string|null }} settings
    */
-  save(botKey, chatId, { provider, model }) {
+  save(botKey, chatId, { provider, model, cwd }) {
     if (!this._db) return;
     this._db.prepare(`
-      INSERT INTO chat_settings (bot_key, chat_id, provider, model)
-      VALUES (?, ?, ?, ?)
+      INSERT INTO chat_settings (bot_key, chat_id, provider, model, cwd)
+      VALUES (?, ?, ?, ?, ?)
       ON CONFLICT(bot_key, chat_id) DO UPDATE SET
         provider = excluded.provider,
-        model    = excluded.model
-    `).run(String(botKey), String(chatId), provider, model ?? null);
+        model    = excluded.model,
+        cwd      = excluded.cwd
+    `).run(String(botKey), String(chatId), provider, model ?? null, cwd ?? null);
+  }
+
+  /**
+   * Persiste solo el cwd sin tocar provider/model.
+   */
+  saveCwd(botKey, chatId, cwd) {
+    if (!this._db) return;
+    this._db.prepare(`
+      INSERT INTO chat_settings (bot_key, chat_id, provider, cwd)
+      VALUES (?, ?, 'claude-code', ?)
+      ON CONFLICT(bot_key, chat_id) DO UPDATE SET cwd = excluded.cwd
+    `).run(String(botKey), String(chatId), cwd);
   }
 }
 


### PR DESCRIPTION
## Summary
- Al reiniciar el servidor, cada chat de Telegram perdía su directorio de trabajo y volvía a `$HOME`
- Ahora el `cwd` se persiste en SQLite (`chat_settings.cwd`) y se restaura al reconectar
- Migración automática: `ALTER TABLE chat_settings ADD COLUMN cwd` (idempotente, no rompe DBs existentes)

## Cambios
- **ChatSettingsRepository**: nueva columna `cwd`, migración automática, método `saveCwd()` para actualizar solo el cwd sin tocar provider/model
- **TelegramChannel**: restaurar `monitorCwd` desde `saved.cwd` al crear chat; persistir en console mode (`cd`)
- **CommandHandler**: recibe `chatSettings`, persiste cwd en `/cd`, `/ls` (navegar a directorio), `/cat` (navegar a directorio)

## Test plan
- [ ] Iniciar server, navegar con `/cd` a un directorio profundo
- [ ] Reiniciar el server
- [ ] Enviar cualquier mensaje → verificar que `/cwd` muestra el directorio anterior
- [ ] Verificar que `/cd`, `/ls` y console mode siguen persistiendo