### PR TITLE
feat: WebChat, MCP telegram tools y dynamic callback buttons

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -20,6 +20,7 @@
       "Bash(pm2 describe:*)",
       "Bash(pm2 logs:*)",
       "Bash(pm2 list:*)",
+      "Bash(pm2:*)",
       "WebSearch",
       "WebFetch(domain:github.com)",
       "WebFetch(domain:rhasspy.github.io)",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,71 @@ pm2 save             # guardar estado para auto-arranque
 - **MCP**: servidor MCP integrado (`mcp/index.js`) que expone herramientas del sistema. `mcps.js` gestiona conexiones a MCPs externos.
 - **PM2**: el servidor se gestiona con PM2 en producción. `ecosystem.config.js` carga `.env` automáticamente y usa `--stack-size=65536`. Auto-arranque con systemd.
 
+## Telegram: envío de imágenes y documentos
+
+El bot puede enviar fotos y archivos a cualquier chat via API REST.
+
+### Endpoints
+
+```
+POST /api/telegram/bots/:key/chats/:chatId/photo
+POST /api/telegram/bots/:key/chats/:chatId/document
+```
+
+- Body: imagen/archivo como binary raw (`Content-Type: image/png`, etc.)
+- Query params: `caption`, `filename`, `contentType`
+
+### Flujo para enviar una imagen (ej: screenshot)
+
+```bash
+# 1. Generar imagen (screenshot, gráfico, etc.)
+#    → archivo en disco: /tmp/screenshot.png
+
+# 2. Identificar bot y chat
+curl -s http://localhost:3002/api/telegram/bots
+#    → bot key: chibi2026_bot, chatId: 7874537448
+
+# 3. Enviar
+curl -X POST \
+  "http://localhost:3002/api/telegram/bots/chibi2026_bot/chats/7874537448/photo?caption=Mi%20imagen&filename=screenshot.png" \
+  --data-binary @/tmp/screenshot.png \
+  -H "Content-Type: image/png"
+#    → {"ok":true,"message_id":1234}
+```
+
+### Flujo interno
+
+```
+API REST (index.js)
+  → telegram.getBot(key) → TelegramBot
+  → bot.sendPhoto(chatId, buffer, opts)
+    → httpsPostMultipart(urlPath, fields, file)
+      → api.telegram.org/bot<TOKEN>/sendPhoto (multipart/form-data)
+        → Telegram entrega al chat
+```
+
+### Métodos disponibles en TelegramBot
+
+- `sendPhoto(chatId, buffer, { caption, filename, contentType, parse_mode })`
+- `sendDocument(chatId, buffer, { caption, filename, contentType, parse_mode })`
+- `_apiCall('sendMessage', { chat_id, text, parse_mode, reply_markup })` — texto
+
+## Health check
+
+```
+GET /api/health → { ok, uptime, startedAt, pid, node }
+```
+
+Usar para verificar reinicios: comparar `pid` antes y después del restart.
+
+## WebChat
+
+Panel de chat web (`WebChatPanel.jsx`) que usa `ConversationService` — mismo motor que Telegram.
+
+- **WebSocket**: tipo `webchat` — envía `{ type: 'chat', text, provider, agent }`
+- **Comandos**: `/provider`, `/agente`, `/modelo`, `/cd`, `/nueva`, `/modo`, `/estado`, `/ayuda`
+- **Streaming**: chunks via `{ type: 'chat_chunk', text }`, fin con `{ type: 'chat_done', text }`
+
 ## Arquitectura detallada
 
 Ver `implementar/ARQUITECTURA.md` para documentación completa de módulos, API REST, protocolo WebSocket, plan multi-proveedor y notas de implementación.

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -96,7 +96,7 @@
 
 .app-body {
   flex: 1;
+  min-width: 0;
   overflow: hidden;
-  padding: 8px;
   position: relative;
 }

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -5,13 +5,13 @@ import TerminalPanel from './components/TerminalPanel.jsx';
 import TelegramPanel from './components/TelegramPanel.jsx';
 import AgentsPanel from './components/AgentsPanel.jsx';
 import ProvidersPanel from './components/ProvidersPanel.jsx';
+import WebChatPanel from './components/WebChatPanel.jsx';
+import { API_BASE, WS_URL } from './config.js';
 import './App.css';
-
-const WS_URL = 'ws://localhost:3001';
-let nextId = 1;
+let nextId = 0;
 
 function createSession(command = null, type = 'pty', httpSessionId = null, provider = null) {
-  const id = nextId++;
+  const id = ++nextId;
   let title;
   if (provider === 'gemini') {
     title = `Gemini ${id}`;
@@ -28,12 +28,16 @@ function createSession(command = null, type = 'pty', httpSessionId = null, provi
 }
 
 export default function App() {
-  const [sessions, setSessions] = useState(() => [createSession()]);
-  const [activeId, setActiveId] = useState(1);
+  const [sessions, setSessions] = useState(() => {
+    const initial = createSession();
+    return [initial];
+  });
+  const [activeId, setActiveId] = useState(() => nextId);
   const [telegramOpen, setTelegramOpen] = useState(false);
   const [telegramChatsCount, setTelegramChatsCount] = useState(0);
   const [agentsOpen, setAgentsOpen] = useState(false);
   const [providersOpen, setProvidersOpen] = useState(false);
+  const [chatOpen, setChatOpen] = useState(false);
 
   // Mapa: httpSessionId → frontendTabId
   const httpIdToTabId = useRef(new Map());
@@ -72,7 +76,7 @@ export default function App() {
     if (!telegramOpen) {
       const interval = setInterval(async () => {
         try {
-          const res = await fetch('http://localhost:3001/api/telegram/bots');
+          const res = await fetch(`${API_BASE}/api/telegram/bots`);
           const bots = await res.json();
           const chats = Array.isArray(bots)
             ? bots.reduce((n, b) => n + (b.chats?.length || 0), 0)
@@ -134,22 +138,29 @@ export default function App() {
 
         <div className="header-right">
           <button
+            className={`telegram-btn ${chatOpen ? 'active' : ''}`}
+            onClick={() => { setChatOpen(v => !v); setProvidersOpen(false); setAgentsOpen(false); setTelegramOpen(false); }}
+            title="Chat con IA"
+          >
+            💬
+          </button>
+          <button
             className={`telegram-btn ${providersOpen ? 'active' : ''}`}
-            onClick={() => { setProvidersOpen(v => !v); setAgentsOpen(false); setTelegramOpen(false); }}
+            onClick={() => { setProvidersOpen(v => !v); setAgentsOpen(false); setTelegramOpen(false); setChatOpen(false); }}
             title="Providers de IA"
           >
             ⚙️
           </button>
           <button
             className={`telegram-btn ${agentsOpen ? 'active' : ''}`}
-            onClick={() => { setAgentsOpen(v => !v); setTelegramOpen(false); setProvidersOpen(false); }}
+            onClick={() => { setAgentsOpen(v => !v); setTelegramOpen(false); setProvidersOpen(false); setChatOpen(false); }}
             title="Agentes personalizados"
           >
             🎭
           </button>
           <button
             className={`telegram-btn ${telegramOpen ? 'active' : ''}`}
-            onClick={() => { setTelegramOpen(v => !v); setAgentsOpen(false); setProvidersOpen(false); }}
+            onClick={() => { setTelegramOpen(v => !v); setAgentsOpen(false); setProvidersOpen(false); setChatOpen(false); }}
             title="Panel de Telegram"
           >
             🤖
@@ -201,6 +212,10 @@ export default function App() {
 
         {providersOpen && (
           <ProvidersPanel onClose={() => setProvidersOpen(false)} />
+        )}
+
+        {chatOpen && (
+          <WebChatPanel onClose={() => setChatOpen(false)} />
         )}
       </div>
     </div>

--- a/client/src/components/AgentsPanel.jsx
+++ b/client/src/components/AgentsPanel.jsx
@@ -1,8 +1,9 @@
 import { useState, useEffect, useCallback } from 'react';
+import { API_BASE } from '../config.js';
 import './AgentsPanel.css';
 
-const API = 'http://localhost:3001/api/agents';
-const SKILLS_API = 'http://localhost:3001/api/skills';
+const API = `${API_BASE}/api/agents`;
+const SKILLS_API = `${API_BASE}/api/skills`;
 
 function AgentForm({ initial, onSave, onCancel }) {
   const isEdit = !!initial;

--- a/client/src/components/DirPicker.jsx
+++ b/client/src/components/DirPicker.jsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useRef } from 'react';
+import { API_BASE } from '../config.js';
 import './DirPicker.css';
 
-const API = 'http://localhost:3001';
+const API = API_BASE;
 
 export default function DirPicker({ value, onChange, onClose }) {
   const [currentPath, setCurrentPath] = useState(value || '');

--- a/client/src/components/McpsPanel.jsx
+++ b/client/src/components/McpsPanel.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
+import { API_BASE } from '../config.js';
 
-const API = 'http://localhost:3001/api/mcps';
+const API = `${API_BASE}/api/mcps`;
 
 // Parsea "KEY=VALUE\nKEY2=VALUE2" → { KEY: "VALUE", KEY2: "VALUE2" }
 function parseEnv(text) {

--- a/client/src/components/ProvidersPanel.jsx
+++ b/client/src/components/ProvidersPanel.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
+import { API_BASE } from '../config.js';
 
-const API = 'http://localhost:3001';
+const API = API_BASE;
 
 const PROVIDER_NAMES = {
   'claude-code': 'Claude Code',

--- a/client/src/components/TelegramPanel.jsx
+++ b/client/src/components/TelegramPanel.jsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
+import { API_BASE } from '../config.js';
 import './TelegramPanel.css';
 
-const API = 'http://localhost:3001/api/telegram';
+const API = `${API_BASE}/api/telegram`;
 
 function timeAgo(ts) {
   const secs = Math.floor((Date.now() - ts) / 1000);
@@ -18,7 +19,7 @@ function ChatRow({ botKey, chat, onOpenSession, onRefresh }) {
   const handleLink = async () => {
     if (linking) { setLinking(false); return; }
     try {
-      const res = await fetch('http://localhost:3001/api/sessions');
+      const res = await fetch(`${API_BASE}/api/sessions`);
       const data = await res.json();
       setSessions(Array.isArray(data) ? data.filter(s => s.active) : []);
     } catch { setSessions([]); }
@@ -167,7 +168,7 @@ function BotCard({ bot, onOpenSession, onRefresh }) {
   const [allAgents, setAllAgents] = useState([]);
 
   useEffect(() => {
-    fetch('http://localhost:3001/api/agents')
+    fetch(`${API_BASE}/api/agents`)
       .then(r => r.json())
       .then(data => setAllAgents(Array.isArray(data) ? data : []))
       .catch(() => {});

--- a/client/src/components/TerminalPanel.jsx
+++ b/client/src/components/TerminalPanel.jsx
@@ -166,8 +166,9 @@ export default function TerminalPanel({ session, wsUrl, active, onSessionId }) {
   return (
     <div
       style={{
-        height: '100%',
-        width: '100%',
+        position: 'absolute',
+        inset: 0,
+        padding: 8,
         display: active ? 'flex' : 'none',
         flexDirection: 'column',
       }}

--- a/client/src/components/WebChatPanel.css
+++ b/client/src/components/WebChatPanel.css
@@ -1,0 +1,277 @@
+/* ─── WebChat Panel ─────────────────────────────────────────────────────────── */
+.wc-panel {
+  display: flex;
+  flex-direction: column;
+  width: 380px;
+  min-width: 300px;
+  max-width: 50vw;
+  height: 100%;
+  background: #1a1a1a;
+  border-left: 1px solid #444;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.wc-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  background: #222;
+  border-bottom: 1px solid #333;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.wc-header-title {
+  font-weight: 600;
+  font-size: 14px;
+  color: #f0f0f0;
+  white-space: nowrap;
+}
+
+.wc-header-controls {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.wc-select {
+  background: #2a2a2a;
+  color: #ccc;
+  border: 1px solid #444;
+  border-radius: 4px;
+  padding: 3px 6px;
+  font-size: 12px;
+  max-width: 110px;
+  cursor: pointer;
+}
+.wc-select:focus {
+  border-color: #007aff;
+  outline: none;
+}
+
+.wc-btn-icon {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 14px;
+  padding: 2px 4px;
+  opacity: 0.7;
+}
+.wc-btn-icon:hover { opacity: 1; }
+
+.wc-close {
+  background: none;
+  border: none;
+  color: #888;
+  font-size: 18px;
+  cursor: pointer;
+  padding: 0 4px;
+  line-height: 1;
+}
+.wc-close:hover { color: #ff5f57; }
+
+/* ─── Status bar ────────────────────────────────────────────────────────────── */
+.wc-status-bar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
+  background: #1e1e1e;
+  border-bottom: 1px solid #2a2a2a;
+  font-size: 11px;
+  color: #888;
+  flex-shrink: 0;
+}
+
+.wc-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.wc-dot.on  { background: #28c840; }
+.wc-dot.off { background: #ff5f57; }
+
+.wc-cwd {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ─── Messages area ─────────────────────────────────────────────────────────── */
+.wc-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.wc-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  color: #666;
+  text-align: center;
+  font-size: 13px;
+}
+.wc-hint {
+  font-size: 11px;
+  color: #555;
+  margin-top: 4px;
+}
+
+/* ─── Message bubbles ───────────────────────────────────────────────────────── */
+.wc-msg {
+  max-width: 85%;
+  display: flex;
+  flex-direction: column;
+}
+
+.wc-msg-user {
+  align-self: flex-end;
+}
+
+.wc-msg-user .wc-msg-content {
+  background: #007aff;
+  color: #fff;
+  border-radius: 12px 12px 4px 12px;
+  padding: 8px 12px;
+  font-size: 13px;
+  line-height: 1.4;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.wc-msg-assistant {
+  align-self: flex-start;
+}
+
+.wc-msg-label {
+  font-size: 10px;
+  color: #888;
+  margin-bottom: 2px;
+  padding-left: 4px;
+}
+
+.wc-msg-assistant .wc-msg-content {
+  background: #2a2a2a;
+  color: #e0e0e0;
+  border-radius: 12px 12px 12px 4px;
+  padding: 8px 12px;
+  font-size: 13px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.wc-msg-system {
+  align-self: center;
+  max-width: 90%;
+}
+
+.wc-msg-system .wc-msg-content {
+  background: #1e2a1e;
+  color: #8ac88a;
+  border-radius: 8px;
+  padding: 8px 14px;
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: 'Cascadia Code', 'Fira Code', 'Courier New', monospace;
+}
+
+.wc-msg-error .wc-msg-content {
+  background: #2a1e1e;
+  color: #ff6b6b;
+}
+
+.wc-msg-system.wc-msg-error {
+  align-self: center;
+}
+
+.wc-cursor {
+  animation: wc-blink 0.8s infinite;
+  color: #007aff;
+  margin-left: 2px;
+}
+@keyframes wc-blink {
+  0%, 50% { opacity: 1; }
+  51%, 100% { opacity: 0; }
+}
+
+/* ─── Input area ────────────────────────────────────────────────────────────── */
+.wc-input-area {
+  display: flex;
+  align-items: flex-end;
+  gap: 6px;
+  padding: 8px 12px;
+  background: #222;
+  border-top: 1px solid #333;
+  flex-shrink: 0;
+}
+
+.wc-input {
+  flex: 1;
+  background: #1e1e1e;
+  color: #f0f0f0;
+  border: 1px solid #444;
+  border-radius: 8px;
+  padding: 8px 12px;
+  font-size: 13px;
+  font-family: inherit;
+  resize: none;
+  min-height: 20px;
+  max-height: 120px;
+  line-height: 1.4;
+  outline: none;
+}
+.wc-input:focus {
+  border-color: #007aff;
+}
+.wc-input::placeholder {
+  color: #666;
+}
+
+.wc-send {
+  background: #007aff;
+  color: #fff;
+  border: none;
+  border-radius: 50%;
+  width: 34px;
+  height: 34px;
+  font-size: 16px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+.wc-send:hover:not(:disabled) {
+  background: #0066dd;
+}
+.wc-send:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* ─── Scrollbar ─────────────────────────────────────────────────────────────── */
+.wc-messages::-webkit-scrollbar {
+  width: 6px;
+}
+.wc-messages::-webkit-scrollbar-track {
+  background: transparent;
+}
+.wc-messages::-webkit-scrollbar-thumb {
+  background: #444;
+  border-radius: 3px;
+}
+.wc-messages::-webkit-scrollbar-thumb:hover {
+  background: #666;
+}

--- a/client/src/components/WebChatPanel.jsx
+++ b/client/src/components/WebChatPanel.jsx
@@ -1,0 +1,233 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { API_BASE, WS_URL } from '../config.js';
+import './WebChatPanel.css';
+
+export default function WebChatPanel({ onClose }) {
+  const [messages, setMessages] = useState([]);
+  const [input, setInput] = useState('');
+  const [sending, setSending] = useState(false);
+  const [provider, setProvider] = useState('anthropic');
+  const [agent, setAgent] = useState(null);
+  const [providers, setProviders] = useState([]);
+  const [agentsList, setAgentsList] = useState([]);
+  const [cwd, setCwd] = useState('~');
+  const [connected, setConnected] = useState(false);
+  const wsRef = useRef(null);
+  const sessionIdRef = useRef(null);
+  const messagesEndRef = useRef(null);
+  const inputRef = useRef(null);
+
+  // Scroll automático al final
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  // Cargar providers y agentes
+  useEffect(() => {
+    fetch(`${API_BASE}/api/providers`)
+      .then(r => r.json())
+      .then(data => {
+        setProviders(data.providers || []);
+        if (data.default) setProvider(data.default);
+      })
+      .catch(() => {});
+    fetch(`${API_BASE}/api/agents`)
+      .then(r => r.json())
+      .then(data => setAgentsList(Array.isArray(data) ? data : []))
+      .catch(() => {});
+  }, []);
+
+  // Conectar WebSocket
+  useEffect(() => {
+    const ws = new WebSocket(WS_URL);
+    wsRef.current = ws;
+
+    ws.onopen = () => {
+      ws.send(JSON.stringify({
+        type: 'init',
+        sessionType: 'webchat',
+      }));
+      setConnected(true);
+    };
+
+    ws.onmessage = (event) => {
+      try {
+        const msg = JSON.parse(event.data);
+        switch (msg.type) {
+          case 'session_id':
+            sessionIdRef.current = msg.id;
+            break;
+
+          case 'chat_chunk':
+            // Streaming: actualizar último mensaje del asistente
+            setMessages(prev => {
+              const last = prev[prev.length - 1];
+              if (last && last.role === 'assistant' && last.streaming) {
+                return [...prev.slice(0, -1), { ...last, content: msg.text }];
+              }
+              return [...prev, { role: 'assistant', content: msg.text, streaming: true }];
+            });
+            break;
+
+          case 'chat_done':
+            setMessages(prev => {
+              const last = prev[prev.length - 1];
+              if (last && last.role === 'assistant' && last.streaming) {
+                return [...prev.slice(0, -1), { ...last, content: msg.text, streaming: false }];
+              }
+              return [...prev, { role: 'assistant', content: msg.text, streaming: false }];
+            });
+            setSending(false);
+            break;
+
+          case 'chat_error':
+            setMessages(prev => [
+              ...prev,
+              { role: 'system', content: `Error: ${msg.error}`, error: true },
+            ]);
+            setSending(false);
+            break;
+
+          case 'command_result':
+            setMessages(prev => [
+              ...prev,
+              { role: 'system', content: msg.text },
+            ]);
+            if (msg.provider) setProvider(msg.provider);
+            if (msg.agent !== undefined) setAgent(msg.agent);
+            if (msg.cwd) setCwd(msg.cwd);
+            setSending(false);
+            break;
+
+          case 'status':
+            if (msg.provider) setProvider(msg.provider);
+            if (msg.agent !== undefined) setAgent(msg.agent);
+            if (msg.cwd) setCwd(msg.cwd);
+            break;
+        }
+      } catch { /* ignorar */ }
+    };
+
+    ws.onclose = () => setConnected(false);
+    ws.onerror = () => {};
+
+    return () => ws.close();
+  }, []);
+
+  const sendMessage = useCallback(() => {
+    const text = input.trim();
+    if (!text || sending) return;
+    const ws = wsRef.current;
+    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+
+    // Mostrar mensaje del usuario
+    setMessages(prev => [...prev, { role: 'user', content: text }]);
+    setInput('');
+    setSending(true);
+
+    ws.send(JSON.stringify({
+      type: 'chat',
+      text,
+      provider,
+      agent,
+    }));
+  }, [input, sending, provider, agent]);
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      sendMessage();
+    }
+  };
+
+  const clearChat = () => {
+    setMessages([]);
+    const ws = wsRef.current;
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify({ type: 'chat', text: '/nueva', provider, agent }));
+    }
+  };
+
+  const providerLabel = providers.find(p => p.name === provider)?.label || provider;
+
+  return (
+    <div className="wc-panel">
+      <div className="wc-header">
+        <span className="wc-header-title">💬 Chat</span>
+        <div className="wc-header-controls">
+          <select
+            className="wc-select"
+            value={provider}
+            onChange={e => setProvider(e.target.value)}
+          >
+            {providers.filter(p => p.configured).map(p => (
+              <option key={p.name} value={p.name}>{p.label || p.name}</option>
+            ))}
+          </select>
+          <select
+            className="wc-select"
+            value={agent || ''}
+            onChange={e => setAgent(e.target.value || null)}
+          >
+            <option value="">Sin agente</option>
+            {agentsList.map(a => (
+              <option key={a.key} value={a.key}>{a.key}</option>
+            ))}
+          </select>
+          <button className="wc-btn-icon" onClick={clearChat} title="Nueva conversación">🗑️</button>
+          <button className="wc-close" onClick={onClose}>×</button>
+        </div>
+      </div>
+
+      <div className="wc-status-bar">
+        <span className={`wc-dot ${connected ? 'on' : 'off'}`} />
+        <span>{providerLabel}</span>
+        {agent && <span> · {agent}</span>}
+        <span className="wc-cwd"> · {cwd}</span>
+      </div>
+
+      <div className="wc-messages">
+        {messages.length === 0 && (
+          <div className="wc-empty">
+            <p>Escribí algo para comenzar</p>
+            <p className="wc-hint">
+              Usá / para comandos: /ayuda
+            </p>
+          </div>
+        )}
+        {messages.map((msg, i) => (
+          <div key={i} className={`wc-msg wc-msg-${msg.role} ${msg.error ? 'wc-msg-error' : ''}`}>
+            {msg.role === 'assistant' && (
+              <div className="wc-msg-label">{providerLabel}</div>
+            )}
+            <div className="wc-msg-content">
+              {msg.content}
+              {msg.streaming && <span className="wc-cursor">▊</span>}
+            </div>
+          </div>
+        ))}
+        <div ref={messagesEndRef} />
+      </div>
+
+      <div className="wc-input-area">
+        <textarea
+          ref={inputRef}
+          className="wc-input"
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Escribí un mensaje..."
+          rows={1}
+          disabled={!connected}
+        />
+        <button
+          className="wc-send"
+          onClick={sendMessage}
+          disabled={!input.trim() || sending || !connected}
+        >
+          {sending ? '...' : '➤'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/client/src/config.js
+++ b/client/src/config.js
@@ -1,0 +1,3 @@
+const SERVER_HOST = import.meta.env.VITE_SERVER_URL || `${window.location.hostname}:3002`;
+export const API_BASE = `http://${SERVER_HOST}`;
+export const WS_URL = `ws://${SERVER_HOST}`;

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -4,6 +4,7 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   plugins: [react()],
   server: {
+    host: '100.64.0.2',
     port: 5173,
   },
 });

--- a/server/channels/telegram/CallbackHandler.js
+++ b/server/channels/telegram/CallbackHandler.js
@@ -3,6 +3,8 @@
 const ClaudePrintSession   = require('../../core/ClaudePrintSession');
 const os                   = require('os');
 const { getSystemStats }   = require('../../core/systemStats');
+const dynamicRegistry      = require('./DynamicCallbackRegistry');
+const { exec }             = require('child_process');
 
 /**
  * CallbackHandler — maneja _handleCallbackQuery y el motor de menús declarativo.
@@ -122,6 +124,66 @@ class CallbackHandler {
     return { text, buttons };
   }
 
+  // ── Ejecución de callbacks dinámicos ────────────────────────────────────────
+
+  async _executeDynamicAction(bot, chatId, msgId, chat, action) {
+    try {
+      switch (action.type) {
+        case 'message': {
+          // Registrar sub-callbacks si vienen anidados
+          if (action.callbacks) {
+            dynamicRegistry.registerMany(action.callbacks);
+          }
+          const body = { chat_id: chatId, text: action.text };
+          if (action.parse_mode) body.parse_mode = action.parse_mode;
+          if (action.reply_markup) {
+            body.reply_markup = typeof action.reply_markup === 'string'
+              ? action.reply_markup : JSON.stringify(action.reply_markup);
+          }
+          if (action.edit && msgId) {
+            body.message_id = msgId;
+            await bot._apiCall('editMessageText', body);
+          } else {
+            await bot._apiCall('sendMessage', body);
+          }
+          break;
+        }
+
+        case 'command': {
+          const cmd = action.cmd;
+          if (!cmd) { await bot.sendText(chatId, '❌ Comando vacío.'); break; }
+          const timeout = action.timeout || 15000;
+          const output = await new Promise((resolve) => {
+            exec(cmd, { timeout, maxBuffer: 1024 * 512 }, (err, stdout, stderr) => {
+              if (err) resolve(`❌ Error: ${err.message}\n${stderr || ''}`);
+              else resolve(stdout || stderr || '(sin output)');
+            });
+          });
+          const truncated = output.length > 4000 ? output.slice(0, 4000) + '\n…(truncado)' : output;
+          await bot._apiCall('sendMessage', {
+            chat_id: chatId,
+            text: `<pre>${truncated}</pre>`,
+            parse_mode: 'HTML',
+          });
+          break;
+        }
+
+        case 'prompt': {
+          if (!action.text) { await bot.sendText(chatId, '❌ Prompt vacío.'); break; }
+          await bot._sendToSession(chatId, action.text, chat);
+          break;
+        }
+
+        default:
+          this.logger.warn(`[DynCallback] Tipo desconocido: ${action.type}`);
+          await bot.sendText(chatId, `❌ Tipo de acción desconocido: ${action.type}`);
+      }
+    } catch (err) {
+      this.logger.error(`[DynCallback] Error: ${err.message}`);
+      await bot.sendText(chatId, `❌ Error ejecutando acción: ${err.message}`);
+    }
+  }
+
   // ── Motor de menús declarativo ──────────────────────────────────────────────
 
   _resolveButtons(rawRows, back = null) {
@@ -165,7 +227,7 @@ class CallbackHandler {
       'menu:sesion': {
         text: (chat) => {
           const cs = chat?.claudeSession;
-          return `💬 *Sesión*\nAgente: \`${bot?.defaultAgent || '—'}\` | Modo: \`${chat?.claudeMode||'ask'}\`` +
+          return `💬 *Sesión*\nAgente: \`${bot?.defaultAgent || '—'}\` | Modo: \`${chat?.claudeMode||'auto'}\`` +
             (cs ? `\nMensajes: ${cs.messageCount} | Costo: $${cs.totalCostUsd.toFixed(4)}` : '');
         },
         buttons: () => [
@@ -183,7 +245,7 @@ class CallbackHandler {
           const text = cs
             ? `📊 *Estado de sesión*\n\nID: \`${cs.id.slice(0,8)}…\`\n` +
               `Agente: ${b.defaultAgent}\nModelo: \`${cs.model||'default'}\`\n` +
-              `Modo permisos: \`${chat.claudeMode||'ask'}\`\nMensajes: ${cs.messageCount}\n` +
+              `Modo permisos: \`${chat.claudeMode||'auto'}\`\nMensajes: ${cs.messageCount}\n` +
               `Uptime: ${Math.floor(uptime/60)}m ${uptime%60}s\n` +
               `Costo: $${cs.totalCostUsd.toFixed(4)} USD`
             : '📊 Sin sesión activa.';
@@ -350,7 +412,7 @@ class CallbackHandler {
       },
       'menu:config:permisos': {
         action: async ({ chatId, msgId, chat, bot: b }) => {
-          const current = chat.claudeMode || 'ask';
+          const current = chat.claudeMode || 'auto';
           await b.sendWithButtons(chatId,
             `🔐 *Modo de permisos*: \`${current}\`\n\n• \`ask\` — describe sin ejecutar\n• \`auto\` — ejecuta todo\n• \`plan\` — solo planifica`,
             [[
@@ -459,8 +521,8 @@ class CallbackHandler {
           claudeSessionId: saved.claude_session_id,
           messageCount:    saved.message_count,
           cwd:             saved.cwd || process.env.HOME,
-          model:           saved.model || null,
-          permissionMode:  saved.claude_mode || 'ask',
+          model:           saved.model || 'sonnet',
+          permissionMode:  saved.claude_mode || 'auto',
         });
       }
 
@@ -479,9 +541,9 @@ class CallbackHandler {
         monitorCwd: saved?.cwd || process.env.HOME,
         busy: false,
         provider: saved?.provider || 'claude-code',
-        model: saved?.model || null,
+        model: saved?.model || 'sonnet',
         aiHistory: [],
-        claudeMode: saved?.claude_mode || 'ask',
+        claudeMode: saved?.claude_mode || 'auto',
         consoleMode: false,
       };
       bot.chats.set(chatId, chat);
@@ -489,6 +551,15 @@ class CallbackHandler {
 
     await bot._answerCallback(cbq.id);
     const data = cbq.data || '';
+
+    // ── Callbacks dinámicos (registrados en runtime) ──────────────────────────
+    if (dynamicRegistry.has(data)) {
+      const action = dynamicRegistry.get(data);
+      if (action) {
+        await this._executeDynamicAction(bot, chatId, msgId, chat, action);
+        return;
+      }
+    }
 
     // Whitelist: agregar / eliminar
     if (data === 'whitelist:add') {
@@ -910,6 +981,11 @@ class CallbackHandler {
       }
 
       case 'noop':
+        break;
+
+      default:
+        // Fallback: enviar callback_data como prompt al AI activo
+        await bot._sendToSession(chatId, data, chat);
         break;
     }
   }

--- a/server/channels/telegram/CommandHandler.js
+++ b/server/channels/telegram/CommandHandler.js
@@ -284,7 +284,7 @@ class CommandHandler {
             `Agente: ${bot.defaultAgent}\n` +
             `Agente activo: ${chat.activeAgent?.key || 'ninguno'}\n` +
             `Modelo: \`${cs.model || 'default'}\`\n` +
-            `Modo permisos: \`${chat.claudeMode || 'ask'}\`\n` +
+            `Modo permisos: \`${chat.claudeMode || 'auto'}\`\n` +
             `Mensajes: ${cs.messageCount}\n` +
             `Uptime: ${Math.floor(uptime/60)}m ${uptime%60}s\n` +
             `Costo total: $${cs.totalCostUsd.toFixed(4)} USD\n` +
@@ -754,7 +754,7 @@ class CommandHandler {
           break;
         }
         if (args.length === 0) {
-          const current = chat.claudeMode || 'ask';
+          const current = chat.claudeMode || 'auto';
           await bot.sendWithButtons(chatId,
             `🔐 *Modo de permisos actual*: \`${current}\`\n\n` +
             `• \`ask\` — describe herramientas sin ejecutarlas (por defecto)\n` +
@@ -826,7 +826,7 @@ class CommandHandler {
           break;
         }
         if (args.length === 0) {
-          const current = chat.claudeMode || 'ask';
+          const current = chat.claudeMode || 'auto';
           await bot.sendWithButtons(chatId,
             `🔐 *Modo de permisos actual*: \`${current}\`\n\n` +
             `• \`ask\` — describe herramientas sin ejecutarlas (por defecto)\n` +

--- a/server/channels/telegram/DynamicCallbackRegistry.js
+++ b/server/channels/telegram/DynamicCallbackRegistry.js
@@ -1,0 +1,136 @@
+'use strict';
+
+/**
+ * DynamicCallbackRegistry — registro en memoria de callbacks dinámicos con TTL.
+ *
+ * Tipos de acción soportados:
+ *   - { type: 'message', text, parse_mode? }       → enviar texto al chat
+ *   - { type: 'command', cmd }                      → ejecutar bash, enviar output
+ *   - { type: 'prompt', text }                      → enviar como prompt al AI
+ *   - { type: 'url', url }                          → (no-op, Telegram abre directo)
+ *
+ * Cada entrada puede tener:
+ *   - once: true   → se elimina tras ejecutarse una vez
+ *   - ttl:  ms     → tiempo de vida (default 5 min)
+ */
+
+const DEFAULT_TTL = 5 * 60 * 1000; // 5 minutos
+const CLEANUP_INTERVAL = 60 * 1000; // 1 minuto
+
+class DynamicCallbackRegistry {
+  constructor() {
+    /** @type {Map<string, { action: object, expiresAt: number|null, once: boolean }>} */
+    this._entries = new Map();
+
+    this._cleanupTimer = setInterval(() => this._cleanup(), CLEANUP_INTERVAL);
+    if (this._cleanupTimer.unref) this._cleanupTimer.unref();
+  }
+
+  /**
+   * Registra uno o más callbacks.
+   * @param {Object<string, object>} callbacks — { callbackData: { type, ...params, ttl?, once? } }
+   */
+  registerMany(callbacks) {
+    if (!callbacks || typeof callbacks !== 'object') return;
+    for (const [key, action] of Object.entries(callbacks)) {
+      this.register(key, action);
+    }
+  }
+
+  /**
+   * Registra un callback individual.
+   * @param {string} callbackData
+   * @param {object} action — { type, ...params, ttl?, once? }
+   */
+  register(callbackData, action) {
+    const ttl = action.ttl != null ? action.ttl : DEFAULT_TTL;
+    const once = action.once != null ? action.once : false;
+
+    // Clonar sin ttl/once para guardar solo la acción
+    const { ttl: _t, once: _o, ...cleanAction } = action;
+
+    this._entries.set(callbackData, {
+      action: cleanAction,
+      expiresAt: ttl > 0 ? Date.now() + ttl : null,
+      once,
+    });
+  }
+
+  /**
+   * Obtiene la acción para un callback_data. Retorna null si no existe o expiró.
+   * Si once=true, elimina la entrada tras obtenerla.
+   * @param {string} callbackData
+   * @returns {object|null}
+   */
+  get(callbackData) {
+    const entry = this._entries.get(callbackData);
+    if (!entry) return null;
+
+    if (entry.expiresAt && Date.now() > entry.expiresAt) {
+      this._entries.delete(callbackData);
+      return null;
+    }
+
+    if (entry.once) {
+      this._entries.delete(callbackData);
+    }
+
+    return entry.action;
+  }
+
+  /**
+   * Verifica si un callback_data está registrado (sin consumirlo).
+   */
+  has(callbackData) {
+    const entry = this._entries.get(callbackData);
+    if (!entry) return false;
+    if (entry.expiresAt && Date.now() > entry.expiresAt) {
+      this._entries.delete(callbackData);
+      return false;
+    }
+    return true;
+  }
+
+  /** Elimina un callback específico */
+  remove(callbackData) {
+    this._entries.delete(callbackData);
+  }
+
+  /** Elimina todos los callbacks que empiezan con un prefijo */
+  removeByPrefix(prefix) {
+    for (const key of this._entries.keys()) {
+      if (key.startsWith(prefix)) this._entries.delete(key);
+    }
+  }
+
+  /** Limpieza de entradas expiradas */
+  _cleanup() {
+    const now = Date.now();
+    for (const [key, entry] of this._entries) {
+      if (entry.expiresAt && now > entry.expiresAt) {
+        this._entries.delete(key);
+      }
+    }
+  }
+
+  /** Stats para debugging */
+  stats() {
+    return {
+      total: this._entries.size,
+      entries: [...this._entries.entries()].map(([key, e]) => ({
+        key,
+        type: e.action.type,
+        once: e.once,
+        expiresIn: e.expiresAt ? Math.max(0, e.expiresAt - Date.now()) : null,
+      })),
+    };
+  }
+
+  destroy() {
+    clearInterval(this._cleanupTimer);
+    this._entries.clear();
+  }
+}
+
+// Singleton
+module.exports = new DynamicCallbackRegistry();

--- a/server/channels/telegram/TelegramChannel.js
+++ b/server/channels/telegram/TelegramChannel.js
@@ -281,7 +281,7 @@ class TelegramBot {
   _claudeSessionOpts(chat) {
     return {
       model: chat.claudeSession?.model || null,
-      permissionMode: chat.claudeMode || 'ask',
+      permissionMode: chat.claudeMode || 'auto',
       cwd: chat.monitorCwd || process.env.HOME,
     };
   }
@@ -308,21 +308,72 @@ class TelegramBot {
     try { await this._apiCall('answerCallbackQuery', { callback_query_id: id, text }); } catch {}
   }
 
+  /**
+   * Enviar una imagen a un chat.
+   * @param {number|string} chatId
+   * @param {Buffer} photoBuffer - imagen como Buffer
+   * @param {object} [opts]
+   * @param {string} [opts.caption] - texto debajo de la imagen
+   * @param {string} [opts.filename] - nombre del archivo (default: photo.png)
+   * @param {string} [opts.contentType] - MIME type (default: image/png)
+   * @param {string} [opts.parse_mode] - 'HTML' | 'Markdown' | 'MarkdownV2'
+   */
+  async sendPhoto(chatId, photoBuffer, opts = {}) {
+    const urlPath = `/bot${this.token}/sendPhoto`;
+    const fields = { chat_id: String(chatId) };
+    if (opts.caption) fields.caption = opts.caption;
+    if (opts.parse_mode) fields.parse_mode = opts.parse_mode;
+    const file = {
+      fieldName: 'photo',
+      filename: opts.filename || 'photo.png',
+      contentType: opts.contentType || 'image/png',
+      buffer: photoBuffer,
+    };
+    const data = await httpsPostMultipart(urlPath, fields, file);
+    if (!data.ok) throw new Error(data.description || 'sendPhoto error');
+    return data.result;
+  }
+
+  /**
+   * Enviar un documento/archivo a un chat.
+   * @param {number|string} chatId
+   * @param {Buffer} docBuffer
+   * @param {object} [opts]
+   * @param {string} [opts.caption]
+   * @param {string} [opts.filename]
+   * @param {string} [opts.contentType]
+   */
+  async sendDocument(chatId, docBuffer, opts = {}) {
+    const urlPath = `/bot${this.token}/sendDocument`;
+    const fields = { chat_id: String(chatId) };
+    if (opts.caption) fields.caption = opts.caption;
+    if (opts.parse_mode) fields.parse_mode = opts.parse_mode;
+    const file = {
+      fieldName: 'document',
+      filename: opts.filename || 'file.bin',
+      contentType: opts.contentType || 'application/octet-stream',
+      buffer: docBuffer,
+    };
+    const data = await httpsPostMultipart(urlPath, fields, file);
+    if (!data.ok) throw new Error(data.description || 'sendDocument error');
+    return data.result;
+  }
+
   // ── Start / Stop / Poll ──────────────────────────────────────────────────
 
   async start() {
     if (this.running) return { username: this.botInfo?.username };
+    this.running = true;
 
     const me = await this._apiCall('getMe');
     this.botInfo = { id: me.id, username: me.username, firstName: me.first_name };
-    this.running = true;
 
     try {
       await this._apiCall('setMyCommands', {
         commands: [
           { command: 'nueva',        description: 'Nueva conversación' },
           { command: 'modelo',       description: 'Ver o cambiar modelo' },
-          { command: 'permisos',     description: 'Modo: auto/ask/plan' },
+          { command: 'modo',         description: 'Modo: auto/ask/plan' },
           { command: 'costo',        description: 'Costo de la sesión' },
           { command: 'estado',       description: 'Estado detallado' },
           { command: 'agentes',      description: 'Listar agentes' },
@@ -570,9 +621,9 @@ class TelegramBot {
           messageCount:    saved.message_count,
           cwd:             saved.cwd || process.env.HOME,
           model:           saved.model || null,
-          permissionMode:  saved.claude_mode || 'ask',
+          permissionMode:  saved.claude_mode || 'auto',
         });
-        tdbg('init', `restored session ${saved.claude_session_id.slice(0,8)}… msgCount=${saved.message_count} cwd=${saved.cwd} mode=${saved.claude_mode || 'ask'}`);
+        tdbg('init', `restored session ${saved.claude_session_id.slice(0,8)}… msgCount=${saved.message_count} cwd=${saved.cwd} mode=${saved.claude_mode || 'auto'}`);
       }
 
       chat = {
@@ -590,9 +641,9 @@ class TelegramBot {
         monitorCwd:     saved?.cwd || process.env.HOME,
         busy:           false,
         provider:       saved?.provider || 'claude-code',
-        model:          saved?.model    || null,
+        model:          saved?.model    || 'sonnet',
         aiHistory:      [],
-        claudeMode:     saved?.claude_mode || 'ask',
+        claudeMode:     saved?.claude_mode || 'auto',
         consoleMode:    false,
         lastButtonsMsgId: null,
       };
@@ -769,8 +820,9 @@ class TelegramBot {
 
     // ── Ruta ConversationService: claude-code y providers API ────────────────
     tdbg('send', `→ ruta ConvSvc`);
-    const mode = chat.claudeMode || 'ask';
-    tdbg('send', `mode=${mode} model=${chat.model} hasClaudeSession=${!!chat.claudeSession} msgCount=${chat.claudeSession?.messageCount || 0}`);
+    const mode = chat.claudeMode || 'auto';
+    const isMcpMode = chatProvider === 'claude-code' && mode === 'auto';
+    tdbg('send', `mode=${mode} model=${chat.model} isMcpMode=${isMcpMode} hasClaudeSession=${!!chat.claudeSession} msgCount=${chat.claudeSession?.messageCount || 0}`);
     const { sentMsg, stop: stopAnim } = await this._startDotAnimation(chatId, mode);
     tdbg('send', `dotAnim sentMsg=${sentMsg?.message_id || 'null'}`);
 
@@ -779,7 +831,33 @@ class TelegramBot {
     let animStopped = false;
     let chunkCount  = 0;
 
-    const onChunk = async (partial) => {
+    // Status icons para modo MCP
+    const STATUS_MAP = {
+      thinking:  '🧠 Pensando...',
+      tool_use:  '⚡ Ejecutando',
+      done:      '✅ Listo',
+    };
+
+    let lastStatus = null;
+
+    // En modo MCP: mostrar status en vez de texto
+    const onStatus = isMcpMode ? async (status, detail) => {
+      if (!sentMsg) return;
+      if (!animStopped) { animStopped = true; stopAnim(); }
+      const now = Date.now();
+      if (now - lastEditAt < THROTTLE && status === lastStatus) return;
+      lastEditAt = now;
+      lastStatus = status;
+      let statusText = STATUS_MAP[status] || `⏳ ${status}`;
+      if (status === 'tool_use' && detail) statusText = `⚡ ${detail}...`;
+      try {
+        await this._apiCall('editMessageText', { chat_id: chatId, message_id: sentMsg.message_id, text: statusText });
+        tdbg('status', `${status} ${detail || ''}`);
+      } catch (e) { tdbg('status', `editMsg FAIL: ${e.message}`); }
+    } : null;
+
+    // En modo normal: streaming de texto (comportamiento original)
+    const onChunk = isMcpMode ? null : async (partial) => {
       chunkCount++;
       if (!partial.trim() || !sentMsg) { tdbg('chunk', `#${chunkCount} SKIP empty=${!partial.trim()} noMsg=${!sentMsg}`); return; }
       if (!animStopped) { animStopped = true; stopAnim(); tdbg('chunk', `#${chunkCount} anim stopped`); }
@@ -815,22 +893,19 @@ class TelegramBot {
         claudeSession: chat.claudeSession,
         claudeMode:    mode,
         onChunk,
+        onStatus,
         shellId:       String(chatId),
+        botKey:        this.key,
+        channel:       'telegram',
       });
-      tdbg('send', `← convSvc.processMessage() ${Date.now() - t0}ms chunks=${chunkCount} resultText=${(result.text || '').length} chars newSession=${!!result.newSession} savedFiles=${result.savedMemoryFiles?.length || 0}`);
+      tdbg('send', `← convSvc.processMessage() ${Date.now() - t0}ms chunks=${chunkCount} resultText=${(result.text || '').length} chars usedMcpTools=${result.usedMcpTools} newSession=${!!result.newSession} savedFiles=${result.savedMemoryFiles?.length || 0}`);
 
       stopAnim();
-      if (!animStopped && sentMsg) {
-        tdbg('send', `deleting dot msg (no chunks received)`);
-        try { await this._apiCall('deleteMessage', { chat_id: chatId, message_id: sentMsg.message_id }); } catch (e) { tdbg('send', `deleteMsg FAIL: ${e.message}`); }
-      }
 
       if (result.newSession)       chat.claudeSession = result.newSession;
       if (result.history)          chat.aiHistory     = result.history;
 
       // Persistir sesión de Claude en SQLite para sobrevivir reinicios
-      // Usar monitorCwd (directorio elegido por el usuario) en vez de claudeSession.cwd
-      // para no sobreescribir el cwd del usuario con el cwd interno de Claude
       if (chat.claudeSession?.claudeSessionId && this._chatSettings) {
         this._chatSettings.saveSession(this.key, chatId, {
           claudeSessionId: chat.claudeSession.claudeSessionId,
@@ -846,25 +921,40 @@ class TelegramBot {
         }
       }
 
-      tdbg('send', `→ _sendResult() textLen=${(result.text || '').length} hasSentMsg=${!!(animStopped ? sentMsg : null)}`);
-      await this._sendResult(chatId, result.text || '', animStopped ? sentMsg : null);
-      tdbg('send', `← _sendResult() OK`);
+      // En modo MCP: borrar status msg y enviar respuesta como mensaje nuevo
+      // Claude puede haber enviado fotos/archivos via MCP, pero el texto lo envía el servidor
+      if (isMcpMode) {
+        if (sentMsg) {
+          try { await this._apiCall('deleteMessage', { chat_id: chatId, message_id: sentMsg.message_id }); } catch (e) { tdbg('send', `deleteStatusMsg FAIL: ${e.message}`); }
+        }
+        if (result.text) {
+          tdbg('send', `MCP mode: enviando texto (${result.text.length} chars) usedMcpTools=${result.usedMcpTools}`);
+          await this._sendResult(chatId, result.text, null);
+        }
+      } else {
+        // Modo normal: streaming de texto
+        if (!animStopped && sentMsg) {
+          tdbg('send', `deleting dot msg (no chunks received)`);
+          try { await this._apiCall('deleteMessage', { chat_id: chatId, message_id: sentMsg.message_id }); } catch (e) { tdbg('send', `deleteMsg FAIL: ${e.message}`); }
+        }
+        tdbg('send', `→ _sendResult() textLen=${(result.text || '').length} hasSentMsg=${!!(animStopped ? sentMsg : null)}`);
+        await this._sendResult(chatId, result.text || '', animStopped ? sentMsg : null);
+        tdbg('send', `← _sendResult() OK`);
+      }
 
-      // TTS: enviar audio si está habilitado
-      if (this._tts && this._tts.isEnabled() && result.text) {
+      // TTS: enviar audio si está habilitado (solo en modo normal)
+      if (!isMcpMode && this._tts && this._tts.isEnabled() && result.text) {
         try {
           const audioBuffer = await this._tts.synthesize(result.text);
           if (audioBuffer) await this.sendVoice(chatId, audioBuffer);
         } catch (err) {
           tdbg('tts', `Error TTS: ${err.message}`);
-          // Fallo silencioso — el texto ya se envió
         }
       }
     } catch (err) {
       stopAnim();
       console.error(`[Telegram:${this.key}] Error en chat ${chatId}:`, err.message);
       tdbg('send', `CATCH ERROR: ${err.stack || err.message}`);
-      // Si Claude falló, limpiar sesión rota para que el próximo mensaje no reintente --resume
       if (chat.claudeSession && err.message?.includes('código')) {
         tdbg('send', `limpiando sesión rota`);
         chat.claudeSession.claudeSessionId = null;

--- a/server/core/ClaudePrintSession.js
+++ b/server/core/ClaudePrintSession.js
@@ -1,7 +1,10 @@
 'use strict';
 
 const crypto = require('crypto');
+const path = require('path');
 const { spawn } = require('child_process');
+
+const DEFAULT_MCP_CONFIG = path.join(__dirname, '..', 'mcp-config.json');
 
 function _cpDbg() { return process.env.DEBUG_TELEGRAM === '1'; }
 function cpdbg(scope, ...args) { if (_cpDbg()) console.log(`[CPS:DBG:${scope}]`, ...args); }
@@ -11,7 +14,7 @@ function cpdbg(scope, ...args) { if (_cpDbg()) console.log(`[CPS:DBG:${scope}]`,
  * Extraído de telegram.js para reutilización por cualquier canal (Telegram, Discord, HTTP).
  */
 class ClaudePrintSession {
-  constructor({ model = null, permissionMode = 'ask', cwd = null, claudeSessionId = null, messageCount = 0 } = {}) {
+  constructor({ model = null, permissionMode = 'ask', cwd = null, claudeSessionId = null, messageCount = 0, mcpConfig = null, appendSystemPrompt = null } = {}) {
     this.id = crypto.randomUUID();
     this.createdAt = Date.now();
     this.active = true;
@@ -23,9 +26,11 @@ class ClaudePrintSession {
     this.lastCostUsd = 0;         // costo del último mensaje
     this.claudeSessionId = claudeSessionId;  // session_id interno de claude (persistible)
     this.cwd = cwd || process.env.HOME;  // directorio de trabajo de la sesión
+    this.mcpConfig = mcpConfig || DEFAULT_MCP_CONFIG;  // ruta a mcp-config.json
+    this.appendSystemPrompt = appendSystemPrompt || null;  // prompt adicional de sistema
   }
 
-  async sendMessage(text, onChunk = null) {
+  async sendMessage(text, onChunk = null, onStatus = null) {
     const isWin = process.platform === 'win32';
     // En Windows: texto por stdin (cmd.exe rompe args largos con saltos de línea)
     // En Linux:   texto como argumento -p (comportamiento original, probado)
@@ -40,6 +45,8 @@ class ClaudePrintSession {
       claudeArgs.unshift('--permission-mode', modeMap[this.permissionMode] || 'default');
     }
     if (this.model) claudeArgs.push('--model', this.model);
+    if (this.mcpConfig) claudeArgs.push('--mcp-config', this.mcpConfig);
+    if (this.appendSystemPrompt) claudeArgs.push('--append-system-prompt', this.appendSystemPrompt);
     if (this.messageCount > 0 && this.claudeSessionId) {
       claudeArgs.push('--resume', this.claudeSessionId);
     } else if (this.messageCount > 0) {
@@ -75,6 +82,14 @@ class ClaudePrintSession {
       let killed = false;
       let exited = false;
       let eventCount = 0;
+      let usedMcpTools = false;
+      const TELEGRAM_TOOLS = ['telegram_send_message', 'telegram_send_photo', 'telegram_send_document'];
+
+      const emitStatus = (status, detail = null) => {
+        if (onStatus) onStatus(status, detail);
+      };
+
+      emitStatus('thinking');
 
       const killTimer = setTimeout(() => {
         killed = true;
@@ -93,6 +108,23 @@ class ClaudePrintSession {
           if (event.type === 'stream_event' && event.event) {
             const raw = event.event;
             const inner = typeof raw === 'string' ? JSON.parse(raw) : raw;
+
+            // Detectar inicio de tool_use para status
+            if (inner.type === 'content_block_start' && inner.content_block?.type === 'tool_use') {
+              const toolName = inner.content_block.name || 'herramienta';
+              if (TELEGRAM_TOOLS.includes(toolName)) usedMcpTools = true;
+              cpdbg('event', `#${eventCount} tool_use start: ${toolName} isTelegramTool=${TELEGRAM_TOOLS.includes(toolName)}`);
+              emitStatus('tool_use', toolName);
+            }
+            // Detectar inicio de bloque de texto
+            else if (inner.type === 'content_block_start' && inner.content_block?.type === 'text') {
+              emitStatus('thinking');
+            }
+            // Detectar fin de tool_use
+            else if (inner.type === 'content_block_stop') {
+              cpdbg('event', `#${eventCount} content_block_stop`);
+            }
+
             if (inner.type === 'content_block_delta' && inner.delta?.type === 'text_delta') {
               fullText += inner.delta.text;
               cpdbg('delta', `#${eventCount} +${inner.delta.text.length}chars total=${fullText.length}`);
@@ -105,6 +137,10 @@ class ClaudePrintSession {
             const content = event.message?.content;
             cpdbg('event', `#${eventCount} assistant content=${Array.isArray(content) ? content.length + ' blocks' : 'none'} fullText=${fullText.length}`);
             if (Array.isArray(content)) {
+              // Detectar tool_use de telegram en bloques de assistant
+              const hasTelegramTool = content.some(b => b.type === 'tool_use' && TELEGRAM_TOOLS.includes(b.name));
+              if (hasTelegramTool) usedMcpTools = true;
+
               const textBlock = content.find(b => b.type === 'text');
               if (textBlock?.text && !fullText) {
                 fullText = textBlock.text;
@@ -127,6 +163,7 @@ class ClaudePrintSession {
               this.lastCostUsd = event.total_cost_usd - this.totalCostUsd;
               this.totalCostUsd = event.total_cost_usd;
             }
+            emitStatus('done');
           } else {
             cpdbg('event', `#${eventCount} type=${event.type}`);
           }
@@ -160,8 +197,8 @@ class ClaudePrintSession {
           return reject(new Error(`claude salió con código ${exitCode}`));
         }
         this.messageCount++;
-        cpdbg('close', `OK msgCount=${this.messageCount} text="${fullText.slice(0, 100)}"`);
-        resolve(fullText.trim());
+        cpdbg('close', `OK msgCount=${this.messageCount} text="${fullText.slice(0, 100)}" usedMcpTools=${usedMcpTools}`);
+        resolve({ text: fullText.trim(), usedMcpTools });
       });
     });
   }

--- a/server/ecosystem.config.js
+++ b/server/ecosystem.config.js
@@ -16,10 +16,18 @@ function loadEnv() {
 }
 
 module.exports = {
-  apps: [{
-    name: 'clawmint',
-    script: 'index.js',
-    node_args: '--stack-size=65536',
-    env: loadEnv(),
-  }],
+  apps: [
+    {
+      name: 'clawmint',
+      script: 'index.js',
+      node_args: '--stack-size=65536',
+      env: loadEnv(),
+    },
+    {
+      name: 'clawmint-client',
+      script: 'node_modules/.bin/vite',
+      cwd: path.join(__dirname, '..', 'client'),
+      args: '--host 100.64.0.2 --port 5173',
+    },
+  ],
 };

--- a/server/index.js
+++ b/server/index.js
@@ -63,7 +63,7 @@ logger.info('HOME:', process.env.HOME);
 
 // ── Carga de módulos (async por sql.js WASM) ─────────────────────────────────
 
-let sessionManager, telegram, agents, skills, events, memory, providerConfig, providersModule, consolidator;
+let sessionManager, telegram, agents, skills, events, memory, providerConfig, providersModule, consolidator, convSvc;
 let mcpRouter = null;
 
 const _modulesReady = (async function loadModules() {
@@ -88,6 +88,7 @@ const _modulesReady = (async function loadModules() {
     const _c = createContainer();
     telegram     = _c.telegramChannel;
     consolidator = _c.consolidator;
+    convSvc      = _c.convSvc;
     // MCP router (embebido en Express)
     try {
       const { createMcpRouter } = require('./mcp');
@@ -104,6 +105,18 @@ const _modulesReady = (async function loadModules() {
 const app = express();
 app.use(cors());
 app.use(express.json());
+
+// ── Health check ─────────────────────────────────────────────────────────────
+const SERVER_START_TIME = Date.now();
+app.get('/api/health', (_req, res) => {
+  res.json({
+    ok: true,
+    uptime: Math.floor((Date.now() - SERVER_START_TIME) / 1000),
+    startedAt: new Date(SERVER_START_TIME).toISOString(),
+    pid: process.pid,
+    node: process.version,
+  });
+});
 
 // ── MCP endpoint (montado después de inicializar mcpRouter) ──────────────────
 // Se registra con app.use('/mcp', ...) luego de que mcpRouter esté disponible.
@@ -568,6 +581,83 @@ app.delete('/api/telegram/bots/:key/chats/:chatId', (req, res) => {
   res.json({ ok });
 });
 
+// POST /api/telegram/bots/:key/chats/:chatId/message — enviar texto a un chat
+app.post('/api/telegram/bots/:key/chats/:chatId/message', async (req, res) => {
+  try {
+    const bot = telegram.getBot(req.params.key);
+    if (!bot) return res.status(404).json({ error: 'Bot no encontrado' });
+    const chatId = Number(req.params.chatId);
+    const { text, parse_mode, reply_markup, callbacks } = req.body || {};
+    if (!text) return res.status(400).json({ error: 'Se requiere text' });
+
+    // Registrar callbacks dinámicos si vienen
+    if (callbacks && typeof callbacks === 'object') {
+      const dynamicRegistry = require('./channels/telegram/DynamicCallbackRegistry');
+      dynamicRegistry.registerMany(callbacks);
+    }
+
+    const body = { chat_id: chatId, text };
+    if (parse_mode) body.parse_mode = parse_mode;
+    if (reply_markup) body.reply_markup = typeof reply_markup === 'string' ? reply_markup : JSON.stringify(reply_markup);
+    const result = await bot._apiCall('sendMessage', body);
+    res.json({ ok: true, message_id: result.message_id });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /api/telegram/bots/:key/chats/:chatId/photo — enviar imagen a un chat
+app.post('/api/telegram/bots/:key/chats/:chatId/photo', express.raw({ type: '*/*', limit: '20mb' }), async (req, res) => {
+  try {
+    const bot = telegram.getBot(req.params.key);
+    if (!bot) return res.status(404).json({ error: 'Bot no encontrado' });
+    const chatId = Number(req.params.chatId);
+    const caption = req.query.caption || '';
+    const filename = req.query.filename || 'photo.png';
+
+    // Aceptar body raw (Buffer) o base64 en JSON
+    let photoBuffer;
+    if (Buffer.isBuffer(req.body) && req.body.length > 0) {
+      photoBuffer = req.body;
+    } else if (typeof req.body === 'string') {
+      photoBuffer = Buffer.from(req.body, 'base64');
+    } else {
+      return res.status(400).json({ error: 'Se requiere imagen como body raw o base64' });
+    }
+
+    const result = await bot.sendPhoto(chatId, photoBuffer, { caption, filename });
+    res.json({ ok: true, message_id: result.message_id });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /api/telegram/bots/:key/chats/:chatId/document — enviar archivo a un chat
+app.post('/api/telegram/bots/:key/chats/:chatId/document', express.raw({ type: '*/*', limit: '50mb' }), async (req, res) => {
+  try {
+    const bot = telegram.getBot(req.params.key);
+    if (!bot) return res.status(404).json({ error: 'Bot no encontrado' });
+    const chatId = Number(req.params.chatId);
+    const caption = req.query.caption || '';
+    const filename = req.query.filename || 'file.bin';
+    const contentType = req.query.contentType || 'application/octet-stream';
+
+    let docBuffer;
+    if (Buffer.isBuffer(req.body) && req.body.length > 0) {
+      docBuffer = req.body;
+    } else if (typeof req.body === 'string') {
+      docBuffer = Buffer.from(req.body, 'base64');
+    } else {
+      return res.status(400).json({ error: 'Se requiere archivo como body raw o base64' });
+    }
+
+    const result = await bot.sendDocument(chatId, docBuffer, { caption, filename, contentType });
+    res.json({ ok: true, message_id: result.message_id });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 // ─── WebSocket ────────────────────────────────────────────────────────────────
 
 wss.on('connection', (ws) => {
@@ -596,6 +686,11 @@ wss.on('connection', (ws) => {
 
         // Listener puro: solo recibe broadcasts, sin PTY
         if (msg.sessionType === 'listener') {
+          return;
+        }
+
+        if (msg.sessionType === 'webchat') {
+          startWebChatSession(ws, msg);
           return;
         }
 
@@ -805,6 +900,251 @@ function startAISession(ws, opts) {
   function send(text) {
     if (ws.readyState === ws.OPEN)
       ws.send(JSON.stringify({ type: 'output', data: text }));
+  }
+}
+
+// ─── WebChat Session (chat con burbujas, usa ConversationService) ─────────────
+
+function startWebChatSession(ws, opts) {
+  const sessionId = crypto.randomUUID();
+  ws.send(JSON.stringify({ type: 'session_id', id: sessionId }));
+
+  // Estado del chat (similar al estado por chat de Telegram)
+  const state = {
+    provider: opts.provider || providerConfig?.getConfig()?.default || 'anthropic',
+    agent: opts.agent || null,
+    model: null,
+    history: [],
+    claudeSession: null,
+    claudeMode: 'auto',
+    cwd: process.env.HOME || '~',
+    processing: false,
+  };
+
+  // Enviar status inicial
+  sendStatus();
+
+  ws.on('message', async (raw) => {
+    try {
+      const msg = JSON.parse(raw);
+      if (msg.type !== 'chat') return;
+      if (state.processing) return;
+
+      const text = (msg.text || '').trim();
+      if (!text) return;
+
+      // Actualizar provider/agent desde el cliente si lo envía
+      if (msg.provider) state.provider = msg.provider;
+      if (msg.agent !== undefined) state.agent = msg.agent || null;
+
+      // Comandos
+      if (text.startsWith('/')) {
+        handleCommand(text);
+        return;
+      }
+
+      // Mensaje normal → enviar a ConversationService
+      await sendToAI(text);
+    } catch (err) {
+      sendJson({ type: 'chat_error', error: err.message || 'Error interno' });
+      state.processing = false;
+    }
+  });
+
+  function handleCommand(text) {
+    const parts = text.split(/\s+/);
+    const cmd = parts[0].toLowerCase();
+    const arg = parts.slice(1).join(' ').trim();
+
+    switch (cmd) {
+      case '/provider': {
+        if (!arg) {
+          const list = providersModule.list().map(p => `${p.name === state.provider ? '→ ' : '  '}${p.name} (${p.label})`).join('\n');
+          sendJson({ type: 'command_result', text: `Providers disponibles:\n${list}` });
+          return;
+        }
+        const p = providersModule.get(arg);
+        if (!p) {
+          sendJson({ type: 'command_result', text: `Provider "${arg}" no encontrado.` });
+          return;
+        }
+        state.provider = arg;
+        state.history = [];
+        sendJson({ type: 'command_result', text: `Provider cambiado a ${p.label || arg}`, provider: arg });
+        return;
+      }
+
+      case '/agente': {
+        if (!arg) {
+          const list = agents.list().map(a => `${a.key === state.agent ? '→ ' : '  '}${a.key}: ${a.description || ''}`).join('\n');
+          sendJson({ type: 'command_result', text: list || 'No hay agentes configurados.', agent: state.agent });
+          return;
+        }
+        if (arg === 'ninguno' || arg === 'none') {
+          state.agent = null;
+          sendJson({ type: 'command_result', text: 'Agente desactivado.', agent: null });
+          return;
+        }
+        const a = agents.get(arg);
+        if (!a) {
+          sendJson({ type: 'command_result', text: `Agente "${arg}" no encontrado.` });
+          return;
+        }
+        state.agent = arg;
+        sendJson({ type: 'command_result', text: `Agente activo: ${arg}`, agent: arg });
+        return;
+      }
+
+      case '/modelo':
+      case '/model': {
+        if (!arg) {
+          sendJson({ type: 'command_result', text: `Modelo actual: ${state.model || '(default del provider)'}` });
+          return;
+        }
+        state.model = arg;
+        sendJson({ type: 'command_result', text: `Modelo: ${arg}` });
+        return;
+      }
+
+      case '/cd': {
+        if (!arg) {
+          sendJson({ type: 'command_result', text: `Directorio actual: ${state.cwd}`, cwd: state.cwd });
+          return;
+        }
+        const resolved = require('path').resolve(state.cwd, arg);
+        try {
+          const stat = require('fs').statSync(resolved);
+          if (!stat.isDirectory()) {
+            sendJson({ type: 'command_result', text: `"${resolved}" no es un directorio.` });
+            return;
+          }
+          state.cwd = resolved;
+          sendJson({ type: 'command_result', text: `Directorio: ${resolved}`, cwd: resolved });
+        } catch {
+          sendJson({ type: 'command_result', text: `Directorio no encontrado: ${resolved}` });
+        }
+        return;
+      }
+
+      case '/nueva':
+      case '/reset':
+      case '/clear': {
+        state.history = [];
+        state.claudeSession = null;
+        sendJson({ type: 'command_result', text: 'Conversación reiniciada.' });
+        return;
+      }
+
+      case '/modo':
+      case '/mode': {
+        const modes = ['ask', 'auto', 'plan'];
+        if (!arg || !modes.includes(arg)) {
+          sendJson({ type: 'command_result', text: `Modo actual: ${state.claudeMode}. Opciones: ${modes.join(', ')}` });
+          return;
+        }
+        state.claudeMode = arg;
+        sendJson({ type: 'command_result', text: `Modo: ${arg}` });
+        return;
+      }
+
+      case '/estado':
+      case '/status': {
+        const info = [
+          `Provider: ${state.provider}`,
+          `Agente: ${state.agent || '(ninguno)'}`,
+          `Modelo: ${state.model || '(default)'}`,
+          `Modo: ${state.claudeMode}`,
+          `Directorio: ${state.cwd}`,
+          `Historial: ${state.history.length} mensajes`,
+        ].join('\n');
+        sendJson({ type: 'command_result', text: info });
+        return;
+      }
+
+      case '/ayuda':
+      case '/help': {
+        const help = [
+          '/provider [nombre] — cambiar provider de IA',
+          '/agente [nombre] — seleccionar agente',
+          '/modelo [nombre] — cambiar modelo',
+          '/cd [ruta] — cambiar directorio',
+          '/nueva — nueva conversación',
+          '/modo [ask|auto|plan] — modo de permisos (Claude Code)',
+          '/estado — ver estado actual',
+          '/ayuda — esta ayuda',
+        ].join('\n');
+        sendJson({ type: 'command_result', text: help });
+        return;
+      }
+
+      default:
+        sendJson({ type: 'command_result', text: `Comando desconocido: ${cmd}. Usá /ayuda.` });
+    }
+  }
+
+  async function sendToAI(text) {
+    state.processing = true;
+
+    try {
+      if (!convSvc) {
+        sendJson({ type: 'chat_error', error: 'ConversationService no disponible.' });
+        state.processing = false;
+        return;
+      }
+
+      const onChunk = (partial) => {
+        sendJson({ type: 'chat_chunk', text: partial });
+      };
+
+      const result = await convSvc.processMessage({
+        chatId: sessionId,
+        agentKey: state.agent,
+        provider: state.provider,
+        model: state.model,
+        text,
+        history: state.history,
+        claudeSession: state.claudeSession,
+        claudeMode: state.claudeMode,
+        onChunk,
+        shellId: sessionId,
+      });
+
+      // Actualizar estado con resultado
+      if (result.history) state.history = result.history;
+      if (result.newSession) state.claudeSession = result.newSession;
+
+      // Para claude-code que no devuelve history, mantener historial manual
+      if (!result.history && state.provider === 'claude-code') {
+        // Claude Code mantiene su propio historial en la session
+      } else if (!result.history) {
+        state.history.push({ role: 'user', content: text });
+        state.history.push({ role: 'assistant', content: result.text });
+      }
+
+      sendJson({ type: 'chat_done', text: result.text });
+
+      if (result.savedMemoryFiles?.length > 0) {
+        sendJson({ type: 'command_result', text: `💾 Memoria guardada: ${result.savedMemoryFiles.join(', ')}` });
+      }
+    } catch (err) {
+      logger.error('WebChat error:', err.stack || err.message);
+      sendJson({ type: 'chat_error', error: err.message || 'Error procesando mensaje' });
+    }
+
+    state.processing = false;
+  }
+
+  function sendStatus() {
+    sendJson({
+      type: 'status',
+      provider: state.provider,
+      agent: state.agent,
+      cwd: state.cwd,
+    });
+  }
+
+  function sendJson(obj) {
+    if (ws.readyState === ws.OPEN) ws.send(JSON.stringify(obj));
   }
 }
 

--- a/server/mcp-config.json
+++ b/server/mcp-config.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "kheiron-tools": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["/home/usuario/.marcos/kheiron-tool/src/mcp-server.js"]
+    },
+    "clawmint": {
+      "type": "http",
+      "url": "http://localhost:3002/mcp"
+    }
+  }
+}

--- a/server/mcp-system-prompt.txt
+++ b/server/mcp-system-prompt.txt
@@ -1,0 +1,37 @@
+Estás respondiendo a un usuario via Telegram (o WebChat) a través de Clawmint.
+Tienes acceso a herramientas MCP que puedes usar cuando sea necesario.
+
+## REGLA PRINCIPAL DE COMUNICACIÓN
+
+TODA tu comunicación con el usuario DEBE ser a través de herramientas MCP.
+NO devuelvas texto plano como respuesta — el usuario NO lo verá.
+
+Para responder con texto: usa `telegram_send_message` (bot y chat_id se pasan en el contexto).
+Para enviar imágenes: usa `telegram_send_photo`.
+Para enviar archivos: usa `telegram_send_document`.
+
+Si tu respuesta es larga, divídela en múltiples llamadas a `telegram_send_message` (un párrafo por mensaje).
+
+## Herramientas disponibles
+
+### kheiron-tools
+Herramientas multimedia: screenshots de webs, OCR, conversión de imágenes, generación de QR/códigos de barras, TTS, video, PDFs, etc.
+Usa estas herramientas cuando el usuario pida algo visual o multimedia.
+
+### clawmint
+Herramientas del servidor Clawmint:
+- **telegram_send_photo**: Enviar imagen al chat actual. Params: bot, chat_id, file_path, caption.
+- **telegram_send_document**: Enviar archivo al chat actual. Params: bot, chat_id, file_path, caption.
+- **telegram_send_message**: Enviar mensaje de texto al chat. Params: bot, chat_id, text, parse_mode?, reply_markup?. Soporta botones inline con reply_markup: `{"inline_keyboard": [[{"text": "Botón", "callback_data": "dato"}]]}` o URLs: `{"text": "Abrir", "url": "https://..."}`.
+- **bash**: Ejecutar comandos en el servidor.
+- **read_file / write_file**: Leer/escribir archivos en el servidor.
+
+## Reglas de uso
+
+1. SIEMPRE responde usando `telegram_send_message`. Nunca devuelvas texto plano.
+2. Cuando generes un archivo (screenshot, PDF, imagen, etc.), envíalo con telegram_send_photo o telegram_send_document.
+3. No describas la imagen — envíala directamente.
+4. El bot y chat_id del usuario actual se pasan en el contexto del mensaje. Usa esos valores para enviar.
+5. Responde siempre en español.
+6. Sé conciso y directo.
+7. Para respuestas largas, envía múltiples mensajes cortos (un párrafo cada uno).

--- a/server/mcp/tools/index.js
+++ b/server/mcp/tools/index.js
@@ -1,10 +1,11 @@
 'use strict';
 
-const bash    = require('./bash');
-const files   = require('./files');  // array
-const pty     = require('./pty');    // array
+const bash     = require('./bash');
+const files    = require('./files');    // array
+const pty      = require('./pty');      // array
+const telegram = require('./telegram'); // array
 
-const ALL_TOOLS = [bash, ...files, ...pty];
+const ALL_TOOLS = [bash, ...files, ...pty, ...telegram];
 
 const _byName = new Map(ALL_TOOLS.map(t => [t.name, t]));
 

--- a/server/mcp/tools/telegram.js
+++ b/server/mcp/tools/telegram.js
@@ -1,0 +1,176 @@
+'use strict';
+
+const http = require('http');
+const fs   = require('fs');
+
+const API_BASE = `http://localhost:${process.env.PORT || 3002}`;
+
+// Helper: HTTP request a la API local
+function apiGet(path) {
+  return new Promise((resolve, reject) => {
+    http.get(`${API_BASE}${path}`, (res) => {
+      let raw = '';
+      res.on('data', c => { raw += c; });
+      res.on('end', () => {
+        try { resolve(JSON.parse(raw)); }
+        catch { resolve(raw); }
+      });
+    }).on('error', reject);
+  });
+}
+
+function apiPost(path, body, contentType = 'application/json') {
+  return new Promise((resolve, reject) => {
+    const url = new URL(`${API_BASE}${path}`);
+    const isJson = contentType === 'application/json';
+    const data = isJson ? JSON.stringify(body) : body;
+
+    const options = {
+      hostname: url.hostname,
+      port: url.port,
+      path: url.pathname + url.search,
+      method: 'POST',
+      headers: {
+        'Content-Type': contentType,
+        'Content-Length': Buffer.byteLength(data),
+      },
+    };
+
+    const req = http.request(options, (res) => {
+      let raw = '';
+      res.on('data', c => { raw += c; });
+      res.on('end', () => {
+        try { resolve(JSON.parse(raw)); }
+        catch { resolve(raw); }
+      });
+    });
+    req.on('error', reject);
+    req.write(data);
+    req.end();
+  });
+}
+
+// ── Tools ────────────────────────────────────────────────────────────────────
+
+const telegramListBots = {
+  name: 'telegram_list_bots',
+  description: 'Lista los bots de Telegram configurados con sus chats activos.',
+  params: {},
+
+  async execute() {
+    const bots = await apiGet('/api/telegram/bots');
+    if (!Array.isArray(bots)) return 'No hay bots configurados.';
+    const lines = bots.map(b => {
+      const status = b.running ? '🟢' : '🔴';
+      const chats = (b.chats || []).map(c =>
+        `    chat ${c.chatId} (${c.firstName || c.username || 'sin nombre'})`
+      ).join('\n');
+      return `${status} ${b.key} (${b.botInfo?.username || '?'})\n${chats || '    (sin chats)'}`;
+    });
+    return lines.join('\n\n');
+  },
+};
+
+const telegramSendMessage = {
+  name: 'telegram_send_message',
+  description: 'Enviar un mensaje de texto a un chat de Telegram. Soporta botones inline con callbacks dinámicos.',
+  params: {
+    bot: 'string — key del bot (ej: chibi2026_bot)',
+    chat_id: 'string — ID del chat destino',
+    text: 'string — texto del mensaje',
+    'parse_mode?': '?string — HTML, Markdown o MarkdownV2 (opcional)',
+    'reply_markup?': '?object — Telegram reply_markup (inline_keyboard, etc.)',
+    'callbacks?': '?object — Callbacks dinámicos: { "callback_data": { type: "message"|"command"|"prompt", ...params, ttl?, once? } }. ' +
+      'type "message": { text, parse_mode? } responde con texto. ' +
+      'type "command": { cmd, timeout? } ejecuta bash y envía output. ' +
+      'type "prompt": { text } envía como prompt al AI activo. ' +
+      'ttl: ms de vida (default 300000=5min). once: true para single-use.',
+  },
+
+  async execute({ bot, chat_id, text, parse_mode, reply_markup, callbacks }) {
+    if (!bot || !chat_id || !text) return 'Error: bot, chat_id y text son requeridos.';
+    const bots = await apiGet('/api/telegram/bots');
+    const botInfo = Array.isArray(bots) && bots.find(b => b.key === bot);
+    if (!botInfo) return `Error: bot "${bot}" no encontrado.`;
+
+    // MCP envía todos los params como strings — parsear JSON si es necesario
+    const parseIfString = (v) => {
+      if (typeof v === 'string') { try { return JSON.parse(v); } catch { return v; } }
+      return v;
+    };
+
+    const body = { text, parse_mode };
+    if (reply_markup) body.reply_markup = parseIfString(reply_markup);
+    if (callbacks) body.callbacks = parseIfString(callbacks);
+    const result = await apiPost(`/api/telegram/bots/${bot}/chats/${chat_id}/message`, body);
+    if (result.error) return `Error: ${result.error}`;
+    return `Mensaje enviado (message_id: ${result.message_id})`;
+  },
+};
+
+const telegramSendPhoto = {
+  name: 'telegram_send_photo',
+  description: 'Enviar una imagen a un chat de Telegram. La imagen debe existir en disco.',
+  params: {
+    bot: 'string — key del bot (ej: chibi2026_bot)',
+    chat_id: 'string — ID del chat destino',
+    file_path: 'string — ruta absoluta de la imagen en disco',
+    'caption?': '?string — texto debajo de la imagen (opcional)',
+  },
+
+  async execute({ bot, chat_id, file_path, caption }) {
+    if (!bot || !chat_id || !file_path) return 'Error: bot, chat_id y file_path son requeridos.';
+
+    if (!fs.existsSync(file_path)) return `Error: archivo no encontrado: ${file_path}`;
+    const buffer = fs.readFileSync(file_path);
+    const ext = file_path.split('.').pop().toLowerCase();
+    const mimeMap = { png: 'image/png', jpg: 'image/jpeg', jpeg: 'image/jpeg', gif: 'image/gif', webp: 'image/webp' };
+    const contentType = mimeMap[ext] || 'image/png';
+    const filename = file_path.split('/').pop();
+
+    const qs = new URLSearchParams();
+    if (caption) qs.set('caption', caption);
+    qs.set('filename', filename);
+
+    const result = await apiPost(
+      `/api/telegram/bots/${bot}/chats/${chat_id}/photo?${qs.toString()}`,
+      buffer,
+      contentType
+    );
+    if (result.error) return `Error: ${result.error}`;
+    return `Foto enviada (message_id: ${result.message_id})`;
+  },
+};
+
+const telegramSendDocument = {
+  name: 'telegram_send_document',
+  description: 'Enviar un archivo/documento a un chat de Telegram.',
+  params: {
+    bot: 'string — key del bot (ej: chibi2026_bot)',
+    chat_id: 'string — ID del chat destino',
+    file_path: 'string — ruta absoluta del archivo en disco',
+    'caption?': '?string — texto debajo del archivo (opcional)',
+  },
+
+  async execute({ bot, chat_id, file_path, caption }) {
+    if (!bot || !chat_id || !file_path) return 'Error: bot, chat_id y file_path son requeridos.';
+
+    if (!fs.existsSync(file_path)) return `Error: archivo no encontrado: ${file_path}`;
+    const buffer = fs.readFileSync(file_path);
+    const filename = file_path.split('/').pop();
+
+    const qs = new URLSearchParams();
+    if (caption) qs.set('caption', caption);
+    qs.set('filename', filename);
+
+    const result = await apiPost(
+      `/api/telegram/bots/${bot}/chats/${chat_id}/document?${qs.toString()}`,
+      buffer,
+      'application/octet-stream'
+    );
+    if (result.error) return `Error: ${result.error}`;
+    return `Documento enviado (message_id: ${result.message_id})`;
+  },
+};
+
+module.exports = [telegramListBots, telegramSendMessage, telegramSendPhoto, telegramSendDocument];

--- a/server/services/ConversationService.js
+++ b/server/services/ConversationService.js
@@ -1,5 +1,17 @@
 'use strict';
 
+const path = require('path');
+const fs = require('fs');
+
+const MCP_SYSTEM_PROMPT_PATH = path.join(__dirname, '..', 'mcp-system-prompt.txt');
+let _mcpSystemPrompt = null;
+function getMcpSystemPrompt() {
+  if (_mcpSystemPrompt === null) {
+    try { _mcpSystemPrompt = fs.readFileSync(MCP_SYSTEM_PROMPT_PATH, 'utf-8'); } catch { _mcpSystemPrompt = ''; }
+  }
+  return _mcpSystemPrompt;
+}
+
 function _csDbg() { return process.env.DEBUG_TELEGRAM === '1'; }
 function csdbg(scope, ...args) { if (_csDbg()) console.log(`[ConvSvc:DBG:${scope}]`, ...args); }
 
@@ -79,9 +91,12 @@ class ConversationService {
     images        = null,
     history       = [],
     claudeSession = null,
-    claudeMode    = 'ask',
+    claudeMode    = 'auto',
     onChunk       = null,
+    onStatus      = null,
     shellId       = null,
+    botKey        = null,
+    channel       = null,
   }) {
     const resolvedShellId = shellId || String(chatId);
     csdbg('msg', `chatId=${chatId} provider=${provider} agent=${agentKey} model=${model} textLen=${text.length} images=${images?.length || 0} histLen=${history.length} hasSession=${!!claudeSession}`);
@@ -95,13 +110,13 @@ class ConversationService {
 
     csdbg('msg', `→ _processClaudeCode mode=${claudeMode}`);
     return this._processClaudeCode({
-      chatId, agentKey, text, images, claudeSession, claudeMode, onChunk,
+      chatId, agentKey, text, images, claudeSession, claudeMode, onChunk, onStatus, botKey, channel,
     });
   }
 
   // ── Proveedor claude-code (ClaudePrintSession) ────────────────────────────
 
-  async _processClaudeCode({ chatId, agentKey, text, images, claudeSession, claudeMode, onChunk }) {
+  async _processClaudeCode({ chatId, agentKey, text, images, claudeSession, claudeMode, onChunk, onStatus, botKey, channel }) {
     // Claude Code CLI no soporta imágenes — extraer texto con OCR (kheiron) + fallback Ollama visión
     if (images && images.length > 0) {
       const { execSync } = require('child_process');
@@ -156,13 +171,33 @@ class ConversationService {
       const imgContext = descriptions.join('\n\n');
       text = `[El usuario envió ${images.length} imagen(es). Análisis:]\n\n${imgContext}\n\n[Mensaje original del usuario: "${text}"]`;
     }
+    const MAX_SESSION_MESSAGES = 10;
     let session = claudeSession;
     let isNewSession = false;
+    const mcpPrompt = getMcpSystemPrompt();
+    const channelCtx = (botKey && chatId)
+      ? `\n\n## Contexto del canal\n- Canal: ${channel || 'telegram'}\n- Bot key: ${botKey}\n- Chat ID: ${chatId}\nUsa estos valores cuando necesites enviar fotos, documentos o mensajes al usuario.`
+      : '';
+    const fullSystemPrompt = mcpPrompt ? (mcpPrompt + channelCtx) : '';
+
+    // Auto-reset: si la sesión tiene demasiados mensajes, crear una nueva
+    if (session && session.messageCount >= MAX_SESSION_MESSAGES) {
+      csdbg('claude', `auto-reset: session tiene ${session.messageCount} msgs (max ${MAX_SESSION_MESSAGES}), creando nueva`);
+      console.log(`[ConvSvc] Auto-reset de sesión (${session.messageCount} mensajes)`);
+      session = null;
+    }
+
     if (!session) {
-      session = new this._ClaudePrintSession({ permissionMode: claudeMode || 'ask' });
+      session = new this._ClaudePrintSession({
+        permissionMode: claudeMode || 'auto',
+        appendSystemPrompt: fullSystemPrompt || undefined,
+      });
       isNewSession = true;
-      csdbg('claude', `nueva ClaudePrintSession mode=${claudeMode}`);
+      csdbg('claude', `nueva ClaudePrintSession mode=${claudeMode} mcpPrompt=${!!mcpPrompt} botKey=${botKey}`);
     } else {
+      if (fullSystemPrompt && !session.appendSystemPrompt) {
+        session.appendSystemPrompt = fullSystemPrompt;
+      }
       csdbg('claude', `reutilizando session msgCount=${session.messageCount}`);
     }
 
@@ -187,9 +222,9 @@ class ConversationService {
 
     csdbg('claude', `→ session.sendMessage() textLen=${messageText.length}`);
     const t0 = Date.now();
-    let rawResponse;
+    let result;
     try {
-      rawResponse = await session.sendMessage(messageText, onChunk);
+      result = await session.sendMessage(messageText, onChunk, onStatus);
     } catch (err) {
       // Si falló con --resume (session_id viejo/inválido), reintentar como nueva sesión
       if (session.claudeSessionId && session.messageCount > 0) {
@@ -198,12 +233,16 @@ class ConversationService {
         session.claudeSessionId = null;
         session.messageCount = 0;
         isNewSession = true;
-        rawResponse = await session.sendMessage(messageText, onChunk);
+        result = await session.sendMessage(messageText, onChunk, onStatus);
       } else {
         throw err;
       }
     }
-    csdbg('claude', `← session.sendMessage() ${Date.now() - t0}ms responseLen=${rawResponse?.length || 0}`);
+
+    // sendMessage ahora devuelve { text, usedMcpTools } o string (backward compat)
+    const rawResponse = typeof result === 'string' ? result : (result?.text || '');
+    const usedMcpTools = typeof result === 'object' ? result.usedMcpTools : false;
+    csdbg('claude', `← session.sendMessage() ${Date.now() - t0}ms responseLen=${rawResponse.length} usedMcpTools=${usedMcpTools}`);
 
     // Extraer y aplicar operaciones de memoria
     let response = rawResponse;
@@ -226,9 +265,10 @@ class ConversationService {
       }
     }
 
-    csdbg('claude', `DONE responseLen=${(response || '').length} savedFiles=${savedMemoryFiles.length} isNew=${isNewSession}`);
+    csdbg('claude', `DONE responseLen=${(response || '').length} savedFiles=${savedMemoryFiles.length} isNew=${isNewSession} usedMcpTools=${usedMcpTools}`);
     return {
       text: response || '',
+      usedMcpTools,
       savedMemoryFiles,
       ...(isNewSession ? { newSession: session } : {}),
     };

--- a/server/tts-config.json
+++ b/server/tts-config.json
@@ -1,6 +1,6 @@
 {
-  "enabled": true,
-  "default": "piper-tts",
+  "enabled": false,
+  "default": "edge-tts",
   "providers": {
     "speecht5": {
       "voice": null,
@@ -22,7 +22,7 @@
       "model": "standard"
     },
     "edge-tts": {
-      "voice": "es-MX-JorgeNeural",
+      "voice": "es-AR-ElenaNeural",
       "model": "default"
     },
     "piper-tts": {


### PR DESCRIPTION
## Summary
- **WebChatPanel**: nuevo panel de chat web que usa ConversationService (mismo motor que Telegram)
- **MCP Telegram tools**: herramientas telegram_send_message, send_photo, send_document y list_bots expuestas via MCP
- **DynamicCallbackRegistry**: sistema de callbacks dinámicos para botones inline con TTL y single-use
- **Fix MCP double-serialization**: los params reply_markup y callbacks llegaban como strings JSON desde MCP, causando doble serialización — ahora se parsean con parseIfString()
- Actualizaciones a componentes del client (AgentsPanel, McpsPanel, ProvidersPanel, TelegramPanel, DirPicker, TerminalPanel)
- Actualizaciones a CallbackHandler, CommandHandler, TelegramChannel, ConversationService, ClaudePrintSession
- Documentación actualizada en CLAUDE.md

## Test plan
- [x] Botones inline con callbacks dinámicos probados en Telegram (message, command types)
- [ ] Verificar WebChatPanel funciona correctamente desde el navegador
- [ ] Verificar MCP tools desde Claude Code CLI