### PR TITLE
fix(telegram): fallback en editMessageText por Markdown roto

### DIFF
--- a/server/channels/telegram/TelegramChannel.js
+++ b/server/channels/telegram/TelegramChannel.js
@@ -928,7 +928,14 @@ class TelegramBot {
         const result = await this._apiCall('editMessageText', { ...body, message_id: editMsgId });
         if (chat) chat.lastButtonsMsgId = editMsgId;
         return result;
-      } catch (e) { if (!e.message?.includes('not modified')) throw e; }
+      } catch (e) {
+        if (e.message?.includes('not modified')) return;
+        try {
+          const result = await this._apiCall('editMessageText', { ...body, message_id: editMsgId, parse_mode: undefined });
+          if (chat) chat.lastButtonsMsgId = editMsgId;
+          return result;
+        } catch (e2) { if (!e2.message?.includes('not modified')) console.error(`[Telegram] editMsg fallback FAIL: ${e2.message}`); }
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary
- Agrega fallback sin `parse_mode` en `sendWithButtons()` cuando `editMessageText` falla por Markdown mal formado
- Evita el error `can't parse entities: Can't find end of the entity starting at byte offset X`
- El mensaje se envía como texto plano solo cuando el formato falla

## Test plan
- [ ] Enviar mensaje con `*` suelto desde el bot → ya no tira error
- [ ] Mensajes con formato válido siguen mostrándose con Markdown