### PR TITLE
fix(providers): Ollama siempre configured

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1267,7 +1267,7 @@ app.get('/api/providers', (_req, res) => {
   const cfg = providerConfig.getConfig();
   const list = providersModule.list().map(p => ({
     ...p,
-    configured: p.name === 'claude-code' ? true : !!(providerConfig.getApiKey(p.name)),
+    configured: ['claude-code', 'ollama'].includes(p.name) ? true : !!(providerConfig.getApiKey(p.name)),
     currentModel: cfg.providers?.[p.name]?.model || p.defaultModel,
   }));
   res.json({ providers: list, default: cfg.default });


### PR DESCRIPTION
## Summary

- Ollama no requiere API key pero `/api/providers` lo marcaba `configured: false`, ocultándolo del selector del WebChat
- Fix: misma lógica que `claude-code` — siempre `configured: true`

## Test plan

- [ ] `GET /api/providers` incluye `ollama` con `configured: true`
- [ ] El selector del WebChat muestra "Ollama (local)" como opción