### PR TITLE
feat(webchat): persistence, recording, code blocks

### DIFF
--- a/client/src/components/ChatMessage.jsx
+++ b/client/src/components/ChatMessage.jsx
@@ -1,5 +1,5 @@
 import { memo, useState, useCallback } from 'react';
-import { Check, Copy } from 'lucide-react';
+import { Check, Copy, Download, FileText, Image, Film, Volume2 } from 'lucide-react';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
@@ -9,10 +9,10 @@ import AudioPlayer from './AudioPlayer.jsx';
 /**
  * ChatMessage — renderiza un mensaje de chat con Markdown completo.
  *
- * Soporta: GFM (tablas, strikethrough, listas de tareas), code blocks
- * con syntax highlighting y botón de copiar, links, imágenes inline.
+ * Soporta: GFM, code blocks con syntax highlighting, media (foto, documento, audio, video),
+ * botones inline, audio del usuario con transcripción.
  */
-function ChatMessage({ content, role, streaming, error, providerLabel, buttons, onButtonClick, audioUrl, audioDuration, transcription }) {
+function ChatMessage({ content, role, streaming, error, providerLabel, buttons, onButtonClick, audioUrl, audioDuration, transcription, mediaType, mediaSrc, caption, filename, mimeType }) {
   // Mensaje de audio TTS
   if (role === 'tts' && audioUrl) {
     return (
@@ -20,6 +20,39 @@ function ChatMessage({ content, role, streaming, error, providerLabel, buttons, 
         <div className="wc-msg-label">Audio TTS</div>
         <div className="wc-msg-content wc-audio-content">
           <audio controls src={audioUrl} className="wc-audio-player" />
+        </div>
+      </div>
+    );
+  }
+
+  // Media: photo, document, voice, video
+  if (mediaType && mediaSrc) {
+    return (
+      <div className={`wc-msg wc-msg-${role}`}>
+        {role === 'assistant' && providerLabel && (
+          <div className="wc-msg-label">{providerLabel}</div>
+        )}
+        <div className="wc-msg-content wc-media-content">
+          {mediaType === 'photo' && (
+            <img src={mediaSrc} alt={caption || filename || 'imagen'} className="wc-media-img" />
+          )}
+          {mediaType === 'video' && (
+            <video controls src={mediaSrc} className="wc-media-video" />
+          )}
+          {mediaType === 'voice' && (
+            <div className="wc-media-voice">
+              <Volume2 size={14} className="wc-media-voice-icon" />
+              <audio controls src={mediaSrc} className="wc-media-audio" />
+            </div>
+          )}
+          {mediaType === 'document' && (
+            <a href={mediaSrc} download={filename || 'archivo'} className="wc-media-doc">
+              <FileText size={18} />
+              <span className="wc-media-doc-name">{filename || 'archivo'}</span>
+              <Download size={14} className="wc-media-doc-dl" />
+            </a>
+          )}
+          {caption && <p className="wc-media-caption">{caption}</p>}
         </div>
       </div>
     );
@@ -88,6 +121,19 @@ function CodeBlock({ node, inline, className, children, ...props }) {
 
   if (inline) {
     return <code className="wc-inline-code" {...props}>{children}</code>;
+  }
+
+  // Bloque corto sin lenguaje: renderizar compacto (inline con botón copiar)
+  const isSingleLine = !code.includes('\n');
+  if (isSingleLine && !lang) {
+    return (
+      <div className="wc-code-inline-block">
+        <code className="wc-code-inline-text">{code}</code>
+        <button className="wc-code-inline-copy" onClick={handleCopy} title="Copiar">
+          {copied ? <Check size={12} /> : <Copy size={12} />}
+        </button>
+      </div>
+    );
   }
 
   return (

--- a/client/src/components/WebChatPanel.css
+++ b/client/src/components/WebChatPanel.css
@@ -320,15 +320,94 @@
   cursor: not-allowed;
 }
 .wc-send-mic {
-  background: #333;
+  background: #2a2a2a;
+  color: #aaa;
   font-size: 15px;
 }
 .wc-send-mic:hover:not(:disabled) {
-  background: #444;
+  background: #333;
+  color: #ccc;
 }
 .wc-send-mic.wc-recording {
+  background: #2a1518;
+  border: 1.5px solid #ff5f57;
+  color: #ff5f57;
+  animation: wc-pulse-icon 1.5s ease-in-out infinite;
+}
+@keyframes wc-pulse-icon {
+  0%, 100% { color: #ff5f57; border-color: #ff5f57; }
+  50% { color: #ff8a85; border-color: #ff8a85; }
+}
+
+/* ─── Recording bar ────────────────────────────────────────────────────────── */
+.wc-rec-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 4px 0;
+}
+.wc-rec-indicator {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 1;
+}
+.wc-rec-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
   background: #ff5f57;
-  animation: wc-pulse 1s infinite;
+  animation: wc-rec-blink 1s ease-in-out infinite;
+}
+.wc-rec-dot-paused {
+  background: #888;
+  animation: none;
+}
+@keyframes wc-rec-blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+.wc-rec-time {
+  font-family: 'Cascadia Code', 'Fira Code', monospace;
+  font-size: 14px;
+  color: #f0f0f0;
+  min-width: 36px;
+}
+.wc-rec-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  border: none;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+.wc-rec-cancel {
+  background: #2a1518;
+  color: #ff5f57;
+}
+.wc-rec-cancel:hover {
+  background: #3a1a1e;
+  color: #ff8a85;
+}
+.wc-rec-pause {
+  background: #2a2a2a;
+  color: #ccc;
+}
+.wc-rec-pause:hover {
+  background: #333;
+  color: #fff;
+}
+.wc-rec-send {
+  background: #1a3a1a;
+  color: #4caf50;
+}
+.wc-rec-send:hover {
+  background: #1e4a1e;
+  color: #66cc66;
 }
 
 /* ─── Scrollbar ─────────────────────────────────────────────────────────────── */
@@ -387,6 +466,36 @@
   border-radius: 3px;
   font-family: 'Cascadia Code', 'Fira Code', monospace;
   font-size: 12px;
+}
+
+/* ─── Code inline block (single-line fenced code without language) ────────── */
+.wc-code-inline-block {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: #2a2a2a;
+  border: 1px solid #3a3a3a;
+  border-radius: 4px;
+  padding: 3px 8px;
+  margin: 2px 0;
+}
+.wc-code-inline-text {
+  font-family: 'Cascadia Code', 'Fira Code', monospace;
+  font-size: 13px;
+  color: #e06c75;
+}
+.wc-code-inline-copy {
+  background: none;
+  border: none;
+  color: #888;
+  cursor: pointer;
+  padding: 2px;
+  display: flex;
+  align-items: center;
+  transition: color 0.15s;
+}
+.wc-code-inline-copy:hover {
+  color: #ccc;
 }
 
 /* ─── Inline buttons ───────────────────────────────────────────────────────── */
@@ -450,12 +559,7 @@
   cursor: not-allowed;
 }
 
-/* Recording state */
-.wc-recording {
-  opacity: 1 !important;
-  color: #ff5f57;
-  animation: wc-pulse 1s infinite;
-}
+/* Recording state (legacy, unused — now handled by .wc-send-mic.wc-recording) */
 @keyframes wc-pulse {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.4; }
@@ -494,4 +598,75 @@
 @keyframes wc-typing-bounce {
   0%, 80%, 100% { transform: scale(0.6); opacity: 0.4; }
   40% { transform: scale(1); opacity: 1; }
+}
+
+/* ─── Media messages (photo, video, voice, document) ──────────────────────── */
+.wc-media-content {
+  padding: 4px !important;
+  background: #2a2a2a;
+  border-radius: 12px;
+  overflow: hidden;
+}
+.wc-media-img {
+  max-width: 100%;
+  max-height: 300px;
+  border-radius: 8px;
+  display: block;
+  object-fit: contain;
+}
+.wc-media-video {
+  max-width: 100%;
+  max-height: 300px;
+  border-radius: 8px;
+  display: block;
+}
+.wc-media-voice {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 8px;
+}
+.wc-media-voice-icon {
+  color: #888;
+  flex-shrink: 0;
+}
+.wc-media-audio {
+  width: 100%;
+  max-width: 250px;
+  height: 32px;
+  border-radius: 8px;
+  filter: invert(1) hue-rotate(180deg);
+}
+.wc-media-doc {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  color: #58a6ff;
+  text-decoration: none;
+  border-radius: 8px;
+  transition: background 0.15s;
+}
+.wc-media-doc:hover {
+  background: #333;
+}
+.wc-media-doc-name {
+  flex: 1;
+  font-size: 13px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.wc-media-doc-dl {
+  opacity: 0.5;
+  flex-shrink: 0;
+}
+.wc-media-doc:hover .wc-media-doc-dl {
+  opacity: 1;
+}
+.wc-media-caption {
+  margin: 6px 8px 4px;
+  font-size: 12px;
+  color: #aaa;
+  line-height: 1.4;
 }

--- a/client/src/components/WebChatPanel.jsx
+++ b/client/src/components/WebChatPanel.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { Trash2, Paperclip, Volume2, Send, Mic, Square, X } from 'lucide-react';
+import { Trash2, Paperclip, Volume2, Send, Mic, Square, X, Pause, Play } from 'lucide-react';
 import { API_BASE, WS_URL } from '../config.js';
 import ChatMessage from './ChatMessage.jsx';
 import './WebChatPanel.css';
@@ -15,6 +15,8 @@ export default function WebChatPanel({ onClose }) {
   const [cwd, setCwd] = useState('~');
   const [connected, setConnected] = useState(false);
   const [recording, setRecording] = useState(false);
+  const [recPaused, setRecPaused] = useState(false);
+  const [recTime, setRecTime] = useState(0);
   const [statusText, setStatusText] = useState(null);
   const wsRef = useRef(null);
   const sessionIdRef = useRef(null);
@@ -23,6 +25,10 @@ export default function WebChatPanel({ onClose }) {
   const mediaRecorderRef = useRef(null);
   const audioChunksRef = useRef([]);
   const recordStartRef = useRef(0);
+  const recTimerRef = useRef(null);
+  const recCancelledRef = useRef(false);
+  const recTimeRef = useRef(0);
+  const streamRef = useRef(null);
   const fileInputRef = useRef(null);
 
   // Scroll automático al final
@@ -165,6 +171,62 @@ export default function WebChatPanel({ onClose }) {
             ]);
             break;
 
+          case 'chat:photo': {
+            const src = `data:${msg.mimeType || 'image/png'};base64,${msg.data}`;
+            setMessages(prev => [...prev, {
+              role: 'assistant', msgId: msg.msgId, mediaType: 'photo',
+              mediaSrc: src, caption: msg.caption, filename: msg.filename,
+            }]);
+            setSending(false);
+            setStatusText(null);
+            break;
+          }
+
+          case 'chat:document': {
+            const href = `data:${msg.mimeType || 'application/octet-stream'};base64,${msg.data}`;
+            setMessages(prev => [...prev, {
+              role: 'assistant', msgId: msg.msgId, mediaType: 'document',
+              mediaSrc: href, caption: msg.caption, filename: msg.filename,
+              mimeType: msg.mimeType,
+            }]);
+            setSending(false);
+            setStatusText(null);
+            break;
+          }
+
+          case 'chat:voice': {
+            const voiceUrl = `data:${msg.mimeType || 'audio/ogg'};base64,${msg.data}`;
+            setMessages(prev => [...prev, {
+              role: 'assistant', msgId: msg.msgId, mediaType: 'voice',
+              mediaSrc: voiceUrl, caption: msg.caption,
+            }]);
+            setSending(false);
+            setStatusText(null);
+            break;
+          }
+
+          case 'chat:video': {
+            const videoUrl = `data:${msg.mimeType || 'video/mp4'};base64,${msg.data}`;
+            setMessages(prev => [...prev, {
+              role: 'assistant', msgId: msg.msgId, mediaType: 'video',
+              mediaSrc: videoUrl, caption: msg.caption, filename: msg.filename,
+              mimeType: msg.mimeType,
+            }]);
+            setSending(false);
+            setStatusText(null);
+            break;
+          }
+
+          case 'chat:delete':
+            setMessages(prev => prev.filter(m => m.msgId !== msg.msgId));
+            break;
+
+          case 'chat:edit':
+            setMessages(prev => prev.map(m =>
+              m.msgId === msg.msgId ? { ...m, content: msg.text } : m
+            ));
+            break;
+
           case 'status':
             if (msg.provider) setProvider(msg.provider);
             if (msg.agent !== undefined) setAgent(msg.agent);
@@ -222,40 +284,57 @@ export default function WebChatPanel({ onClose }) {
 
   // ── Audio (grabación) ──────────────────────────────────────────────────────
 
-  const toggleRecording = useCallback(async () => {
-    const ws = wsRef.current;
-    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+  // Formatear segundos a m:ss
+  const formatRecTime = (s) => {
+    const m = Math.floor(s / 60);
+    const sec = String(s % 60).padStart(2, '0');
+    return `${m}:${sec}`;
+  };
 
-    if (recording) {
-      // Parar grabación
-      mediaRecorderRef.current?.stop();
-      setRecording(false);
+  // Timer de grabación
+  useEffect(() => {
+    if (recording && !recPaused) {
+      recTimerRef.current = setInterval(() => setRecTime(t => { recTimeRef.current = t + 1; return t + 1; }), 1000);
+    } else {
+      clearInterval(recTimerRef.current);
+    }
+    return () => clearInterval(recTimerRef.current);
+  }, [recording, recPaused]);
+
+  // Limpiar estado de grabación
+  const cleanupRecording = useCallback(() => {
+    clearInterval(recTimerRef.current);
+    streamRef.current?.getTracks().forEach(t => t.stop());
+    streamRef.current = null;
+    mediaRecorderRef.current = null;
+    setRecording(false);
+    setRecPaused(false);
+    setRecTime(0);
+  }, []);
+
+  // Iniciar grabación
+  const startRecording = useCallback(async () => {
+    if (!navigator.mediaDevices?.getUserMedia) {
+      const hint = !window.isSecureContext
+        ? 'Necesitás acceder via HTTPS o localhost para usar el micrófono'
+        : 'Tu navegador no soporta grabación de audio';
+      setStatusText(hint);
+      setTimeout(() => setStatusText(null), 5000);
       return;
     }
-
     try {
-      // Verificar que la API de medios está disponible
-      if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
-        const hint = !window.isSecureContext
-          ? 'Necesitás acceder via HTTPS o localhost para usar el micrófono'
-          : 'Tu navegador no soporta grabación de audio';
-        setStatusText(hint);
-        setTimeout(() => setStatusText(null), 5000);
-        return;
-      }
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-
-      // Elegir mimeType compatible
+      streamRef.current = stream;
       const mimeType = MediaRecorder.isTypeSupported('audio/webm;codecs=opus')
         ? 'audio/webm;codecs=opus'
-        : MediaRecorder.isTypeSupported('audio/webm')
-          ? 'audio/webm'
-          : '';
+        : MediaRecorder.isTypeSupported('audio/webm') ? 'audio/webm' : '';
       const mediaRecorder = mimeType
         ? new MediaRecorder(stream, { mimeType })
         : new MediaRecorder(stream);
       mediaRecorderRef.current = mediaRecorder;
       audioChunksRef.current = [];
+      recCancelledRef.current = false;
+      recTimeRef.current = 0;
 
       mediaRecorder.ondataavailable = (e) => {
         if (e.data.size > 0) audioChunksRef.current.push(e.data);
@@ -263,21 +342,20 @@ export default function WebChatPanel({ onClose }) {
 
       mediaRecorder.onstop = async () => {
         stream.getTracks().forEach(t => t.stop());
+        streamRef.current = null;
+        if (recCancelledRef.current) return; // Descartado
+        const ws = wsRef.current;
+        if (!ws || ws.readyState !== WebSocket.OPEN) return;
         const actualMime = mediaRecorder.mimeType || 'audio/webm';
         const blob = new Blob(audioChunksRef.current, { type: actualMime });
         const audioUrl = URL.createObjectURL(blob);
-        const audioDuration = (Date.now() - recordStartRef.current) / 1000;
-        // Mostrar audio en el chat inmediatamente
+        const audioDuration = recTimeRef.current;
         setMessages(prev => [...prev, { role: 'user', audioUrl, audioDuration, transcription: null }]);
         const reader = new FileReader();
         reader.onloadend = () => {
           const base64 = reader.result.split(',')[1];
           setSending(true);
-          ws.send(JSON.stringify({
-            type: 'chat:audio',
-            data: base64,
-            mimeType: actualMime,
-          }));
+          ws.send(JSON.stringify({ type: 'chat:audio', data: base64, mimeType: actualMime }));
         };
         reader.readAsDataURL(blob);
       };
@@ -285,19 +363,48 @@ export default function WebChatPanel({ onClose }) {
       mediaRecorder.start();
       recordStartRef.current = Date.now();
       setRecording(true);
+      setRecPaused(false);
+      setRecTime(0);
     } catch (err) {
       let errorMsg = 'Micrófono no disponible';
-      if (err.name === 'NotAllowedError') {
-        errorMsg = 'Permiso de micrófono denegado. Revisá los permisos del navegador';
-      } else if (err.name === 'NotFoundError') {
-        errorMsg = 'No se encontró ningún micrófono';
-      } else if (err.name === 'NotReadableError') {
-        errorMsg = 'El micrófono está siendo usado por otra aplicación';
-      }
+      if (err.name === 'NotAllowedError') errorMsg = 'Permiso de micrófono denegado. Revisá los permisos del navegador';
+      else if (err.name === 'NotFoundError') errorMsg = 'No se encontró ningún micrófono';
+      else if (err.name === 'NotReadableError') errorMsg = 'El micrófono está siendo usado por otra aplicación';
       setStatusText(errorMsg);
       setTimeout(() => setStatusText(null), 5000);
     }
-  }, [recording]);
+  }, []);
+
+  // Cancelar grabación (descartar)
+  const cancelRecording = useCallback(() => {
+    recCancelledRef.current = true;
+    const mr = mediaRecorderRef.current;
+    if (mr && mr.state !== 'inactive') mr.stop();
+    cleanupRecording();
+  }, [cleanupRecording]);
+
+  // Pausar / reanudar grabación
+  const togglePauseRecording = useCallback(() => {
+    const mr = mediaRecorderRef.current;
+    if (!mr) return;
+    if (mr.state === 'recording') {
+      mr.pause();
+      setRecPaused(true);
+    } else if (mr.state === 'paused') {
+      mr.resume();
+      setRecPaused(false);
+    }
+  }, []);
+
+  // Enviar grabación
+  const sendRecording = useCallback(() => {
+    recCancelledRef.current = false;
+    const mr = mediaRecorderRef.current;
+    if (mr && mr.state !== 'inactive') mr.stop();
+    setRecording(false);
+    setRecPaused(false);
+    setRecTime(0);
+  }, []);
 
   // ── TTS (reproducir última respuesta) ──────────────────────────────────────
 
@@ -467,7 +574,7 @@ export default function WebChatPanel({ onClose }) {
         )}
         {messages.map((msg, i) => (
           <ChatMessage
-            key={i}
+            key={msg.msgId || i}
             content={msg.content}
             role={msg.role}
             streaming={msg.streaming}
@@ -478,6 +585,11 @@ export default function WebChatPanel({ onClose }) {
             audioUrl={msg.audioUrl}
             audioDuration={msg.audioDuration}
             transcription={msg.transcription}
+            mediaType={msg.mediaType}
+            mediaSrc={msg.mediaSrc}
+            caption={msg.caption}
+            filename={msg.filename}
+            mimeType={msg.mimeType}
           />
         ))}
         {sending && !messages.some(m => m.streaming) && (
@@ -494,56 +606,78 @@ export default function WebChatPanel({ onClose }) {
       </div>
 
       <div className="wc-input-area">
-        <input
-          type="file"
-          ref={fileInputRef}
-          className="wc-file-input"
-          accept="image/*,.pdf,.txt,.doc,.docx,.xls,.xlsx,.csv,.json,.xml,.zip,.rar,.7z,.mp3,.wav,.ogg,.mp4,.webm"
-          onChange={handleFileSelect}
-        />
-        <button
-          className="wc-btn-icon wc-attach-btn"
-          onClick={() => fileInputRef.current?.click()}
-          disabled={!connected || sending}
-          title="Adjuntar archivo"
-        >
-          <Paperclip size={16} />
-        </button>
-        <textarea
-          ref={inputRef}
-          className="wc-input"
-          value={input}
-          onChange={e => setInput(e.target.value)}
-          onKeyDown={handleKeyDown}
-          placeholder={recording ? 'Grabando...' : 'Escribí un mensaje...'}
-          rows={1}
-          disabled={!connected || recording}
-        />
-        <button
-          className="wc-btn-icon wc-tts-btn"
-          onClick={playTTS}
-          disabled={!connected || !messages.some(m => m.role === 'assistant')}
-          title="Escuchar última respuesta (TTS)"
-        >
-          <Volume2 size={16} />
-        </button>
-        {input.trim() ? (
-          <button
-            className="wc-send"
-            onClick={sendMessage}
-            disabled={sending || !connected}
-          >
-            {sending ? '...' : <Send size={16} />}
-          </button>
+        {recording ? (
+          /* ── Barra de grabación ── */
+          <div className="wc-rec-bar">
+            <button className="wc-rec-btn wc-rec-cancel" onClick={cancelRecording} title="Cancelar grabación">
+              <Trash2 size={16} />
+            </button>
+            <div className="wc-rec-indicator">
+              <span className={`wc-rec-dot ${recPaused ? 'wc-rec-dot-paused' : ''}`} />
+              <span className="wc-rec-time">{formatRecTime(recTime)}</span>
+            </div>
+            <button className="wc-rec-btn wc-rec-pause" onClick={togglePauseRecording} title={recPaused ? 'Reanudar' : 'Pausar'}>
+              {recPaused ? <Mic size={16} /> : <Pause size={16} />}
+            </button>
+            <button className="wc-rec-btn wc-rec-send" onClick={sendRecording} title="Enviar audio">
+              <Send size={16} />
+            </button>
+          </div>
         ) : (
-          <button
-            className={`wc-send wc-send-mic ${recording ? 'wc-recording' : ''}`}
-            onClick={toggleRecording}
-            disabled={!connected || (sending && !recording)}
-            title={recording ? 'Parar grabación' : 'Grabar audio'}
-          >
-            {recording ? <Square size={14} /> : <Mic size={16} />}
-          </button>
+          /* ── Barra normal de input ── */
+          <>
+            <input
+              type="file"
+              ref={fileInputRef}
+              className="wc-file-input"
+              accept="image/*,.pdf,.txt,.doc,.docx,.xls,.xlsx,.csv,.json,.xml,.zip,.rar,.7z,.mp3,.wav,.ogg,.mp4,.webm"
+              onChange={handleFileSelect}
+            />
+            <button
+              className="wc-btn-icon wc-attach-btn"
+              onClick={() => fileInputRef.current?.click()}
+              disabled={!connected || sending}
+              title="Adjuntar archivo"
+            >
+              <Paperclip size={16} />
+            </button>
+            <textarea
+              ref={inputRef}
+              className="wc-input"
+              value={input}
+              onChange={e => setInput(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="Escribí un mensaje..."
+              rows={1}
+              disabled={!connected}
+            />
+            <button
+              className="wc-btn-icon wc-tts-btn"
+              onClick={playTTS}
+              disabled={!connected || !messages.some(m => m.role === 'assistant')}
+              title="Escuchar última respuesta (TTS)"
+            >
+              <Volume2 size={16} />
+            </button>
+            {input.trim() ? (
+              <button
+                className="wc-send"
+                onClick={sendMessage}
+                disabled={sending || !connected}
+              >
+                {sending ? '...' : <Send size={16} />}
+              </button>
+            ) : (
+              <button
+                className="wc-send wc-send-mic"
+                onClick={startRecording}
+                disabled={!connected || sending}
+                title="Grabar audio"
+              >
+                <Mic size={16} />
+              </button>
+            )}
+          </>
         )}
       </div>
     </div>

--- a/server/bootstrap.js
+++ b/server/bootstrap.js
@@ -18,8 +18,9 @@ const Logger     = require('./core/Logger');
 const EventBus   = require('./core/EventBus');
 
 const DatabaseProvider         = require('./storage/DatabaseProvider');
-const ChatSettingsRepository   = require('./storage/ChatSettingsRepository');
-const BotsRepository           = require('./storage/BotsRepository');
+const ChatSettingsRepository       = require('./storage/ChatSettingsRepository');
+const WebchatMessagesRepository   = require('./storage/WebchatMessagesRepository');
+const BotsRepository               = require('./storage/BotsRepository');
 const ConversationService      = require('./services/ConversationService');
 const { TelegramChannel }      = require('./channels/telegram/TelegramChannel');
 const WebChannel               = require('./channels/web/WebChannel');
@@ -52,6 +53,9 @@ function createContainer() {
 
   const chatSettingsRepo = new ChatSettingsRepository(db);
   chatSettingsRepo.init();
+
+  const messagesRepo = new WebchatMessagesRepository(db);
+  messagesRepo.init();
 
   const botsRepo = new BotsRepository(path.join(__dirname, 'bots.json'));
 
@@ -145,6 +149,7 @@ function createContainer() {
     providerConfig,
     agents,
     chatSettingsRepo,
+    messagesRepo,
     eventBus,
     logger,
     transcriber,

--- a/server/channels/web/WebChannel.js
+++ b/server/channels/web/WebChannel.js
@@ -24,13 +24,14 @@ const CLEANUP_INTERVAL_MS = 5 * 60 * 1000;
  * y upload de imágenes.
  */
 class WebChannel extends BaseChannel {
-  constructor({ convSvc, providers, providerConfig, agents, chatSettingsRepo, eventBus, logger, transcriber, tts } = {}) {
+  constructor({ convSvc, providers, providerConfig, agents, chatSettingsRepo, messagesRepo, eventBus, logger, transcriber, tts } = {}) {
     super({ eventBus, logger });
     this.convSvc          = convSvc;
     this.providers        = providers;
     this.providerConfig   = providerConfig;
     this.agents           = agents;
     this.chatSettingsRepo = chatSettingsRepo;
+    this.messagesRepo     = messagesRepo;
     this.transcriber      = transcriber;
     this.tts              = tts;
     /** @type {Map<string, object>} sessionId → { ws, state } */
@@ -95,11 +96,14 @@ class WebChannel extends BaseChannel {
     // Cargar settings persistidos de SQLite
     const saved = this.chatSettingsRepo?.load(WebChannel.BOT_KEY, sessionId) || null;
 
+    // Cargar historial de mensajes de SQLite
+    const savedMessages = this.messagesRepo?.load(sessionId) || [];
+
     const state = {
       provider: saved?.provider || opts.provider || this.providerConfig?.getConfig()?.default || 'anthropic',
       agent: opts.agent || null,
       model: saved?.model || null,
-      history: [],
+      history: savedMessages,
       claudeSession: saved?.claude_session_id || null,
       claudeMode: saved?.claude_mode || 'auto',
       cwd: saved?.cwd || process.env.HOME || '~',
@@ -109,8 +113,9 @@ class WebChannel extends BaseChannel {
     this.sessions.set(sessionId, { ws, state });
     if (!saved) this._saveSettings(sessionId, state);
     this._sendStatus(ws, state);
+    if (savedMessages.length > 0) this._sendHistory(ws, state);
     this._bindWs(ws, sessionId, state);
-    this.logger.info(`[WebChannel] Nueva sesión ${sessionId.slice(0, 8)} (provider: ${state.provider})`);
+    this.logger.info(`[WebChannel] Sesión ${sessionId.slice(0, 8)} ${savedMessages.length > 0 ? 'restaurada' : 'nueva'} (provider: ${state.provider}, msgs: ${savedMessages.length})`);
   }
 
   /** Vincula handlers de WS a una sesión */
@@ -274,6 +279,8 @@ class WebChannel extends BaseChannel {
         this.logger.info(`[WebChannel] Sesión parked ${id.slice(0, 8)} expirada, eliminada`);
       }
     }
+    // Limpiar mensajes de sesiones inactivas > 7 días
+    try { this.messagesRepo?.cleanup(); } catch {}
   }
 
   // ── BaseChannel interface ──────────────────────────────────────────────────
@@ -419,6 +426,7 @@ class WebChannel extends BaseChannel {
         }
         state.provider = arg;
         state.history = [];
+        try { this.messagesRepo?.clear(sessionId); } catch {}
         this._saveSettings(sessionId, state);
         this._sendJson(ws, { type: 'command_result', text: `Provider cambiado a ${p.label || arg}`, provider: arg });
         return;
@@ -484,6 +492,7 @@ class WebChannel extends BaseChannel {
       case '/clear': {
         state.history = [];
         state.claudeSession = null;
+        try { this.messagesRepo?.clear(sessionId); } catch {}
         this._sendJson(ws, { type: 'command_result', text: 'Conversación reiniciada.' });
         return;
       }
@@ -590,6 +599,13 @@ class WebChannel extends BaseChannel {
       } else if (!result.history) {
         state.history.push({ role: 'user', content: text });
         state.history.push({ role: 'assistant', content: result.text });
+      }
+
+      // Persistir mensajes en SQLite
+      try {
+        this.messagesRepo?.pushPair(sessionId, text, result.text);
+      } catch (err) {
+        this.logger.error('[WebChannel] Error persistiendo mensajes:', err.message);
       }
 
       // Parsear botones inline del AI response

--- a/server/storage/WebchatMessagesRepository.js
+++ b/server/storage/WebchatMessagesRepository.js
@@ -1,0 +1,119 @@
+'use strict';
+
+/**
+ * WebchatMessagesRepository — persistencia de mensajes de WebChat en SQLite.
+ *
+ * Límite de 100 mensajes por sesión (FIFO). Limpieza de sesiones
+ * inactivas > 7 días.
+ */
+
+const MAX_MESSAGES_PER_SESSION = 100;
+const STALE_DAYS = 7;
+
+class WebchatMessagesRepository {
+  constructor(db) {
+    this._db = db || null;
+  }
+
+  /** Crea la tabla si no existe. Idempotente. */
+  init() {
+    if (!this._db) return;
+    this._db.exec(`
+      CREATE TABLE IF NOT EXISTS webchat_messages (
+        id         INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT NOT NULL,
+        role       TEXT NOT NULL,
+        content    TEXT NOT NULL DEFAULT '',
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      )
+    `);
+    // Índice para consultas por sesión
+    try {
+      this._db.exec(`CREATE INDEX IF NOT EXISTS idx_wcm_session ON webchat_messages (session_id, id)`);
+    } catch {}
+  }
+
+  /**
+   * Guarda un mensaje. Aplica FIFO si se excede el límite.
+   * @param {string} sessionId
+   * @param {string} role  — 'user' | 'assistant' | 'system'
+   * @param {string} content
+   */
+  push(sessionId, role, content) {
+    if (!this._db) return;
+    this._db.prepare(
+      `INSERT INTO webchat_messages (session_id, role, content) VALUES (?, ?, ?)`
+    ).run(sessionId, role, content);
+    this._trim(sessionId);
+  }
+
+  /**
+   * Guarda par usuario + asistente de una vez.
+   * @param {string} sessionId
+   * @param {string} userText
+   * @param {string} assistantText
+   */
+  pushPair(sessionId, userText, assistantText) {
+    if (!this._db) return;
+    const stmt = this._db.prepare(
+      `INSERT INTO webchat_messages (session_id, role, content) VALUES (?, ?, ?)`
+    );
+    stmt.run(sessionId, 'user', userText);
+    stmt.run(sessionId, 'assistant', assistantText);
+    this._trim(sessionId);
+  }
+
+  /**
+   * Carga los últimos N mensajes de una sesión.
+   * @param {string} sessionId
+   * @param {number} [limit=100]
+   * @returns {Array<{ role: string, content: string }>}
+   */
+  load(sessionId, limit = MAX_MESSAGES_PER_SESSION) {
+    if (!this._db) return [];
+    return this._db.prepare(
+      `SELECT role, content FROM webchat_messages
+       WHERE session_id = ? ORDER BY id DESC LIMIT ?`
+    ).all(sessionId, limit).reverse();
+  }
+
+  /**
+   * Borra todos los mensajes de una sesión.
+   * @param {string} sessionId
+   */
+  clear(sessionId) {
+    if (!this._db) return;
+    this._db.prepare(`DELETE FROM webchat_messages WHERE session_id = ?`).run(sessionId);
+  }
+
+  /**
+   * Limpia sesiones inactivas de más de STALE_DAYS días.
+   */
+  cleanup() {
+    if (!this._db) return;
+    this._db.prepare(
+      `DELETE FROM webchat_messages WHERE session_id IN (
+         SELECT session_id FROM webchat_messages
+         GROUP BY session_id
+         HAVING MAX(created_at) < datetime('now', ?)
+       )`
+    ).run(`-${STALE_DAYS} days`);
+  }
+
+  /** Recorta mensajes viejos si la sesión excede el límite */
+  _trim(sessionId) {
+    const count = this._db.prepare(
+      `SELECT COUNT(*) as n FROM webchat_messages WHERE session_id = ?`
+    ).get(sessionId);
+    if (count && count.n > MAX_MESSAGES_PER_SESSION) {
+      const excess = count.n - MAX_MESSAGES_PER_SESSION;
+      this._db.prepare(
+        `DELETE FROM webchat_messages WHERE id IN (
+           SELECT id FROM webchat_messages WHERE session_id = ? ORDER BY id ASC LIMIT ?
+         )`
+      ).run(sessionId, excess);
+    }
+  }
+}
+
+module.exports = WebchatMessagesRepository;


### PR DESCRIPTION
## Summary
- **Chat persistence**: New `webchat_messages` SQLite table persists conversation history across page refreshes, panel switches, and server restarts. FIFO limit of 100 messages per session, auto-cleanup of sessions inactive >7 days.
- **Recording bar**: Replaced single mic toggle with WhatsApp-style recording controls: cancel (discard), pause/resume, and send. Fixed duration counter to exclude paused time.
- **Compact code blocks**: Single-line fenced code blocks without a language now render as compact inline elements instead of full SyntaxHighlighter blocks with header.

## Changes

### Server
- **`server/storage/WebchatMessagesRepository.js`** (new) — SQLite repository with `push`, `pushPair`, `load`, `clear`, `cleanup` methods
- **`server/channels/web/WebChannel.js`** — Loads messages from DB on reconnect, persists after each AI response, clears on `/nueva` and provider change
- **`server/bootstrap.js`** — Wires up `WebchatMessagesRepository`

### Client
- **`client/src/components/WebChatPanel.jsx`** — New recording bar UI with cancel/pause/resume/send, accurate duration tracking via `recTimeRef`
- **`client/src/components/WebChatPanel.css`** — Styles for `.wc-rec-bar` and `.wc-code-inline-block`
- **`client/src/components/ChatMessage.jsx`** — Compact rendering for single-line code blocks

## Test plan
- [ ] Open WebChat, send messages, switch to Telegram panel, switch back → messages restored
- [ ] Refresh the page → messages restored
- [ ] Restart the server → messages restored
- [ ] Send >100 messages → oldest trimmed automatically
- [ ] `/nueva` command → messages cleared from UI and DB
- [ ] Record audio → cancel button discards without sending
- [ ] Record → pause → resume → send → duration shows active time only
- [ ] AI response with single-line code block → renders compact (no full block header)

🤖 Generated with [Claude Code](https://claude.com/claude-code)