### PR TITLE
fix(webchat): persist history for all providers

### DIFF
--- a/server/channels/web/WebChannel.js
+++ b/server/channels/web/WebChannel.js
@@ -85,6 +85,11 @@ class WebChannel extends BaseChannel {
       this._parked.delete(sessionId);
       const state = parked.state;
       state.processing = false;
+      // Fallback: si historial RAM está vacío, cargar de SQLite
+      if (state.history.length === 0) {
+        const dbMessages = this.messagesRepo?.load(sessionId) || [];
+        if (dbMessages.length > 0) state.history = dbMessages;
+      }
       this.sessions.set(sessionId, { ws, state });
       this._sendStatus(ws, state);
       this._sendHistory(ws, state);
@@ -594,9 +599,7 @@ class WebChannel extends BaseChannel {
       if (result.history) state.history = result.history;
       if (result.newSession) state.claudeSession = result.newSession;
 
-      if (!result.history && state.provider === 'claude-code') {
-        // Claude Code mantiene su propio historial en la session
-      } else if (!result.history) {
+      if (!result.history) {
         state.history.push({ role: 'user', content: text });
         state.history.push({ role: 'assistant', content: result.text });
       }


### PR DESCRIPTION
## Summary
- Remove `claude-code` no-op branch in `_sendToAI` that prevented `state.history` from being populated — messages were saved to SQLite but RAM history stayed empty, so parked session restores sent empty history
- Add SQLite fallback when restoring parked sessions with empty RAM history

## Root cause
```javascript
// BEFORE — claude-code never populated state.history
if (!result.history && state.provider === 'claude-code') {
  // no-op
} else if (!result.history) {
  state.history.push(...)  // ← never reached for claude-code
}
```

## Test plan
- [ ] Send messages with any provider → refresh → messages restored
- [ ] Switch panels and come back → messages still there
- [ ] `/nueva` → clears correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)