### PR TITLE
fix(telegram): mejorar logging de errores en fotos

### DIFF
--- a/server/channels/telegram/TelegramChannel.js
+++ b/server/channels/telegram/TelegramChannel.js
@@ -499,8 +499,8 @@ class TelegramBot {
       msg._images = [{ base64, mediaType }];
       await this._handleMessage(msg);
     } catch (err) {
-      console.error(`[Telegram:${this.key}] Error procesando foto:`, err.message);
-      await this.sendText(chatId, `❌ Error al procesar la foto: ${err.message}`);
+      console.error(`[Telegram:${this.key}] Error procesando foto:`, err?.message || err?.stack || err);
+      await this.sendText(chatId, `❌ Error al procesar la foto: ${err?.message || String(err)}`);
     }
   }
 


### PR DESCRIPTION
## Summary
- El catch de `_handlePhotoMessage` mostraba `err.message` que podía ser undefined
- Ahora usa `err?.message || err?.stack || err` para capturar el error completo

## Test plan
- [ ] Enviar foto → si falla, el log muestra el error real