### PR TITLE
feat(ollama): visión con minicpm-v para fotos en Telegram

### DIFF
--- a/server/providers/ollama.js
+++ b/server/providers/ollama.js
@@ -1,20 +1,87 @@
 'use strict';
 
 const OpenAI = require('openai');
+const http   = require('http');
 
-const DEFAULT_BASE_URL = 'http://100.64.0.1:11434';
+const DEFAULT_BASE_URL = 'http://100.64.0.5:11434';
+
+// Modelos con soporte de visión
+const VISION_MODELS = ['minicpm-v', 'llava', 'llava:13b', 'llava:34b'];
+
+function getBaseUrl() {
+  return process.env.OLLAMA_URL || DEFAULT_BASE_URL;
+}
+
+/**
+ * Envía un mensaje con imágenes a Ollama usando la API nativa (/api/chat)
+ * La API compatible con OpenAI no soporta imágenes en Ollama.
+ */
+function ollamaNativeChat(baseUrl, model, messages) {
+  return new Promise((resolve, reject) => {
+    const url = new URL('/api/chat', baseUrl);
+    const body = JSON.stringify({ model, messages, stream: false });
+    const req = http.request(url, { method: 'POST', headers: { 'Content-Type': 'application/json' } }, (res) => {
+      const chunks = [];
+      res.on('data', c => chunks.push(c));
+      res.on('end', () => {
+        try {
+          const data = JSON.parse(Buffer.concat(chunks).toString());
+          resolve(data.message?.content || '');
+        } catch (e) { reject(new Error(`Respuesta inválida de Ollama: ${e.message}`)); }
+      });
+      res.on('error', reject);
+    });
+    req.on('error', reject);
+    req.setTimeout(120000, () => { req.destroy(); reject(new Error('Timeout: Ollama no respondió en 120s')); });
+    req.write(body);
+    req.end();
+  });
+}
 
 module.exports = {
   name: 'ollama',
   label: 'Ollama (local)',
-  defaultModel: 'llama3.2',
-  models: ['llama3.2', 'llama3.1', 'mistral', 'codellama', 'deepseek-coder'],
+  defaultModel: 'qwen2.5',
+  models: ['qwen2.5', 'minicpm-v', 'llama3.2', 'llama3.1', 'mistral', 'codellama', 'deepseek-coder'],
 
-  async *chat({ systemPrompt, history, model }) {
-    const baseURL = (process.env.OLLAMA_URL || DEFAULT_BASE_URL) + '/v1';
-
-    const client = new OpenAI({ apiKey: 'ollama', baseURL });
+  async *chat({ systemPrompt, history, model, images }) {
+    const baseUrl   = getBaseUrl();
     const usedModel = model || this.defaultModel;
+    const hasImages = images && images.length > 0;
+
+    // Si hay imágenes, usar la API nativa de Ollama (no la compatible con OpenAI)
+    if (hasImages) {
+      const visionModel = VISION_MODELS.includes(usedModel) ? usedModel : 'minicpm-v';
+      const messages = [];
+      if (systemPrompt) messages.push({ role: 'system', content: systemPrompt });
+
+      for (const m of history.slice(0, -1)) {
+        messages.push({ role: m.role === 'assistant' ? 'assistant' : 'user', content: m.content || '' });
+      }
+
+      // Último mensaje con imágenes
+      const lastMsg = history[history.length - 1];
+      const lastText = typeof lastMsg?.content === 'string' ? lastMsg.content : (Array.isArray(lastMsg?.content) ? lastMsg.content.find(c => c.type === 'text')?.text || '' : '');
+      messages.push({
+        role: 'user',
+        content: lastText,
+        images: images.map(img => img.base64),
+      });
+
+      try {
+        const result = await ollamaNativeChat(baseUrl, visionModel, messages);
+        yield { type: 'text', text: result };
+        yield { type: 'done', fullText: result };
+      } catch (err) {
+        yield { type: 'text', text: `Error Ollama visión: ${err.message}` };
+        yield { type: 'done', fullText: `Error Ollama visión: ${err.message}` };
+      }
+      return;
+    }
+
+    // Sin imágenes: usar API compatible con OpenAI (streaming)
+    const baseURL = baseUrl + '/v1';
+    const client = new OpenAI({ apiKey: 'ollama', baseURL });
 
     const messages = [];
     if (systemPrompt) {
@@ -50,5 +117,18 @@ module.exports = {
     }
 
     yield { type: 'done', fullText };
+  },
+
+  /**
+   * Describe una imagen usando minicpm-v (usado como "ojos" para otros providers)
+   */
+  async describeImage(images, prompt = 'Describí detalladamente lo que ves en esta imagen.') {
+    const baseUrl = getBaseUrl();
+    const messages = [{
+      role: 'user',
+      content: prompt,
+      images: images.map(img => img.base64),
+    }];
+    return ollamaNativeChat(baseUrl, 'minicpm-v', messages);
   },
 };

--- a/server/services/ConversationService.js
+++ b/server/services/ConversationService.js
@@ -102,11 +102,18 @@ class ConversationService {
   // ── Proveedor claude-code (ClaudePrintSession) ────────────────────────────
 
   async _processClaudeCode({ chatId, agentKey, text, images, claudeSession, claudeMode, onChunk }) {
-    // Claude Code CLI no soporta imágenes — avisar al usuario con contexto
+    // Claude Code CLI no soporta imágenes — usar minicpm-v (Ollama) como "ojos"
     if (images && images.length > 0) {
-      const imgNote = `[El usuario envió ${images.length} imagen(es) pero claude-code CLI no soporta visión. Respondé basándote solo en el texto.]`;
-      text = `${imgNote}\n\n${text}`;
-      csdbg('claude', `images fallback: ${images.length} imagen(es) no soportadas en CLI`);
+      try {
+        const ollama = require('../providers/ollama');
+        csdbg('claude', `images: enviando ${images.length} imagen(es) a minicpm-v para descripción`);
+        const description = await ollama.describeImage(images, text);
+        text = `[El usuario envió ${images.length} imagen(es). Descripción generada por visión IA:]\n\n${description}\n\n[Mensaje original del usuario: "${text}"]`;
+        csdbg('claude', `images: descripción recibida (${description.length} chars)`);
+      } catch (err) {
+        csdbg('claude', `images: error en minicpm-v: ${err.message}`);
+        text = `[El usuario envió ${images.length} imagen(es) pero no se pudo analizar: ${err.message}]\n\n${text}`;
+      }
     }
     let session = claudeSession;
     let isNewSession = false;
@@ -243,9 +250,9 @@ class ConversationService {
 
     const updatedHistory = [...history, { role: 'user', content: userContent }];
 
-    // Para Gemini: adjuntar imágenes raw para conversión en el provider
+    // Para Gemini y Ollama: adjuntar imágenes raw para conversión en el provider
     const extraOpts = {};
-    if (images && images.length > 0 && provider === 'gemini') {
+    if (images && images.length > 0 && (provider === 'gemini' || provider === 'ollama')) {
       extraOpts.images = images;
     }
 


### PR DESCRIPTION
## Summary
- Actualiza IP de Ollama a `100.64.0.5` y modelos por defecto (`qwen2.5` para texto, `minicpm-v` para visión)
- Provider `ollama.js` ahora soporta imágenes vía API nativa de Ollama (`/api/chat` con campo `images`)
- Nueva función `describeImage()` que usa `minicpm-v` como servicio de visión independiente
- Cuando el provider es `claude-code` y llegan fotos, se envían a `minicpm-v` para obtener una descripción, que se inyecta como contexto textual a Claude Code
- Si Ollama no está disponible, se degrada gracefully con mensaje de error

## Flujo de imágenes por provider
| Provider | Método |
|----------|--------|
| **anthropic** | Content blocks `image` nativos |
| **openai / grok** | Content blocks `image_url` nativos |
| **gemini** | `inlineData` nativo |
| **ollama** | API nativa `/api/chat` con `minicpm-v` |
| **claude-code** | `minicpm-v` como "ojos" → descripción textual a CLI |

## Test plan
- [ ] Enviar foto con provider `claude-code` → minicpm-v describe la imagen, Claude responde con contexto
- [ ] Enviar foto con provider `ollama` modelo `minicpm-v` → visión directa
- [ ] Enviar foto con provider `anthropic` → visión nativa (ya funciona)
- [ ] Enviar mensaje de texto con `ollama` → sigue usando streaming normal
- [ ] Ollama caído + foto + claude-code → mensaje de error, no crash