### PR TITLE
feat(telegram): soporte para recibir fotos con visión

### DIFF
--- a/server/channels/telegram/TelegramChannel.js
+++ b/server/channels/telegram/TelegramChannel.js
@@ -418,6 +418,10 @@ class TelegramBot {
       await this._handleVoiceMessage(msg);
       return;
     }
+    if (msg.photo) {
+      await this._handlePhotoMessage(msg);
+      return;
+    }
     if (!msg.text) return;
     await this._handleMessage(msg);
   }
@@ -456,6 +460,47 @@ class TelegramBot {
     } catch (err) {
       console.error(`[Telegram:${this.key}] Error procesando audio:`, err.message);
       await this.sendText(chatId, `❌ Error al procesar audio: ${err.message}`);
+    }
+  }
+
+  async _handlePhotoMessage(msg) {
+    const chatId = msg.chat.id;
+    if (!this._isAllowed(chatId, msg.chat.type)) {
+      await this.sendText(chatId, '⛔ No tenés acceso a este bot.', msg.message_id);
+      return;
+    }
+    try {
+      // Telegram envía array de resoluciones, tomar la más grande
+      const photo  = msg.photo[msg.photo.length - 1];
+      const fileInfo = await this._apiCall('getFile', { file_id: photo.file_id });
+      const fileUrl  = `https://api.telegram.org/file/bot${this.token}/${fileInfo.file_path}`;
+
+      // Descargar foto a buffer
+      const buffer = await new Promise((resolve, reject) => {
+        https.get(fileUrl, (res) => {
+          if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+            https.get(res.headers.location, (r2) => {
+              const chunks = []; r2.on('data', c => chunks.push(c)); r2.on('end', () => resolve(Buffer.concat(chunks))); r2.on('error', reject);
+            }).on('error', reject);
+            return;
+          }
+          const chunks = []; res.on('data', c => chunks.push(c)); res.on('end', () => resolve(Buffer.concat(chunks))); res.on('error', reject);
+        }).on('error', reject);
+      });
+
+      const ext = path.extname(fileInfo.file_path || '').replace('.', '') || 'jpg';
+      const mediaType = ext === 'png' ? 'image/png' : ext === 'gif' ? 'image/gif' : ext === 'webp' ? 'image/webp' : 'image/jpeg';
+      const base64 = buffer.toString('base64');
+
+      console.log(`[Telegram:${this.key}] Foto recibida de ${chatId}: ${photo.width}x${photo.height}, ${Math.round(buffer.length / 1024)}KB`);
+
+      // Pasar al handler con la imagen adjunta
+      msg.text = msg.caption || 'Describe esta imagen';
+      msg._images = [{ base64, mediaType }];
+      await this._handleMessage(msg);
+    } catch (err) {
+      console.error(`[Telegram:${this.key}] Error procesando foto:`, err.message);
+      await this.sendText(chatId, `❌ Error al procesar la foto: ${err.message}`);
     }
   }
 
@@ -600,7 +645,7 @@ class TelegramBot {
       const args  = parts.slice(1);
       await this._handleCommand(msg, cmd, args, chat);
     } else {
-      await this._sendToSession(chatId, text, chat);
+      await this._sendToSession(chatId, text, chat, msg._images);
     }
   }
 
@@ -681,7 +726,7 @@ class TelegramBot {
 
   // ── Envío a sesión / provider ─────────────────────────────────────────────
 
-  async _sendToSession(chatId, text, chat) {
+  async _sendToSession(chatId, text, chat, images = null) {
     tdbg('send', `chatId=${chatId} text="${text.slice(0, 80)}" busy=${chat.busy}`);
     if (chat.busy) {
       tdbg('send', `SKIP — chat busy`);
@@ -763,6 +808,7 @@ class TelegramBot {
         provider:      chatProvider,
         model:         chat.model,
         text:          messageText,
+        images:        images || null,
         history:       chat.aiHistory || [],
         claudeSession: chat.claudeSession,
         claudeMode:    mode,

--- a/server/providers/gemini.js
+++ b/server/providers/gemini.js
@@ -9,7 +9,7 @@ module.exports = {
   defaultModel: 'gemini-2.5-flash',
   models: ['gemini-2.5-flash', 'gemini-2.5-pro'],
 
-  async *chat({ systemPrompt, history, apiKey, model, executeTool: execToolFn }) {
+  async *chat({ systemPrompt, history, apiKey, model, executeTool: execToolFn, images }) {
     if (!apiKey) {
       yield { type: 'done', fullText: 'Error: API key de Gemini no configurada. Configurala en el panel ⚙️.' };
       return;
@@ -37,7 +37,15 @@ module.exports = {
     if (systemPrompt) config.systemInstruction = systemPrompt;
 
     let fullText = '';
-    let currentContents = [...contents, { role: 'user', parts: [{ text: userText }] }];
+    // Construir parts del último mensaje con imágenes si las hay
+    const lastParts = [];
+    if (images && images.length > 0) {
+      for (const img of images) {
+        lastParts.push({ inlineData: { mimeType: img.mediaType, data: img.base64 } });
+      }
+    }
+    lastParts.push({ text: userText });
+    let currentContents = [...contents, { role: 'user', parts: lastParts }];
 
     while (true) {
       let response;

--- a/server/providers/grok.js
+++ b/server/providers/grok.js
@@ -25,7 +25,7 @@ module.exports = {
       messages.push({ role: 'system', content: systemPrompt });
     }
     for (const m of history) {
-      messages.push({ role: m.role === 'assistant' ? 'assistant' : 'user', content: m.content || '' });
+      messages.push({ role: m.role === 'assistant' ? 'assistant' : 'user', content: Array.isArray(m.content) ? m.content : (m.content || '') });
     }
 
     let fullText = '';

--- a/server/providers/openai.js
+++ b/server/providers/openai.js
@@ -26,7 +26,7 @@ module.exports = {
       messages.push({ role: 'system', content: systemPrompt });
     }
     for (const m of history) {
-      messages.push({ role: m.role === 'assistant' ? 'assistant' : 'user', content: m.content || '' });
+      messages.push({ role: m.role === 'assistant' ? 'assistant' : 'user', content: Array.isArray(m.content) ? m.content : (m.content || '') });
     }
 
     let fullText = '';

--- a/server/services/ConversationService.js
+++ b/server/services/ConversationService.js
@@ -76,6 +76,7 @@ class ConversationService {
     provider      = 'claude-code',
     model         = null,
     text,
+    images        = null,
     history       = [],
     claudeSession = null,
     claudeMode    = 'ask',
@@ -83,24 +84,30 @@ class ConversationService {
     shellId       = null,
   }) {
     const resolvedShellId = shellId || String(chatId);
-    csdbg('msg', `chatId=${chatId} provider=${provider} agent=${agentKey} model=${model} textLen=${text.length} histLen=${history.length} hasSession=${!!claudeSession}`);
+    csdbg('msg', `chatId=${chatId} provider=${provider} agent=${agentKey} model=${model} textLen=${text.length} images=${images?.length || 0} histLen=${history.length} hasSession=${!!claudeSession}`);
 
     if (provider !== 'claude-code' && this._providers) {
       csdbg('msg', `→ _processApiProvider`);
       return this._processApiProvider({
-        chatId, agentKey, provider, model, text, history, onChunk, shellId: resolvedShellId,
+        chatId, agentKey, provider, model, text, images, history, onChunk, shellId: resolvedShellId,
       });
     }
 
     csdbg('msg', `→ _processClaudeCode mode=${claudeMode}`);
     return this._processClaudeCode({
-      chatId, agentKey, text, claudeSession, claudeMode, onChunk,
+      chatId, agentKey, text, images, claudeSession, claudeMode, onChunk,
     });
   }
 
   // ── Proveedor claude-code (ClaudePrintSession) ────────────────────────────
 
-  async _processClaudeCode({ chatId, agentKey, text, claudeSession, claudeMode, onChunk }) {
+  async _processClaudeCode({ chatId, agentKey, text, images, claudeSession, claudeMode, onChunk }) {
+    // Claude Code CLI no soporta imágenes — avisar al usuario con contexto
+    if (images && images.length > 0) {
+      const imgNote = `[El usuario envió ${images.length} imagen(es) pero claude-code CLI no soporta visión. Respondé basándote solo en el texto.]`;
+      text = `${imgNote}\n\n${text}`;
+      csdbg('claude', `images fallback: ${images.length} imagen(es) no soportadas en CLI`);
+    }
     let session = claudeSession;
     let isNewSession = false;
     if (!session) {
@@ -181,7 +188,7 @@ class ConversationService {
 
   // ── Proveedores API (Anthropic, Gemini, OpenAI, …) ───────────────────────
 
-  async _processApiProvider({ chatId, agentKey, provider, model, text, history, onChunk, shellId }) {
+  async _processApiProvider({ chatId, agentKey, provider, model, text, images, history, onChunk, shellId }) {
     const provObj   = this._providers.get(provider);
     const apiKey    = this._providerConfig ? this._providerConfig.getApiKey(provider) : '';
     const cfg       = this._providerConfig ? this._providerConfig.getConfig() : {};
@@ -207,11 +214,42 @@ class ConversationService {
 
     const toolInstr    = (agentKey && shouldNudge && this._memory) ? this._memory.TOOL_INSTRUCTIONS : '';
     const systemPrompt = [basePrompt, memoryCtx, toolInstr].filter(Boolean).join('\n\n');
-    const userContent  = (shouldNudge && this._memory) ? text + this._memory.buildNudge(signals) : text;
+    const userText = (shouldNudge && this._memory) ? text + this._memory.buildNudge(signals) : text;
+
+    // Construir content con imágenes según el provider
+    let userContent;
+    if (images && images.length > 0) {
+      if (provider === 'anthropic') {
+        // Anthropic: { type: 'image', source: { type: 'base64', media_type, data } }
+        userContent = images.map(img => ({
+          type: 'image',
+          source: { type: 'base64', media_type: img.mediaType, data: img.base64 },
+        }));
+        userContent.push({ type: 'text', text: userText });
+      } else if (provider === 'gemini') {
+        // Gemini: se pasa como _images en el último mensaje, se convierte en el provider
+        userContent = userText;
+      } else {
+        // OpenAI / Grok: { type: 'image_url', image_url: { url: 'data:...' } }
+        userContent = images.map(img => ({
+          type: 'image_url',
+          image_url: { url: `data:${img.mediaType};base64,${img.base64}` },
+        }));
+        userContent.push({ type: 'text', text: userText });
+      }
+    } else {
+      userContent = userText;
+    }
 
     const updatedHistory = [...history, { role: 'user', content: userContent }];
 
-    const gen = provObj.chat({ systemPrompt, history: updatedHistory, apiKey, model: useModel, executeTool: execToolFn });
+    // Para Gemini: adjuntar imágenes raw para conversión en el provider
+    const extraOpts = {};
+    if (images && images.length > 0 && provider === 'gemini') {
+      extraOpts.images = images;
+    }
+
+    const gen = provObj.chat({ systemPrompt, history: updatedHistory, apiKey, model: useModel, executeTool: execToolFn, ...extraOpts });
     let accumulated = '';
 
     for await (const event of gen) {


### PR DESCRIPTION
## Summary
- El bot de Telegram ahora puede recibir fotos y enviarlas a los providers IA con soporte de visión
- La imagen se descarga en base64 y se convierte al formato nativo de cada provider:
  - **Anthropic**: content block `image` con `source.type: 'base64'`
  - **OpenAI / Grok**: content block `image_url` con data URI
  - **Gemini**: `inlineData` con `mimeType` y `data`
  - **Claude Code CLI**: fallback con nota textual (CLI no soporta imágenes)
- Si la foto tiene caption, se usa como texto; si no, se envía "Describe esta imagen"

## Test plan
- [ ] Enviar foto a un bot con provider Anthropic → describe la imagen
- [ ] Enviar foto con caption → usa el caption como prompt
- [ ] Enviar foto con provider OpenAI → describe la imagen
- [ ] Enviar foto con provider Gemini → describe la imagen
- [ ] Enviar foto con provider claude-code → avisa que no soporta visión
- [ ] Enviar mensaje de texto normal → sigue funcionando igual