### PR TITLE
fix(telegram): diagnóstico de errores en fotos + silenciar stderr OCR

### DIFF
--- a/server/channels/telegram/TelegramChannel.js
+++ b/server/channels/telegram/TelegramChannel.js
@@ -499,8 +499,10 @@ class TelegramBot {
       msg._images = [{ base64, mediaType }];
       await this._handleMessage(msg);
     } catch (err) {
-      console.error(`[Telegram:${this.key}] Error procesando foto:`, err?.message || err?.stack || err);
-      await this.sendText(chatId, `❌ Error al procesar la foto: ${err?.message || String(err)}`);
+      const errDetail = err?.message || err?.stack || (err ? JSON.stringify(err) : 'error desconocido');
+      console.error(`[Telegram:${this.key}] Error procesando foto:`, errDetail);
+      if (err?.stack) console.error(`[Telegram:${this.key}] Stack:`, err.stack);
+      await this.sendText(chatId, `❌ Error al procesar la foto: ${errDetail.slice(0, 200)}`);
     }
   }
 

--- a/server/services/ConversationService.js
+++ b/server/services/ConversationService.js
@@ -117,7 +117,7 @@ class ConversationService {
 
           // 1. Intentar OCR con kheiron
           try {
-            const rawOcr = execSync(`kheiron ocr "${tmpPath}" -l spa`, { timeout: 30000, encoding: 'utf-8' });
+            const rawOcr = execSync(`kheiron ocr "${tmpPath}" -l spa 2>/dev/null`, { timeout: 30000, encoding: 'utf-8' });
             // Extraer texto entre marcadores, o tomar las últimas líneas limpias
             let ocrText = '';
             const startMark = rawOcr.indexOf('--- Texto extraído ---');


### PR DESCRIPTION
## Summary
- Capturar error completo en _handlePhotoMessage (message, stack, JSON)
- Redirigir stderr de kheiron OCR a /dev/null

## Test plan
- [ ] Enviar foto → si falla, el log muestra el error detallado