### PR TITLE
feat: MCP memory tools, IDF-weighted tags, session continuity

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terminal-live-client",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Frontend React + xterm.js para terminal en tiempo real",
   "scripts": {
     "dev": "vite",

--- a/server/channels/telegram/CallbackHandler.js
+++ b/server/channels/telegram/CallbackHandler.js
@@ -582,34 +582,6 @@ class CallbackHandler {
       return;
     }
 
-    // Botones post-respuesta
-    if (data.startsWith('postreply:')) {
-      const action = data.slice(10);
-      if (action === 'continue') {
-        await bot._sendToSession(chatId, 'continúa', chat);
-      } else if (action === 'new') {
-        if (bot._isClaudeBased()) {
-          chat.claudeSession = new ClaudePrintSession(bot._claudeSessionOpts(chat));
-          if (this.chatSettings) this.chatSettings.clearSession(bot.key, chatId);
-          await bot.sendText(chatId, '✅ Nueva conversación iniciada.');
-        } else {
-          chat.aiHistory = [];
-          await bot.sendText(chatId, '✅ Historial limpiado.');
-        }
-      } else if (action === 'save') {
-        const lastReply = cbq.message?.text;
-        if (lastReply && this.memory) {
-          const agentKey  = chat.activeAgent?.key || bot.defaultAgent;
-          const filename  = `telegram_${Date.now()}.md`;
-          this.memory.write(agentKey, filename, lastReply);
-          await bot.sendText(chatId, `💾 Guardado en memoria de *${agentKey}* → \`${filename}\``);
-        } else {
-          await bot.sendText(chatId, '❌ No hay texto para guardar.');
-        }
-      }
-      return;
-    }
-
     // Callbacks de consola
     if (data.startsWith('console:')) {
       const command = data.slice(8);

--- a/server/channels/telegram/TelegramChannel.js
+++ b/server/channels/telegram/TelegramChannel.js
@@ -748,31 +748,25 @@ class TelegramBot {
     tdbg('result', `chatId=${chatId} rawLen=${(text||'').length} cleanLen=${finalText.length} hasSentMsg=${!!sentMsg}`);
     if (!finalText) { tdbg('result', `SKIP — finalText vacío`); return; }
 
-    const postButtons = [
-      [{ text: '▶ Seguir',             callback_data: 'postreply:continue' },
-       { text: '🔄 Nueva conv',         callback_data: 'postreply:new' }],
-      [{ text: '💾 Guardar en memoria', callback_data: 'postreply:save' }],
-    ];
-
     const chunks = chunkText(finalText, 4096);
     const lastIdx = chunks.length - 1;
     tdbg('result', `${chunks.length} chunk(s), first=${chunks[0]?.slice(0, 80)}`);
 
     if (sentMsg) {
       if (chunks.length === 1) {
-        tdbg('result', `editando msg ${sentMsg.message_id} con botones`);
-        await this.sendWithButtons(chatId, chunks[0], postButtons, sentMsg.message_id);
+        tdbg('result', `editando msg ${sentMsg.message_id}`);
+        try {
+          await this._apiCall('editMessageText', { chat_id: chatId, message_id: sentMsg.message_id, text: chunks[0] });
+        } catch (e) { tdbg('result', `editMsg FAIL: ${e.message}`); await this.sendText(chatId, chunks[0]); }
       } else {
         try {
           await this._apiCall('editMessageText', { chat_id: chatId, message_id: sentMsg.message_id, text: chunks[0] });
         } catch (e) { tdbg('result', `editMsg FAIL: ${e.message}`); await this.sendText(chatId, chunks[0]); }
-        for (let i = 1; i < lastIdx; i++) await this.sendText(chatId, chunks[i]);
-        await this.sendWithButtons(chatId, chunks[lastIdx], postButtons);
+        for (let i = 1; i <= lastIdx; i++) await this.sendText(chatId, chunks[i]);
       }
     } else {
       tdbg('result', `enviando ${chunks.length} chunk(s) como mensajes nuevos`);
-      for (let i = 0; i < lastIdx; i++) await this.sendText(chatId, chunks[i]);
-      await this.sendWithButtons(chatId, chunks[lastIdx], postButtons);
+      for (let i = 0; i <= lastIdx; i++) await this.sendText(chatId, chunks[i]);
     }
     tdbg('result', `OK`);
   }

--- a/server/mcp-system-prompt.txt
+++ b/server/mcp-system-prompt.txt
@@ -25,6 +25,41 @@ Herramientas del servidor Clawmint:
 - **telegram_send_message**: Enviar mensaje de texto al chat. Params: bot, chat_id, text, parse_mode?, reply_markup?. Soporta botones inline con reply_markup: `{"inline_keyboard": [[{"text": "Botón", "callback_data": "dato"}]]}` o URLs: `{"text": "Abrir", "url": "https://..."}`.
 - **bash**: Ejecutar comandos en el servidor.
 - **read_file / write_file**: Leer/escribir archivos en el servidor.
+- **memory_list**: Lista archivos de memoria del agente. Params: agent?.
+- **memory_read**: Lee un archivo de memoria. Params: filename, agent?.
+- **memory_write**: Guarda/sobreescribe un archivo de memoria. Params: filename, content, agent?.
+- **memory_append**: Agrega contenido a un archivo de memoria. Params: filename, content, agent?.
+- **memory_delete**: Elimina un archivo de memoria. Params: filename, agent?.
+
+## Memoria
+
+Tienes un sistema de memoria persistente para recordar información entre conversaciones.
+Tu memoria se reinicia cada ~10 mensajes, así que es CRÍTICO guardar información importante antes de perderla.
+
+### Cuándo guardar (PROACTIVO — no esperes a que te lo pidan):
+- El usuario comparte información personal (nombre, trabajo, gustos, datos)
+- El usuario expresa preferencias ("me gusta X", "prefiero Y", "no me gusta Z")
+- Se resuelve un problema técnico (guardar la solución para futuras consultas)
+- El usuario pide explícitamente que recuerdes algo
+- Estás en el mensaje 7+ de la conversación: guarda un resumen del contexto actual
+
+### Cuándo leer:
+- Al inicio de la conversación, si el contexto inyectado no es suficiente
+- Cuando el usuario pregunte algo que podría tener contexto previo
+- Cuando el usuario diga "¿te acordás de...?" o similar
+
+### Herramientas:
+- `memory_list` — ver qué memorias existen
+- `memory_read` — leer una memoria específica
+- `memory_write` — guardar/sobreescribir (usa nombres descriptivos: `preferencias-usuario.md`, `proyecto-actual.md`)
+- `memory_append` — agregar a un archivo existente (ideal para logs o notas acumulativas)
+- `memory_delete` — eliminar una memoria obsoleta
+
+### Reglas:
+- El parámetro `agent` se pasa en el contexto del canal — úsalo siempre.
+- Usa nombres de archivo descriptivos en español (ej: `datos-personales.md`, no `note1.md`).
+- No guardes información trivial o efímera.
+- Consolida: si ya existe un archivo sobre el tema, actualízalo con `memory_write` en vez de crear uno nuevo.
 
 ## Reglas de uso
 

--- a/server/mcp/tools/index.js
+++ b/server/mcp/tools/index.js
@@ -4,8 +4,9 @@ const bash     = require('./bash');
 const files    = require('./files');    // array
 const pty      = require('./pty');      // array
 const telegram = require('./telegram'); // array
+const memory   = require('./memory');   // array
 
-const ALL_TOOLS = [bash, ...files, ...pty, ...telegram];
+const ALL_TOOLS = [bash, ...files, ...pty, ...telegram, ...memory];
 
 const _byName = new Map(ALL_TOOLS.map(t => [t.name, t]));
 

--- a/server/mcp/tools/memory.js
+++ b/server/mcp/tools/memory.js
@@ -1,0 +1,98 @@
+'use strict';
+
+/**
+ * mcp/tools/memory.js — Tools MCP para gestión de memoria del agente.
+ *
+ * Expone: memory_list, memory_read, memory_write, memory_append, memory_delete
+ * Usa ctx.memory (server/memory.js) pasado desde el router MCP.
+ * El agentKey se resuelve desde ctx.agentKey o args.agent (default: 'default').
+ */
+
+function _agent(args, ctx) {
+  return args.agent || ctx.agentKey || 'default';
+}
+
+function _requireMemory(ctx) {
+  if (!ctx.memory) throw new Error('Módulo de memoria no disponible');
+}
+
+const MEMORY_LIST = {
+  name: 'memory_list',
+  description: 'Lista los archivos de memoria del agente actual. Retorna nombre, tamaño y fecha de cada archivo.',
+  params: { agent: '?string' },
+
+  execute(args = {}, ctx = {}) {
+    _requireMemory(ctx);
+    const agentKey = _agent(args, ctx);
+    const files = ctx.memory.listFiles(agentKey);
+    if (!files.length) return `Sin archivos de memoria para "${agentKey}".`;
+    const lines = files.map(f => {
+      const date = new Date(f.updatedAt).toISOString().slice(0, 16).replace('T', ' ');
+      return `${f.filename}\t${f.size}B\t${date}`;
+    });
+    return `Memoria de "${agentKey}" (${files.length} archivos):\n${lines.join('\n')}`;
+  },
+};
+
+const MEMORY_READ = {
+  name: 'memory_read',
+  description: 'Lee el contenido de un archivo de memoria del agente.',
+  params: { filename: 'string', agent: '?string' },
+
+  execute(args = {}, ctx = {}) {
+    _requireMemory(ctx);
+    if (!args.filename) return 'Error: parámetro filename requerido';
+    const agentKey = _agent(args, ctx);
+    const content = ctx.memory.read(agentKey, args.filename);
+    if (content === null) return `Archivo no encontrado: ${args.filename} (agente: ${agentKey})`;
+    return content;
+  },
+};
+
+const MEMORY_WRITE = {
+  name: 'memory_write',
+  description: 'Escribe (crea o sobreescribe) un archivo de memoria del agente. Usar para guardar información importante.',
+  params: { filename: 'string', content: 'string', agent: '?string' },
+
+  execute(args = {}, ctx = {}) {
+    _requireMemory(ctx);
+    if (!args.filename) return 'Error: parámetro filename requerido';
+    if (!args.content)  return 'Error: parámetro content requerido';
+    const agentKey = _agent(args, ctx);
+    ctx.memory.write(agentKey, args.filename, args.content);
+    return `Memoria guardada: ${args.filename} (agente: ${agentKey})`;
+  },
+};
+
+const MEMORY_APPEND = {
+  name: 'memory_append',
+  description: 'Agrega contenido al final de un archivo de memoria existente (o lo crea si no existe).',
+  params: { filename: 'string', content: 'string', agent: '?string' },
+
+  execute(args = {}, ctx = {}) {
+    _requireMemory(ctx);
+    if (!args.filename) return 'Error: parámetro filename requerido';
+    if (!args.content)  return 'Error: parámetro content requerido';
+    const agentKey = _agent(args, ctx);
+    ctx.memory.append(agentKey, args.filename, args.content);
+    return `Contenido agregado a: ${args.filename} (agente: ${agentKey})`;
+  },
+};
+
+const MEMORY_DELETE = {
+  name: 'memory_delete',
+  description: 'Elimina un archivo de memoria del agente.',
+  params: { filename: 'string', agent: '?string' },
+
+  execute(args = {}, ctx = {}) {
+    _requireMemory(ctx);
+    if (!args.filename) return 'Error: parámetro filename requerido';
+    const agentKey = _agent(args, ctx);
+    const deleted = ctx.memory.remove(agentKey, args.filename);
+    return deleted
+      ? `Archivo eliminado: ${args.filename} (agente: ${agentKey})`
+      : `Archivo no encontrado: ${args.filename} (agente: ${agentKey})`;
+  },
+};
+
+module.exports = [MEMORY_LIST, MEMORY_READ, MEMORY_WRITE, MEMORY_APPEND, MEMORY_DELETE];

--- a/server/memory.js
+++ b/server/memory.js
@@ -944,10 +944,33 @@ function spreadingActivation(agentKey, queryKeywords) {
 
   // ── Paso 1a: Nodos semilla por TAGS (match exacto en expanded set) ─────────
   const placeholders = expanded.map(() => '?').join(', ');
+
+  // Total de notas del agente (para cálculo IDF)
+  const totalNotes = Math.max(1, (db.prepare(
+    'SELECT COUNT(*) as cnt FROM notes WHERE agent_key = ?'
+  ).get(agentKey) || {}).cnt || 1);
+
+  // IDF por tag: log(totalNotes / notas_con_tag) — tags raros pesan más
+  const tagIdfMap = new Map();
+  const tagFreqs = db.prepare(`
+    SELECT t.name, COUNT(DISTINCT nt.note_id) as doc_count
+    FROM tags t
+    JOIN note_tags nt ON t.id = nt.tag_id
+    JOIN notes n      ON nt.note_id = n.id
+    WHERE n.agent_key = ? AND t.name IN (${placeholders})
+    GROUP BY t.name
+  `).all(agentKey, ...expanded);
+  for (const row of tagFreqs) {
+    tagIdfMap.set(row.name, Math.log(totalNotes / Math.max(1, row.doc_count)));
+  }
+
+  dbg('spread', `IDF tags (total=${totalNotes}): ${[...tagIdfMap].map(([t, w]) => `${t}=${w.toFixed(2)}`).join(', ')}`);
+
+  // Seeds: notas que tienen tags matcheados, con sus tags específicos
   const seeds = db.prepare(`
     SELECT n.id, n.title, n.content, n.importance, n.access_count,
            n.created_at, n.last_accessed, n.filename,
-           COUNT(*) as tag_hits
+           GROUP_CONCAT(t.name) as matched_tags
     FROM notes n
     JOIN note_tags nt ON n.id = nt.note_id
     JOIN tags t       ON nt.tag_id = t.id
@@ -961,7 +984,9 @@ function spreadingActivation(agentKey, queryKeywords) {
   dbg('spread', `seeds por tags: ${seeds.length}`);
 
   for (const seed of seeds) {
-    let activation = seed.tag_hits;
+    // Activación = suma de IDF de cada tag matcheado (tags raros aportan más)
+    const matchedTags = seed.matched_tags ? seed.matched_tags.split(',') : [];
+    let activation = matchedTags.reduce((sum, tag) => sum + (tagIdfMap.get(tag) || 1), 0);
     const titleNorm = _stripAccents(seed.title.toLowerCase());
     if (expanded.some(k => titleNorm.includes(_stripAccents(k)))) activation += 2;
     activation = Math.min(activation, 10);

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terminal-live-server",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Backend WebSocket + node-pty para terminal en tiempo real",
   "main": "index.js",
   "scripts": {

--- a/server/services/ConversationService.js
+++ b/server/services/ConversationService.js
@@ -176,14 +176,32 @@ class ConversationService {
     let isNewSession = false;
     const mcpPrompt = getMcpSystemPrompt();
     const channelCtx = (botKey && chatId)
-      ? `\n\n## Contexto del canal\n- Canal: ${channel || 'telegram'}\n- Bot key: ${botKey}\n- Chat ID: ${chatId}\nUsa estos valores cuando necesites enviar fotos, documentos o mensajes al usuario.`
+      ? `\n\n## Contexto del canal\n- Canal: ${channel || 'telegram'}\n- Bot key: ${botKey}\n- Chat ID: ${chatId}\n- Agente activo: ${agentKey || 'default'}\nUsa estos valores cuando necesites enviar fotos, documentos o mensajes al usuario.\nPara herramientas de memoria (memory_list, memory_read, memory_write, etc.), usa agent="${agentKey || 'default'}".`
       : '';
     const fullSystemPrompt = mcpPrompt ? (mcpPrompt + channelCtx) : '';
 
     // Auto-reset: si la sesión tiene demasiados mensajes, crear una nueva
+    // Antes de resetear, guardar resumen en memoria para continuidad
     if (session && session.messageCount >= MAX_SESSION_MESSAGES) {
       csdbg('claude', `auto-reset: session tiene ${session.messageCount} msgs (max ${MAX_SESSION_MESSAGES}), creando nueva`);
       console.log(`[ConvSvc] Auto-reset de sesión (${session.messageCount} mensajes)`);
+
+      // Guardar resumen de sesión en memoria para continuidad
+      if (agentKey && this._memory) {
+        try {
+          const ts = new Date().toISOString().slice(0, 16).replace('T', ' ');
+          const summaryFile = 'last-session-summary.md';
+          const existing = this._memory.read(agentKey, summaryFile);
+          const summary = `---\nSesión anterior (${ts}, ${session.messageCount} mensajes, chatId: ${chatId})\n---\n` +
+            `Último mensaje del usuario: ${text.slice(0, 500)}${text.length > 500 ? '...' : ''}\n` +
+            (existing ? `\nContexto previo:\n${existing.slice(0, 1000)}` : '');
+          this._memory.write(agentKey, summaryFile, summary);
+          csdbg('claude', `saved session summary to ${summaryFile}`);
+        } catch (err) {
+          csdbg('claude', `error saving session summary: ${err.message}`);
+        }
+      }
+
       session = null;
     }
 
@@ -213,9 +231,15 @@ class ConversationService {
       if (session.messageCount === 0) {
         const memCtx    = this._memory.buildMemoryContext(agentKey, text);
         const toolInstr = shouldNudge ? this._memory.TOOL_INSTRUCTIONS : '';
-        const parts     = [memCtx, toolInstr].filter(Boolean);
+        // Inyectar resumen de sesión anterior si existe (continuidad post-reset)
+        let sessionSummary = '';
+        try {
+          const summary = this._memory.read(agentKey, 'last-session-summary.md');
+          if (summary) sessionSummary = `## Resumen de sesión anterior\n${summary}`;
+        } catch {}
+        const parts = [sessionSummary, memCtx, toolInstr].filter(Boolean);
         if (parts.length > 0) messageText = `${parts.join('\n\n')}\n\n---\n\n${text}`;
-        csdbg('claude', `memCtx injected: ${memCtx?.length || 0} chars, toolInstr: ${toolInstr?.length || 0} chars`);
+        csdbg('claude', `memCtx injected: ${memCtx?.length || 0} chars, toolInstr: ${toolInstr?.length || 0} chars, sessionSummary: ${sessionSummary?.length || 0} chars`);
       }
     }
     if (shouldNudge && this._memory) messageText += this._memory.buildNudge(signals);


### PR DESCRIPTION
## Summary
- **MCP Memory Tools**: Nuevas herramientas `memory_list`, `memory_read`, `memory_write`, `memory_append`, `memory_delete` expuestas como tools MCP para que los agentes gestionen su memoria persistente
- **IDF-Weighted Tags**: El spreading activation ahora usa TF-IDF para ponderar tags — tags raros/específicos aportan más activación que tags comunes, mejorando la relevancia de búsqueda
- **Session Continuity**: Al auto-resetear sesiones (>10 mensajes), se guarda un resumen en memoria y se inyecta al inicio de la nueva sesión para mantener contexto
- **System Prompt**: Documentación de memory tools, instrucciones de uso proactivo, y contexto de agente activo
- **Cleanup**: Eliminados botones post-reply de Telegram (continue/new/save) — la funcionalidad se reemplaza con memory tools MCP

## Version
`v1.1.0` → `v1.2.0`

## Test plan
- [ ] Verificar que `memory_list`, `memory_read`, `memory_write`, `memory_append`, `memory_delete` funcionan desde MCP
- [ ] Confirmar que tags raros producen mayor activación que tags comunes en spreading activation
- [ ] Verificar que al resetear sesión se guarda `last-session-summary.md` en memoria del agente
- [ ] Confirmar que nueva sesión inyecta el resumen anterior como contexto
- [ ] Verificar que los botones post-reply ya no aparecen en Telegram