### PR TITLE
fix: contraste WCAG AA en todos los CSS (#50)

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -48,7 +48,7 @@
   background: none;
   border: 1px solid transparent;
   border-radius: 6px;
-  color: #888;
+  color: #aaa;
   font-size: 16px;
   cursor: pointer;
   padding: 3px 7px;

--- a/client/src/components/AgentsPanel.css
+++ b/client/src/components/AgentsPanel.css
@@ -45,7 +45,7 @@
 .ap-close {
   background: none;
   border: none;
-  color: #888;
+  color: #aaa;
   font-size: 18px;
   cursor: pointer;
   padding: 0 4px;
@@ -224,7 +224,7 @@
 
 .ap-btn-ghost {
   background: transparent;
-  color: #888;
+  color: #aaa;
   border: 1px solid #444;
 }
 .ap-btn-ghost:hover:not(:disabled) { color: #ccc; border-color: #666; }

--- a/client/src/components/CommandBar.css
+++ b/client/src/components/CommandBar.css
@@ -28,7 +28,7 @@
 }
 
 .command-input::placeholder {
-  color: #444;
+  color: #999;
 }
 
 .command-submit {

--- a/client/src/components/DirPicker.css
+++ b/client/src/components/DirPicker.css
@@ -33,7 +33,7 @@
 .dirpicker-close {
   background: none;
   border: none;
-  color: #888;
+  color: #aaa;
   font-size: 18px;
   cursor: pointer;
   padding: 0 4px;
@@ -142,7 +142,7 @@
 .dirpicker-error,
 .dirpicker-empty {
   padding: 12px 14px;
-  color: #666;
+  color: #999;
   font-size: 12px;
   text-align: center;
 }

--- a/client/src/components/TabBar.css
+++ b/client/src/components/TabBar.css
@@ -19,7 +19,7 @@
   padding: 6px 14px;
   cursor: pointer;
   font-size: 12px;
-  color: #888;
+  color: #aaa;
   border-right: 1px solid #333;
   white-space: nowrap;
   transition: background 0.15s;
@@ -47,7 +47,7 @@
 .tab-close {
   background: none;
   border: none;
-  color: #666;
+  color: #999;
   cursor: pointer;
   font-size: 14px;
   line-height: 1;
@@ -63,7 +63,7 @@
 .tab-new {
   background: none;
   border: none;
-  color: #666;
+  color: #999;
   cursor: pointer;
   font-size: 18px;
   padding: 0 14px;

--- a/client/src/components/TelegramPanel.css
+++ b/client/src/components/TelegramPanel.css
@@ -48,7 +48,7 @@
 .tg-close {
   background: none;
   border: none;
-  color: #777;
+  color: #aaa;
   font-size: 18px;
   cursor: pointer;
   padding: 2px 4px;
@@ -75,7 +75,7 @@
   display: flex;
   gap: 6px;
   font-size: 11px;
-  color: #555;
+  color: #999;
   padding: 0 2px;
 }
 
@@ -84,20 +84,20 @@
 .tg-empty-state {
   text-align: center;
   padding: 24px 0 8px;
-  color: #555;
+  color: #999;
   font-size: 13px;
   line-height: 1.6;
 }
 
 .tg-empty-hint {
   font-size: 11px;
-  color: #444;
+  color: #999;
   margin-top: 4px;
 }
 
 .tg-empty-small {
   font-size: 11px;
-  color: #555;
+  color: #999;
   margin: 4px 0;
   padding: 0 2px;
 }
@@ -156,7 +156,7 @@
 
 .tg-bot-expand {
   font-size: 10px;
-  color: #555;
+  color: #999;
   margin-left: 2px;
 }
 
@@ -195,12 +195,12 @@
 
 .tg-chat-time {
   font-size: 10px;
-  color: #555;
+  color: #999;
 }
 
 .tg-chat-preview {
   font-size: 11px;
-  color: #666;
+  color: #999;
   font-style: italic;
   margin: 0;
   white-space: nowrap;
@@ -210,7 +210,7 @@
 
 .tg-chat-session {
   font-size: 10px;
-  color: #555;
+  color: #999;
   margin: 0;
 }
 
@@ -218,7 +218,7 @@
   background: #2a2a2a;
   border-radius: 3px;
   padding: 1px 4px;
-  color: #777;
+  color: #aaa;
 }
 
 .tg-chat-btns {
@@ -248,7 +248,7 @@
 
 .tg-form-help {
   font-size: 11px;
-  color: #555;
+  color: #999;
   background: #1e1e1e;
   border-radius: 5px;
   padding: 7px 9px;
@@ -263,7 +263,7 @@
 
 .tg-label {
   font-size: 11px;
-  color: #666;
+  color: #999;
 }
 
 .tg-token-input-row {
@@ -337,7 +337,7 @@
 
 .tg-btn-add {
   background: #252525;
-  color: #777;
+  color: #aaa;
   border: 1px dashed #3a3a3a;
   width: 100%;
   text-align: center;
@@ -397,7 +397,7 @@
   background: #2a2a2a;
   border: 1px solid #3a3a3a;
   border-radius: 10px;
-  color: #777;
+  color: #aaa;
   font-size: 10px;
   font-weight: 600;
   padding: 1px 7px;
@@ -428,7 +428,7 @@
 
 .tg-session-empty {
   font-size: 11px;
-  color: #555;
+  color: #999;
   padding: 3px 4px;
 }
 
@@ -457,7 +457,7 @@
 
 .tg-session-id {
   font-size: 10px;
-  color: #555;
+  color: #999;
   background: #1e1e1e;
   border-radius: 3px;
   padding: 1px 4px;
@@ -490,12 +490,12 @@
 .access-config label {
   display: block;
   font-size: 0.75rem;
-  color: #888;
+  color: #aaa;
   margin-bottom: 4px;
 }
 
 .access-config label span {
-  color: #555;
+  color: #999;
   font-size: 0.7rem;
 }
 

--- a/client/src/components/WebChatPanel.css
+++ b/client/src/components/WebChatPanel.css
@@ -74,7 +74,7 @@
 .wc-close {
   background: none;
   border: none;
-  color: #888;
+  color: #aaa;
   font-size: 18px;
   cursor: pointer;
   padding: 0 4px;
@@ -497,7 +497,7 @@
 .wc-code-inline-copy {
   background: none;
   border: none;
-  color: #888;
+  color: #aaa;
   cursor: pointer;
   padding: 2px;
   display: flex;
@@ -637,7 +637,7 @@
   padding: 4px 8px;
 }
 .wc-media-voice-icon {
-  color: #888;
+  color: #aaa;
   flex-shrink: 0;
 }
 .wc-media-audio {


### PR DESCRIPTION
## Summary
- Corrige **todos** los textos secundarios con ratio de contraste inferior a WCAG AA (4.5:1)
- 7 archivos CSS actualizados, 30 líneas cambiadas
- Mapeo: `#444→#999`, `#555→#999`, `#666→#999`, `#777→#aaa`, `#888→#aaa`

## Archivos
- `TelegramPanel.css` — 18 selectores corregidos
- `TabBar.css` — 3 selectores
- `DirPicker.css` — 2 selectores
- `WebChatPanel.css` — 3 selectores
- `AgentsPanel.css` — 2 selectores
- `CommandBar.css` — 1 selector (placeholder)
- `App.css` — 1 selector (header buttons)

Closes #50

## Test plan
- [ ] Verificar visualmente que textos secundarios se leen bien en todos los paneles
- [ ] Confirmar que no hay pérdida de jerarquía visual (secundarios siguen siendo más tenues que primarios)