### PR TITLE
fix(ollama): load models dynamically from Ollama API

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1263,9 +1263,10 @@ function startAISession(ws, opts) {
 // ─── Providers API ────────────────────────────────────────────────────────────
 
 // GET /api/providers — lista providers con label, models, si está configurado
-app.get('/api/providers', (_req, res) => {
+app.get('/api/providers', async (_req, res) => {
   const cfg = providerConfig.getConfig();
-  const list = providersModule.list().map(p => ({
+  const providers = await providersModule.listAsync();
+  const list = providers.map(p => ({
     ...p,
     configured: ['claude-code', 'ollama'].includes(p.name) ? true : !!(providerConfig.getApiKey(p.name)),
     currentModel: cfg.providers?.[p.name]?.model || p.defaultModel,

--- a/server/providers/index.js
+++ b/server/providers/index.js
@@ -18,6 +18,13 @@ module.exports = {
       defaultModel: p.defaultModel,
     }));
   },
+  async listAsync() {
+    const ollama = providers['ollama'];
+    if (ollama && typeof ollama.fetchModels === 'function') {
+      await ollama.fetchModels();
+    }
+    return this.list();
+  },
   get(name) {
     return providers[name] || providers['anthropic'];
   },

--- a/server/providers/ollama.js
+++ b/server/providers/ollama.js
@@ -5,11 +5,34 @@ const http   = require('http');
 
 const DEFAULT_BASE_URL = 'http://100.64.0.5:11434';
 
-// Modelos con soporte de visión
-const VISION_MODELS = ['minicpm-v', 'llava', 'llava:13b', 'llava:34b'];
+// Modelos con soporte de visión (prefijos, se matchean sin tag)
+const VISION_PREFIXES = ['minicpm-v', 'llava', 'llava-llama3', 'bakllava'];
+
+// Cache de modelos disponibles
+let cachedModels = null;
+let cacheExpiry = 0;
 
 function getBaseUrl() {
   return process.env.OLLAMA_URL || DEFAULT_BASE_URL;
+}
+
+function isVisionModel(model) {
+  const name = model.split(':')[0];
+  return VISION_PREFIXES.some(p => name === p || name.startsWith(p));
+}
+
+async function fetchAvailableModels() {
+  if (cachedModels && Date.now() < cacheExpiry) return cachedModels;
+  try {
+    const res = await fetch(`${getBaseUrl()}/api/tags`);
+    if (!res.ok) return cachedModels || [];
+    const data = await res.json();
+    cachedModels = (data.models || []).map(m => m.name);
+    cacheExpiry = Date.now() + 30000; // cache 30s
+    return cachedModels;
+  } catch {
+    return cachedModels || [];
+  }
 }
 
 /**
@@ -41,17 +64,26 @@ function ollamaNativeChat(baseUrl, model, messages) {
 module.exports = {
   name: 'ollama',
   label: 'Ollama (local)',
-  defaultModel: 'qwen2.5',
-  models: ['qwen2.5', 'minicpm-v', 'llama3.2', 'llama3.1', 'mistral', 'codellama', 'deepseek-coder'],
+  defaultModel: 'qwen2.5:7b',
+  models: [], // se llena dinámicamente con fetchModels()
+
+  async fetchModels() {
+    const models = await fetchAvailableModels();
+    this.models = models.length ? models : ['qwen2.5:7b'];
+    return this.models;
+  },
 
   async *chat({ systemPrompt, history, model, images }) {
     const baseUrl   = getBaseUrl();
+    // Cargar modelos disponibles si no hay
+    if (!this.models.length) await this.fetchModels();
     const usedModel = model || this.defaultModel;
     const hasImages = images && images.length > 0;
 
     // Si hay imágenes, usar la API nativa de Ollama (no la compatible con OpenAI)
     if (hasImages) {
-      const visionModel = VISION_MODELS.includes(usedModel) ? usedModel : 'minicpm-v';
+      const visionModel = isVisionModel(usedModel) ? usedModel
+        : this.models.find(m => isVisionModel(m)) || 'minicpm-v:latest';
       const messages = [];
       if (systemPrompt) messages.push({ role: 'system', content: systemPrompt });
 
@@ -143,6 +175,8 @@ module.exports = {
       content: prompt,
       images: resized,
     }];
-    return ollamaNativeChat(baseUrl, 'minicpm-v', messages);
+    const models = await fetchAvailableModels();
+    const visionModel = models.find(m => isVisionModel(m)) || 'minicpm-v:latest';
+    return ollamaNativeChat(baseUrl, visionModel, messages);
   },
 };


### PR DESCRIPTION
## Summary
- Ollama models are now fetched dynamically from `/api/tags` instead of being hardcoded
- Fixes "model not found" errors caused by mismatched model names (e.g. `qwen2.5` vs `qwen2.5:7b`)
- Vision model detection uses prefix matching instead of exact list
- Models cached for 30s to avoid excessive API calls
- `GET /api/providers` now returns real models available in Ollama

## Test plan
- [ ] `pm2 restart clawmint` and verify `GET /api/providers` returns `llava:7b`, `minicpm-v:latest`, `qwen2.5:7b`
- [ ] Send a message via WebChat with Ollama provider selected — should respond correctly
- [ ] Send an image — should auto-detect vision model (`minicpm-v:latest`)
- [ ] Stop Ollama on remote server and verify graceful fallback (no crash)