### PR TITLE
feat: persistir sesión de Claude + cwd para resume tras reinicio

### DIFF
--- a/server/channels/telegram/CallbackHandler.js
+++ b/server/channels/telegram/CallbackHandler.js
@@ -388,19 +388,31 @@ class CallbackHandler {
     let chat = bot.chats.get(chatId);
     if (!chat) {
       const saved = this.chatSettings ? this.chatSettings.load(bot.key, chatId) : null;
+
+      // Restaurar sesión de Claude desde SQLite si hay una guardada
+      let restoredSession = null;
+      if (saved?.claude_session_id && saved.message_count > 0) {
+        restoredSession = new ClaudePrintSession({
+          claudeSessionId: saved.claude_session_id,
+          messageCount:    saved.message_count,
+          cwd:             saved.cwd || process.env.HOME,
+          model:           saved.model || null,
+        });
+      }
+
       chat = {
         chatId,
         username: cbq.from?.username || null,
         firstName: cbq.from?.first_name || 'Usuario',
         sessionId: null,
-        claudeSession: null,
+        claudeSession: restoredSession,
         activeAgent: null,
         pendingAction: null,
         lastMessageAt: Date.now(),
         lastPreview: '',
         rateLimited: false,
         rateLimitedUntil: 0,
-        monitorCwd: process.env.HOME,
+        monitorCwd: saved?.cwd || process.env.HOME,
         busy: false,
         provider: saved?.provider || 'claude-code',
         model: saved?.model || null,
@@ -520,6 +532,7 @@ class CallbackHandler {
         chat.model    = null;
         if (newProvider === 'claude-code') {
           chat.claudeSession = null;
+          if (this.chatSettings) this.chatSettings.clearSession(bot.key, chatId);
         } else {
           chat.aiHistory = [];
         }
@@ -660,6 +673,7 @@ class CallbackHandler {
       case 'reset': {
         if (bot._isClaudeBased()) {
           chat.claudeSession = new ClaudePrintSession(bot._claudeSessionOpts(chat));
+          if (this.chatSettings) this.chatSettings.clearSession(bot.key, chatId);
           await bot.sendWithButtons(chatId,
             `✅ Nueva conversación *${bot.defaultAgent}* iniciada (\`${chat.claudeSession.id.slice(0,8)}…\`)`,
             [[{ text: '🤖 Menú', callback_data: 'menu' }]]

--- a/server/channels/telegram/CallbackHandler.js
+++ b/server/channels/telegram/CallbackHandler.js
@@ -455,6 +455,7 @@ class CallbackHandler {
       } else if (action === 'new') {
         if (bot._isClaudeBased()) {
           chat.claudeSession = new ClaudePrintSession(bot._claudeSessionOpts(chat));
+          if (this.chatSettings) this.chatSettings.clearSession(bot.key, chatId);
           await bot.sendText(chatId, '✅ Nueva conversación iniciada.');
         } else {
           chat.aiHistory = [];

--- a/server/channels/telegram/CommandHandler.js
+++ b/server/channels/telegram/CommandHandler.js
@@ -125,6 +125,7 @@ class CommandHandler {
       case 'clear': {
         if (bot._isClaudeBased()) {
           chat.claudeSession = new ClaudePrintSession(bot._claudeSessionOpts(chat));
+          if (this.chatSettings) this.chatSettings.clearSession(bot.key, chatId);
           await bot.sendWithButtons(chatId,
             `✅ Nueva conversación *${bot.defaultAgent}* iniciada (\`${chat.claudeSession.id.slice(0,8)}…\`)`,
             [[{ text: '🤖 Menú', callback_data: 'menu' }]]
@@ -785,6 +786,7 @@ class CommandHandler {
           chat.provider = newProvider;
           if (newProvider === 'claude-code') {
             chat.claudeSession = null;
+            if (this.chatSettings) this.chatSettings.clearSession(bot.key, chatId);
           } else {
             chat.aiHistory = [];
           }

--- a/server/channels/telegram/CommandHandler.js
+++ b/server/channels/telegram/CommandHandler.js
@@ -414,6 +414,9 @@ class CommandHandler {
           const stat = fs.statSync(resolved);
           if (!stat.isDirectory()) throw new Error('no es un directorio');
           chat.monitorCwd = resolved;
+          // Sincronizar cwd de la sesión Claude activa para que el próximo
+          // mensaje use el directorio correcto
+          if (chat.claudeSession) chat.claudeSession.cwd = resolved;
           this._persistCwd(bot.key, chatId, resolved);
           const short = resolved.replace(process.env.HOME, '~');
           await bot.sendText(chatId, `📁 Directorio cambiado a \`${short}\``);

--- a/server/channels/telegram/TelegramChannel.js
+++ b/server/channels/telegram/TelegramChannel.js
@@ -724,11 +724,13 @@ class TelegramBot {
       if (result.history)          chat.aiHistory     = result.history;
 
       // Persistir sesión de Claude en SQLite para sobrevivir reinicios
+      // Usar monitorCwd (directorio elegido por el usuario) en vez de claudeSession.cwd
+      // para no sobreescribir el cwd del usuario con el cwd interno de Claude
       if (chat.claudeSession?.claudeSessionId && this._chatSettings) {
         this._chatSettings.saveSession(this.key, chatId, {
           claudeSessionId: chat.claudeSession.claudeSessionId,
           messageCount:    chat.claudeSession.messageCount,
-          cwd:             chat.claudeSession.cwd,
+          cwd:             chat.monitorCwd || chat.claudeSession.cwd,
         });
       }
 
@@ -746,6 +748,13 @@ class TelegramBot {
       stopAnim();
       console.error(`[Telegram:${this.key}] Error en chat ${chatId}:`, err.message);
       tdbg('send', `CATCH ERROR: ${err.stack || err.message}`);
+      // Si Claude falló, limpiar sesión rota para que el próximo mensaje no reintente --resume
+      if (chat.claudeSession && err.message?.includes('código')) {
+        tdbg('send', `limpiando sesión rota`);
+        chat.claudeSession.claudeSessionId = null;
+        chat.claudeSession.messageCount = 0;
+        if (this._chatSettings) this._chatSettings.clearSession(this.key, chatId);
+      }
       const errMsg = `⚠️ Error: ${err.message}`;
       try {
         if (sentMsg) {
@@ -814,6 +823,7 @@ class TelegramBot {
       const target = trimmed.slice(2).trim();
       const result = session.changeDirectory(target);
       chat.monitorCwd = session.cwd;
+      if (chat.claudeSession) chat.claudeSession.cwd = session.cwd;
       if (this._chatSettings) this._chatSettings.saveCwd(this.key, chatId, session.cwd);
       const msg = result.ok ? '' : `❌ cd: ${result.error}`;
       await this._sendConsolePrompt(chatId, msg, chat);

--- a/server/channels/telegram/TelegramChannel.js
+++ b/server/channels/telegram/TelegramChannel.js
@@ -458,12 +458,25 @@ class TelegramBot {
     let chat = this.chats.get(chatId);
     if (!chat) {
       const saved = this._chatSettings ? this._chatSettings.load(this.key, chatId) : null;
+
+      // Restaurar sesión de Claude desde SQLite si hay una guardada
+      let restoredSession = null;
+      if (saved?.claude_session_id && saved.message_count > 0) {
+        restoredSession = new ClaudePrintSession({
+          claudeSessionId: saved.claude_session_id,
+          messageCount:    saved.message_count,
+          cwd:             saved.cwd || process.env.HOME,
+          model:           saved.model || null,
+        });
+        tdbg('init', `restored session ${saved.claude_session_id.slice(0,8)}… msgCount=${saved.message_count} cwd=${saved.cwd}`);
+      }
+
       chat = {
         chatId,
         username:       msg.from?.username || null,
         firstName:      msg.from?.first_name || 'Usuario',
         sessionId:      null,
-        claudeSession:  null,
+        claudeSession:  restoredSession,
         activeAgent:    null,
         pendingAction:  null,
         lastMessageAt:  Date.now(),
@@ -709,6 +722,16 @@ class TelegramBot {
 
       if (result.newSession)       chat.claudeSession = result.newSession;
       if (result.history)          chat.aiHistory     = result.history;
+
+      // Persistir sesión de Claude en SQLite para sobrevivir reinicios
+      if (chat.claudeSession?.claudeSessionId && this._chatSettings) {
+        this._chatSettings.saveSession(this.key, chatId, {
+          claudeSessionId: chat.claudeSession.claudeSessionId,
+          messageCount:    chat.claudeSession.messageCount,
+          cwd:             chat.claudeSession.cwd,
+        });
+      }
+
       if (result.savedMemoryFiles?.length > 0) {
         if (!chat._savedInSession) chat._savedInSession = [];
         for (const f of result.savedMemoryFiles) {

--- a/server/core/ClaudePrintSession.js
+++ b/server/core/ClaudePrintSession.js
@@ -11,17 +11,17 @@ function cpdbg(scope, ...args) { if (_cpDbg()) console.log(`[CPS:DBG:${scope}]`,
  * Extraído de telegram.js para reutilización por cualquier canal (Telegram, Discord, HTTP).
  */
 class ClaudePrintSession {
-  constructor({ model = null, permissionMode = 'ask', cwd = null } = {}) {
+  constructor({ model = null, permissionMode = 'ask', cwd = null, claudeSessionId = null, messageCount = 0 } = {}) {
     this.id = crypto.randomUUID();
     this.createdAt = Date.now();
     this.active = true;
-    this.messageCount = 0;
+    this.messageCount = messageCount;
     this.title = 'claude';
     this.model = model;                    // modelo explícito (null = default)
     this.permissionMode = permissionMode;  // 'auto' | 'ask' | 'plan'
     this.totalCostUsd = 0;        // costo acumulado de la sesión
     this.lastCostUsd = 0;         // costo del último mensaje
-    this.claudeSessionId = null;  // session_id interno de claude
+    this.claudeSessionId = claudeSessionId;  // session_id interno de claude (persistible)
     this.cwd = cwd || process.env.HOME;  // directorio de trabajo de la sesión
   }
 
@@ -40,7 +40,11 @@ class ClaudePrintSession {
       claudeArgs.unshift('--permission-mode', modeMap[this.permissionMode] || 'default');
     }
     if (this.model) claudeArgs.push('--model', this.model);
-    if (this.messageCount > 0) claudeArgs.push('--continue');
+    if (this.messageCount > 0 && this.claudeSessionId) {
+      claudeArgs.push('--resume', this.claudeSessionId);
+    } else if (this.messageCount > 0) {
+      claudeArgs.push('--continue');
+    }
 
     cpdbg('spawn', `args=[${claudeArgs.join(' ')}] mode=${this.permissionMode} model=${this.model} msgCount=${this.messageCount}`);
     cpdbg('spawn', `text="${text.slice(0, 120)}${text.length > 120 ? '...' : ''}" (${text.length} chars ${isWin ? 'via stdin' : 'via arg'})`);

--- a/server/services/ConversationService.js
+++ b/server/services/ConversationService.js
@@ -132,7 +132,22 @@ class ConversationService {
 
     csdbg('claude', `→ session.sendMessage() textLen=${messageText.length}`);
     const t0 = Date.now();
-    const rawResponse = await session.sendMessage(messageText, onChunk);
+    let rawResponse;
+    try {
+      rawResponse = await session.sendMessage(messageText, onChunk);
+    } catch (err) {
+      // Si falló con --resume (session_id viejo/inválido), reintentar como nueva sesión
+      if (session.claudeSessionId && session.messageCount > 0) {
+        csdbg('claude', `--resume falló (${err.message}), reintentando como nueva sesión`);
+        console.log(`[ConvSvc] --resume falló (${err.message}), reintentando sin resume`);
+        session.claudeSessionId = null;
+        session.messageCount = 0;
+        isNewSession = true;
+        rawResponse = await session.sendMessage(messageText, onChunk);
+      } else {
+        throw err;
+      }
+    }
     csdbg('claude', `← session.sendMessage() ${Date.now() - t0}ms responseLen=${rawResponse?.length || 0}`);
 
     // Extraer y aplicar operaciones de memoria

--- a/server/storage/ChatSettingsRepository.js
+++ b/server/storage/ChatSettingsRepository.js
@@ -19,6 +19,8 @@ class ChatSettingsRepository {
 
   static MIGRATIONS = [
     `ALTER TABLE chat_settings ADD COLUMN cwd TEXT`,
+    `ALTER TABLE chat_settings ADD COLUMN claude_session_id TEXT`,
+    `ALTER TABLE chat_settings ADD COLUMN message_count INTEGER DEFAULT 0`,
   ];
 
   constructor(db) {
@@ -42,7 +44,7 @@ class ChatSettingsRepository {
   load(botKey, chatId) {
     if (!this._db) return null;
     return this._db.prepare(
-      'SELECT provider, model, cwd FROM chat_settings WHERE bot_key = ? AND chat_id = ?'
+      'SELECT provider, model, cwd, claude_session_id, message_count FROM chat_settings WHERE bot_key = ? AND chat_id = ?'
     ).get(String(botKey), String(chatId)) || null;
   }
 
@@ -73,6 +75,32 @@ class ChatSettingsRepository {
       VALUES (?, ?, 'claude-code', ?)
       ON CONFLICT(bot_key, chat_id) DO UPDATE SET cwd = excluded.cwd
     `).run(String(botKey), String(chatId), cwd);
+  }
+
+  /**
+   * Persiste el estado de la sesión de Claude (session_id + message_count + cwd).
+   */
+  saveSession(botKey, chatId, { claudeSessionId, messageCount, cwd }) {
+    if (!this._db) return;
+    this._db.prepare(`
+      INSERT INTO chat_settings (bot_key, chat_id, provider, claude_session_id, message_count, cwd)
+      VALUES (?, ?, 'claude-code', ?, ?, ?)
+      ON CONFLICT(bot_key, chat_id) DO UPDATE SET
+        claude_session_id = excluded.claude_session_id,
+        message_count     = excluded.message_count,
+        cwd               = excluded.cwd
+    `).run(String(botKey), String(chatId), claudeSessionId ?? null, messageCount ?? 0, cwd ?? null);
+  }
+
+  /**
+   * Limpia la sesión de Claude (al hacer /new o reset).
+   */
+  clearSession(botKey, chatId) {
+    if (!this._db) return;
+    this._db.prepare(`
+      UPDATE chat_settings SET claude_session_id = NULL, message_count = 0
+      WHERE bot_key = ? AND chat_id = ?
+    `).run(String(botKey), String(chatId));
   }
 }
 


### PR DESCRIPTION
## Summary
- Al reiniciar el servidor, las sesiones de Claude se perdían completamente — el usuario tenía que empezar de cero
- Ahora se persiste `claude_session_id`, `message_count` y `cwd` en SQLite
- Al reconectar, se restaura la sesión y se usa `--resume <session_id>` para continuar donde quedó

## Cambios
- **ClaudePrintSession**: acepta `claudeSessionId` y `messageCount` en el constructor para restaurar sesiones; usa `--resume <id>` cuando hay session_id guardado
- **ChatSettingsRepository**: nuevas columnas `claude_session_id` y `message_count` con migración automática; métodos `saveSession()` y `clearSession()`
- **TelegramChannel**: restaura `ClaudePrintSession` desde SQLite al crear chat; persiste sesión después de cada respuesta
- **CallbackHandler/CommandHandler**: limpia sesión en SQLite al hacer `/nueva`, reset, o cambio de provider

## Test plan
- [ ] Iniciar server, enviar mensaje a Claude, verificar que responde
- [ ] Reiniciar server, enviar otro mensaje → debe continuar la conversación (no empezar de cero)
- [ ] Verificar que `/cwd` muestra el directorio correcto tras reinicio
- [ ] Hacer `/nueva` o reset → verificar que se limpia la sesión en SQLite
- [ ] Cambiar provider → verificar que se limpia la sesión de Claude