### PR TITLE
chore: update .gitignore with runtime files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@ server/memory/
 server/models-cache/
 server/voice-providers/piper/
 server/mcps/
+ecosystem.config.js
+logs/
+server/logs/
+server/scripts/
+*.traineddata


### PR DESCRIPTION
## Summary
- Add ecosystem.config.js, logs/, server/logs/, server/scripts/, and *.traineddata to .gitignore
- These are runtime/local config files that shouldn't be tracked

## Test plan
- Verify `git status` no longer shows these files as untracked