### PR TITLE
feat(telegram): expand MCP tools (4 new)

### DIFF
--- a/server/channels/telegram/TelegramChannel.js
+++ b/server/channels/telegram/TelegramChannel.js
@@ -512,8 +512,13 @@ class TelegramBot {
         return;
       }
       console.log(`[Telegram:${this.key}] Audio transcrito de ${chatId}: ${text.slice(0, 60)}`);
+      // Actualizar el mensaje de transcripción con el texto reconocido (ya no se reutiliza para status posteriores)
+      if (statusMsg) {
+        const preview = text.length > 200 ? text.slice(0, 200) + '…' : text;
+        try { await this._apiCall('editMessageText', { chat_id: chatId, message_id: statusMsg.message_id, text: `🎙️ ${preview}` }); } catch {}
+      }
       msg.text = text;
-      msg._statusMsg = statusMsg; // Pasar el mensaje de status para reutilizar
+      // No pasar _statusMsg — _sendToSession creará su propio mensaje de status
       await this._handleMessage(msg);
     } catch (err) {
       console.error(`[Telegram:${this.key}] Error procesando audio:`, err.message);
@@ -1129,6 +1134,32 @@ class TelegramBot {
       contentType: 'audio/wav',
     });
     if (!data.ok) throw new Error(data.description || 'sendVoice error');
+    return data.result;
+  }
+
+  /**
+   * Enviar un video a un chat.
+   * @param {number|string} chatId
+   * @param {Buffer} videoBuffer
+   * @param {object} [opts]
+   * @param {string} [opts.caption]
+   * @param {string} [opts.filename]
+   * @param {string} [opts.contentType]
+   * @param {string} [opts.parse_mode]
+   */
+  async sendVideo(chatId, videoBuffer, opts = {}) {
+    const urlPath = `/bot${this.token}/sendVideo`;
+    const fields = { chat_id: String(chatId) };
+    if (opts.caption) fields.caption = opts.caption;
+    if (opts.parse_mode) fields.parse_mode = opts.parse_mode;
+    const file = {
+      fieldName: 'video',
+      filename: opts.filename || 'video.mp4',
+      contentType: opts.contentType || 'video/mp4',
+      buffer: videoBuffer,
+    };
+    const data = await httpsPostMultipart(urlPath, fields, file);
+    if (!data.ok) throw new Error(data.description || 'sendVideo error');
     return data.result;
   }
 

--- a/server/index.js
+++ b/server/index.js
@@ -658,6 +658,88 @@ app.post('/api/telegram/bots/:key/chats/:chatId/document', express.raw({ type: '
   }
 });
 
+// POST /api/telegram/bots/:key/chats/:chatId/voice — enviar audio/voz a un chat
+app.post('/api/telegram/bots/:key/chats/:chatId/voice', express.raw({ type: '*/*', limit: '20mb' }), async (req, res) => {
+  try {
+    const bot = telegram.getBot(req.params.key);
+    if (!bot) return res.status(404).json({ error: 'Bot no encontrado' });
+    const chatId = Number(req.params.chatId);
+
+    let audioBuffer;
+    if (Buffer.isBuffer(req.body) && req.body.length > 0) {
+      audioBuffer = req.body;
+    } else if (typeof req.body === 'string') {
+      audioBuffer = Buffer.from(req.body, 'base64');
+    } else {
+      return res.status(400).json({ error: 'Se requiere audio como body raw o base64' });
+    }
+
+    const result = await bot.sendVoice(chatId, audioBuffer);
+    res.json({ ok: true, message_id: result.message_id });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /api/telegram/bots/:key/chats/:chatId/video — enviar video a un chat
+app.post('/api/telegram/bots/:key/chats/:chatId/video', express.raw({ type: '*/*', limit: '50mb' }), async (req, res) => {
+  try {
+    const bot = telegram.getBot(req.params.key);
+    if (!bot) return res.status(404).json({ error: 'Bot no encontrado' });
+    const chatId = Number(req.params.chatId);
+    const caption = req.query.caption || '';
+    const filename = req.query.filename || 'video.mp4';
+
+    let videoBuffer;
+    if (Buffer.isBuffer(req.body) && req.body.length > 0) {
+      videoBuffer = req.body;
+    } else if (typeof req.body === 'string') {
+      videoBuffer = Buffer.from(req.body, 'base64');
+    } else {
+      return res.status(400).json({ error: 'Se requiere video como body raw o base64' });
+    }
+
+    const result = await bot.sendVideo(chatId, videoBuffer, { caption, filename });
+    res.json({ ok: true, message_id: result.message_id });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /api/telegram/bots/:key/chats/:chatId/edit — editar mensaje de texto
+app.post('/api/telegram/bots/:key/chats/:chatId/edit', async (req, res) => {
+  try {
+    const bot = telegram.getBot(req.params.key);
+    if (!bot) return res.status(404).json({ error: 'Bot no encontrado' });
+    const chatId = Number(req.params.chatId);
+    const { message_id, text, parse_mode } = req.body || {};
+    if (!message_id || !text) return res.status(400).json({ error: 'Se requieren message_id y text' });
+
+    const body = { chat_id: chatId, message_id, text };
+    if (parse_mode) body.parse_mode = parse_mode;
+    const result = await bot._apiCall('editMessageText', body);
+    res.json({ ok: true, message_id: result.message_id });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /api/telegram/bots/:key/chats/:chatId/delete — borrar mensaje
+app.post('/api/telegram/bots/:key/chats/:chatId/delete', async (req, res) => {
+  try {
+    const bot = telegram.getBot(req.params.key);
+    if (!bot) return res.status(404).json({ error: 'Bot no encontrado' });
+    const chatId = Number(req.params.chatId);
+    const { message_id } = req.body || {};
+    if (!message_id) return res.status(400).json({ error: 'Se requiere message_id' });
+
+    await bot._apiCall('deleteMessage', { chat_id: chatId, message_id });
+    res.json({ ok: true });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 // ─── WebSocket ────────────────────────────────────────────────────────────────
 
 wss.on('connection', (ws) => {

--- a/server/mcp/tools/telegram.js
+++ b/server/mcp/tools/telegram.js
@@ -173,4 +173,100 @@ const telegramSendDocument = {
   },
 };
 
-module.exports = [telegramListBots, telegramSendMessage, telegramSendPhoto, telegramSendDocument];
+const telegramSendVoice = {
+  name: 'telegram_send_voice',
+  description: 'Enviar un audio/voz a un chat de Telegram. El archivo debe existir en disco.',
+  params: {
+    bot: 'string — key del bot (ej: chibi2026_bot)',
+    chat_id: 'string — ID del chat destino',
+    file_path: 'string — ruta absoluta del archivo de audio en disco',
+  },
+
+  async execute({ bot, chat_id, file_path }) {
+    if (!bot || !chat_id || !file_path) return 'Error: bot, chat_id y file_path son requeridos.';
+
+    if (!fs.existsSync(file_path)) return `Error: archivo no encontrado: ${file_path}`;
+    const buffer = fs.readFileSync(file_path);
+
+    const result = await apiPost(
+      `/api/telegram/bots/${bot}/chats/${chat_id}/voice`,
+      buffer,
+      'audio/ogg'
+    );
+    if (result.error) return `Error: ${result.error}`;
+    return `Audio enviado (message_id: ${result.message_id})`;
+  },
+};
+
+const telegramSendVideo = {
+  name: 'telegram_send_video',
+  description: 'Enviar un video a un chat de Telegram. El archivo debe existir en disco.',
+  params: {
+    bot: 'string — key del bot (ej: chibi2026_bot)',
+    chat_id: 'string — ID del chat destino',
+    file_path: 'string — ruta absoluta del video en disco',
+    'caption?': '?string — texto debajo del video (opcional)',
+  },
+
+  async execute({ bot, chat_id, file_path, caption }) {
+    if (!bot || !chat_id || !file_path) return 'Error: bot, chat_id y file_path son requeridos.';
+
+    if (!fs.existsSync(file_path)) return `Error: archivo no encontrado: ${file_path}`;
+    const buffer = fs.readFileSync(file_path);
+    const filename = file_path.split('/').pop();
+
+    const qs = new URLSearchParams();
+    if (caption) qs.set('caption', caption);
+    qs.set('filename', filename);
+
+    const result = await apiPost(
+      `/api/telegram/bots/${bot}/chats/${chat_id}/video?${qs.toString()}`,
+      buffer,
+      'video/mp4'
+    );
+    if (result.error) return `Error: ${result.error}`;
+    return `Video enviado (message_id: ${result.message_id})`;
+  },
+};
+
+const telegramEditMessage = {
+  name: 'telegram_edit_message',
+  description: 'Editar el texto de un mensaje ya enviado en Telegram.',
+  params: {
+    bot: 'string — key del bot (ej: chibi2026_bot)',
+    chat_id: 'string — ID del chat',
+    message_id: 'string — ID del mensaje a editar',
+    text: 'string — nuevo texto del mensaje',
+    'parse_mode?': '?string — HTML, Markdown o MarkdownV2 (opcional)',
+  },
+
+  async execute({ bot, chat_id, message_id, text, parse_mode }) {
+    if (!bot || !chat_id || !message_id || !text) return 'Error: bot, chat_id, message_id y text son requeridos.';
+
+    const body = { message_id: Number(message_id), text };
+    if (parse_mode) body.parse_mode = parse_mode;
+    const result = await apiPost(`/api/telegram/bots/${bot}/chats/${chat_id}/edit`, body);
+    if (result.error) return `Error: ${result.error}`;
+    return `Mensaje editado (message_id: ${result.message_id})`;
+  },
+};
+
+const telegramDeleteMessage = {
+  name: 'telegram_delete_message',
+  description: 'Borrar un mensaje de Telegram por su ID.',
+  params: {
+    bot: 'string — key del bot (ej: chibi2026_bot)',
+    chat_id: 'string — ID del chat',
+    message_id: 'string — ID del mensaje a borrar',
+  },
+
+  async execute({ bot, chat_id, message_id }) {
+    if (!bot || !chat_id || !message_id) return 'Error: bot, chat_id y message_id son requeridos.';
+
+    const result = await apiPost(`/api/telegram/bots/${bot}/chats/${chat_id}/delete`, { message_id: Number(message_id) });
+    if (result.error) return `Error: ${result.error}`;
+    return 'Mensaje borrado.';
+  },
+};
+
+module.exports = [telegramListBots, telegramSendMessage, telegramSendPhoto, telegramSendDocument, telegramSendVoice, telegramSendVideo, telegramEditMessage, telegramDeleteMessage];


### PR DESCRIPTION
## Summary
- Add **telegram_send_voice**: send audio files directly via MCP
- Add **telegram_send_video**: send video files with optional caption
- Add **telegram_edit_message**: edit existing message text by ID
- Add **telegram_delete_message**: delete messages by ID
- Fix: separate audio transcription status from thinking/tool_use status (independent messages)

Expands Telegram MCP tools from 4 to 8. Each new tool includes its TelegramBot method, REST endpoint, and MCP tool definition.

## Test plan
- [ ] Send a voice message via `telegram_send_voice`
- [ ] Send a video via `telegram_send_video`
- [ ] Edit a message via `telegram_edit_message`
- [ ] Delete a message via `telegram_delete_message`
- [ ] Verify audio transcription shows text, then a separate thinking message