### PR TITLE
fix: error handling silencioso + UX improvements (#52)

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -29,7 +29,7 @@
 .title {
   margin-left: 8px;
   font-size: 12px;
-  color: #888;
+  color: #aaa;
   letter-spacing: 0.05em;
 }
 
@@ -99,4 +99,28 @@
   min-width: 0;
   overflow: hidden;
   position: relative;
+}
+
+/* ─── Responsive: móvil (<768px) ──────────────────────────────────────────── */
+@media (max-width: 768px) {
+  .app-header {
+    padding: 6px 10px;
+    gap: 6px;
+  }
+  .app-body-wrap {
+    flex-direction: column;
+  }
+  .app-body-wrap > * {
+    width: 100% !important;
+    min-width: 0 !important;
+    max-width: 100% !important;
+    border-left: none !important;
+  }
+}
+
+/* ─── Responsive: tablet (768px-1000px) ───────────────────────────────────── */
+@media (max-width: 1000px) and (min-width: 769px) {
+  .app-body-wrap > * {
+    min-width: 0 !important;
+  }
 }

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -69,7 +69,9 @@ export default function App() {
             return [...prev, s];
           });
         }
-      } catch { /* ignorar */ }
+      } catch (err) {
+        console.warn('[App] Error procesando mensaje WS:', err.message);
+      }
     };
     return () => ws.close();
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
@@ -85,7 +87,9 @@ export default function App() {
             ? bots.reduce((n, b) => n + (b.chats?.length || 0), 0)
             : 0;
           setTelegramChatsCount(chats);
-        } catch { /* ignorar */ }
+        } catch (err) {
+          console.warn('[App] Error obteniendo bots de Telegram:', err.message);
+        }
       }, 5000);
       return () => clearInterval(interval);
     }

--- a/client/src/components/AgentsPanel.css
+++ b/client/src/components/AgentsPanel.css
@@ -11,6 +11,15 @@
   flex-shrink: 0;
 }
 
+@media (max-width: 768px) {
+  .ap-panel {
+    width: 100%;
+    min-width: 0;
+    border-left: none;
+    border-top: 1px solid #333;
+  }
+}
+
 .ap-header {
   display: flex;
   align-items: center;
@@ -86,7 +95,7 @@
 
 .ap-agent-desc {
   font-size: 11px;
-  color: #888;
+  color: #aaa;
   margin: 4px 0 0;
 }
 
@@ -138,7 +147,7 @@
 
 .ap-label {
   font-size: 11px;
-  color: #888;
+  color: #aaa;
   margin-bottom: 4px;
   display: block;
 }
@@ -177,7 +186,7 @@
 
 .ap-hint {
   font-size: 10px;
-  color: #555;
+  color: #999;
   margin: 4px 0 0;
 }
 
@@ -238,14 +247,14 @@
 
 .ap-empty-state {
   text-align: center;
-  color: #666;
+  color: #999;
   padding: 24px 12px;
   font-size: 13px;
 }
 
 .ap-empty-hint {
   font-size: 11px;
-  color: #555;
+  color: #999;
   margin-top: 6px;
 }
 
@@ -274,7 +283,7 @@
 
 .ap-skills-hint {
   font-size: 10px;
-  color: #555;
+  color: #999;
   margin: 0 0 6px;
 }
 
@@ -290,7 +299,7 @@
 
 .ap-skills-empty {
   font-size: 11px;
-  color: #555;
+  color: #999;
   text-align: center;
   padding: 8px 0;
 }
@@ -327,7 +336,7 @@
 
 .ap-skill-desc {
   font-size: 10px;
-  color: #666;
+  color: #999;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/client/src/components/AgentsPanel.jsx
+++ b/client/src/components/AgentsPanel.jsx
@@ -121,7 +121,7 @@ function SkillsSection() {
   const [error, setError] = useState('');
 
   const loadSkills = useCallback(() => {
-    fetch(SKILLS_API).then(r => r.json()).then(setSkillsList).catch(() => {});
+    fetch(SKILLS_API).then(r => r.json()).then(setSkillsList).catch(() => setError('Error cargando skills'));
   }, []);
 
   useEffect(() => { loadSkills(); }, [loadSkills]);
@@ -190,13 +190,15 @@ export default function AgentsPanel({ onClose }) {
   const [agents, setAgents] = useState([]);
   const [showForm, setShowForm] = useState(false);
   const [editAgent, setEditAgent] = useState(null);
+  const [loadError, setLoadError] = useState('');
 
   const fetchAgents = useCallback(async () => {
     try {
+      setLoadError('');
       const res = await fetch(API);
       const data = await res.json();
       setAgents(Array.isArray(data) ? data : []);
-    } catch { /* ignorar */ }
+    } catch { setLoadError('Error cargando agentes'); }
   }, []);
 
   useEffect(() => { fetchAgents(); }, [fetchAgents]);
@@ -217,7 +219,7 @@ export default function AgentsPanel({ onClose }) {
     try {
       await fetch(`${API}/${key}`, { method: 'DELETE' });
       fetchAgents();
-    } catch { /* ignorar */ }
+    } catch { setLoadError('Error eliminando agente'); }
   };
 
   const handleNewClick = () => {
@@ -235,6 +237,7 @@ export default function AgentsPanel({ onClose }) {
         <button className="ap-close" onClick={onClose} title="Cerrar"><X size={16} /></button>
       </div>
 
+      {loadError && <div className="ap-error" style={{ padding: '6px 14px' }}>{loadError}</div>}
       <div className="ap-body">
         {agents.length === 0 && !showForm && (
           <div className="ap-empty-state">

--- a/client/src/components/McpsPanel.jsx
+++ b/client/src/components/McpsPanel.jsx
@@ -245,10 +245,11 @@ export default function McpsPanel({ onClose }) {
 
   const fetchMcps = useCallback(async () => {
     try {
+      setCliError('');
       const res = await fetch(API);
       const data = await res.json();
       setMcpList(Array.isArray(data) ? data : []);
-    } catch { /* ignorar */ }
+    } catch { setCliError('Error cargando MCPs'); }
   }, []);
 
   useEffect(() => { fetchMcps(); }, [fetchMcps]);
@@ -269,7 +270,7 @@ export default function McpsPanel({ onClose }) {
     try {
       await fetch(`${API}/${name}`, { method: 'DELETE' });
       fetchMcps();
-    } catch { /* ignorar */ }
+    } catch { setCliError('Error eliminando MCP'); }
   };
 
   const handleToggle = async (mcp) => {

--- a/client/src/components/WebChatPanel.css
+++ b/client/src/components/WebChatPanel.css
@@ -12,6 +12,16 @@
   flex-shrink: 0;
 }
 
+@media (max-width: 768px) {
+  .wc-panel {
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+    border-left: none;
+    border-top: 1px solid #444;
+  }
+}
+
 .wc-header {
   display: flex;
   align-items: center;
@@ -81,7 +91,7 @@
   background: #1e1e1e;
   border-bottom: 1px solid #2a2a2a;
   font-size: 11px;
-  color: #888;
+  color: #aaa;
   flex-shrink: 0;
 }
 
@@ -116,13 +126,13 @@
   align-items: center;
   justify-content: center;
   flex: 1;
-  color: #666;
+  color: #999;
   text-align: center;
   font-size: 13px;
 }
 .wc-hint {
   font-size: 11px;
-  color: #555;
+  color: #999;
   margin-top: 4px;
 }
 
@@ -154,7 +164,7 @@
 
 .wc-msg-label {
   font-size: 10px;
-  color: #888;
+  color: #aaa;
   margin-bottom: 2px;
   padding-left: 4px;
 }
@@ -294,7 +304,7 @@
   border-color: #007aff;
 }
 .wc-input::placeholder {
-  color: #666;
+  color: #999;
 }
 
 .wc-send {
@@ -442,7 +452,7 @@
   font-size: 11px;
 }
 .wc-code-lang {
-  color: #888;
+  color: #aaa;
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }

--- a/client/src/components/WebChatPanel.jsx
+++ b/client/src/components/WebChatPanel.jsx
@@ -44,11 +44,11 @@ export default function WebChatPanel({ onClose }) {
         setProviders(data.providers || []);
         if (data.default) setProvider(data.default);
       })
-      .catch(() => {});
+      .catch(() => setStatusText('Error cargando providers'));
     fetch(`${API_BASE}/api/agents`)
       .then(r => r.json())
       .then(data => setAgentsList(Array.isArray(data) ? data : []))
-      .catch(() => {});
+      .catch(() => setStatusText('Error cargando agentes'));
   }, []);
 
   // Conectar WebSocket
@@ -233,13 +233,24 @@ export default function WebChatPanel({ onClose }) {
             if (msg.cwd) setCwd(msg.cwd);
             break;
         }
-      } catch { /* ignorar */ }
+      } catch (err) {
+        console.warn('[WebChat] Error procesando mensaje WS:', err.message);
+      }
     };
 
     ws.onclose = () => setConnected(false);
-    ws.onerror = () => {};
+    ws.onerror = () => setStatusText('Error de conexión WebSocket');
 
     return () => ws.close();
+  }, []);
+
+  // Cleanup de grabación al desmontar el componente
+  useEffect(() => {
+    return () => {
+      streamRef.current?.getTracks().forEach(t => t.stop());
+      streamRef.current = null;
+      clearInterval(recTimerRef.current);
+    };
   }, []);
 
   // ── Enviar mensaje ─────────────────────────────────────────────────────────
@@ -465,6 +476,11 @@ export default function WebChatPanel({ onClose }) {
         }));
       }
     };
+    reader.onerror = () => {
+      setSending(false);
+      setStatusText(`Error leyendo archivo: ${file.name}`);
+      setTimeout(() => setStatusText(null), 5000);
+    };
     reader.readAsDataURL(file);
     // Reset input para permitir seleccionar el mismo archivo
     e.target.value = '';
@@ -518,6 +534,11 @@ export default function WebChatPanel({ onClose }) {
           files: [{ base64, mediaType, name: file.name }],
         }));
       }
+    };
+    reader.onerror = () => {
+      setSending(false);
+      setStatusText(`Error leyendo archivo: ${file.name}`);
+      setTimeout(() => setStatusText(null), 5000);
     };
     reader.readAsDataURL(file);
   }, [input, provider, agent]);

--- a/server/channels/telegram/CommandHandler.js
+++ b/server/channels/telegram/CommandHandler.js
@@ -457,6 +457,7 @@ class CommandHandler {
       case 'cd': {
         const target = args.join(' ').trim() || process.env.HOME;
         const resolved = target === '~' ? process.env.HOME
+          : target.startsWith('~/') ? path.join(process.env.HOME, target.slice(2))
           : target.startsWith('/') ? target
           : path.resolve(chat.monitorCwd || process.env.HOME, target);
         try {

--- a/server/channels/web/WebChannel.js
+++ b/server/channels/web/WebChannel.js
@@ -476,7 +476,10 @@ class WebChannel extends BaseChannel {
           this._sendJson(ws, { type: 'command_result', text: `Directorio actual: ${state.cwd}`, cwd: state.cwd });
           return;
         }
-        const resolved = path.resolve(state.cwd, arg);
+        const expanded = arg === '~' ? process.env.HOME
+          : arg.startsWith('~/') ? path.join(process.env.HOME, arg.slice(2))
+          : arg;
+        const resolved = path.isAbsolute(expanded) ? expanded : path.resolve(state.cwd, expanded);
         try {
           const stat = fs.statSync(resolved);
           if (!stat.isDirectory()) {


### PR DESCRIPTION
## Summary
- **Issue #52**: Resuelve todos los casos de error handling silencioso en WebChatPanel, AgentsPanel, McpsPanel y App.jsx
- **Contraste**: Mejora colores de textos secundarios para cumplir accesibilidad (#50 parcial)
- **Responsive**: CSS para móvil (<768px) y tablet (#54 parcial)
- **cd con tilde**: `/cd ~/path` funciona correctamente en Telegram y WebChat

## Cambios por archivo

| Archivo | Cambio |
|---------|--------|
| `WebChatPanel.jsx` | `FileReader.onerror` en file upload y drag&drop, `ws.onmessage` catch con warn, `ws.onerror` muestra status, cleanup grabación |
| `AgentsPanel.jsx` | `loadError` state, catches muestran error al usuario |
| `McpsPanel.jsx` | catches muestran error con `setCliError` |
| `App.jsx` | catches silenciosos → `console.warn` |
| `App.css` | responsive móvil + tablet |
| `AgentsPanel.css` | contraste + responsive |
| `WebChatPanel.css` | contraste + responsive |
| `CommandHandler.js` | `/cd ~/path` expande tilde |
| `WebChannel.js` | `/cd ~/path` expande tilde |

## Test plan
- [ ] Subir archivo en WebChat → simular error de FileReader (archivo corrupto)
- [ ] Verificar que catches muestren errores visibles al usuario
- [ ] Verificar responsive en viewport <768px
- [ ] Probar `/cd ~/Documents` en Telegram y WebChat