### PR TITLE
chore: git hooks para proteger rama main

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Bloquear commits directos en main — usar ramas + PR
+
+protected_branch="main"
+current_branch=$(git symbolic-ref HEAD 2>/dev/null | sed 's|refs/heads/||')
+
+if [ "$current_branch" = "$protected_branch" ]; then
+  echo "❌ Commit directo en '$protected_branch' bloqueado."
+  echo "   Creá una rama primero: git checkout -b mi-rama"
+  exit 1
+fi
+
+exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Bloquear push directo a main — usar ramas + PR
+
+protected_branch="main"
+current_branch=$(git symbolic-ref HEAD 2>/dev/null | sed 's|refs/heads/||')
+
+if [ "$current_branch" = "$protected_branch" ]; then
+  echo "❌ Push directo a '$protected_branch' bloqueado."
+  echo "   Creá una rama, pusheá ahí y abrí un PR."
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
- Agrega hooks `pre-commit` y `pre-push` en `.githooks/` que bloquean commits y pushes directos a `main`
- Los hooks se versionan con el repo (a diferencia de `.git/hooks/`)
- Se activan con: `git config core.hooksPath .githooks`

## Test plan
- [x] `git commit` en main → bloqueado
- [x] `git push` en main → bloqueado
- [ ] `git commit` en otra rama → permitido
- [ ] `git push` en otra rama → permitido