### PR TITLE
fix: WebChat dropdown sync con servidor (#32)

### DIFF
--- a/client/src/components/WebChatPanel.jsx
+++ b/client/src/components/WebChatPanel.jsx
@@ -555,7 +555,14 @@ export default function WebChatPanel({ onClose }) {
           <select
             className="wc-select"
             value={provider}
-            onChange={e => setProvider(e.target.value)}
+            onChange={e => {
+              const val = e.target.value;
+              setProvider(val);
+              const ws = wsRef.current;
+              if (ws && ws.readyState === WebSocket.OPEN) {
+                ws.send(JSON.stringify({ type: 'chat:settings', provider: val }));
+              }
+            }}
           >
             {providers.filter(p => p.configured).map(p => (
               <option key={p.name} value={p.name}>{p.label || p.name}</option>
@@ -564,7 +571,14 @@ export default function WebChatPanel({ onClose }) {
           <select
             className="wc-select"
             value={agent || ''}
-            onChange={e => setAgent(e.target.value || null)}
+            onChange={e => {
+              const val = e.target.value || null;
+              setAgent(val);
+              const ws = wsRef.current;
+              if (ws && ws.readyState === WebSocket.OPEN) {
+                ws.send(JSON.stringify({ type: 'chat:settings', agent: val }));
+              }
+            }}
           >
             <option value="">Sin agente</option>
             {agentsList.map(a => (

--- a/server/channels/web/WebChannel.js
+++ b/server/channels/web/WebChannel.js
@@ -184,6 +184,24 @@ class WebChannel extends BaseChannel {
             break;
           }
 
+          case 'chat:settings': {
+            // Sync de settings desde el dropdown del cliente
+            if (msg.provider) {
+              const p = this.providers.get(msg.provider);
+              if (p) {
+                state.provider = msg.provider;
+                state.history = [];
+                try { this.messagesRepo?.clear(sessionId); } catch {}
+                this._saveSettings(sessionId, state);
+              }
+            }
+            if (msg.agent !== undefined) {
+              state.agent = msg.agent || null;
+              this._saveSettings(sessionId, state);
+            }
+            break;
+          }
+
           default:
             break;
         }


### PR DESCRIPTION
## Summary
- Cuando el usuario cambia provider o agente desde el dropdown, ahora se envía un mensaje `chat:settings` al servidor via WebSocket
- El servidor actualiza el estado de la sesión inmediatamente (no espera al siguiente mensaje de chat)
- Previene desincronización si el servidor envía un `status` entre el cambio de dropdown y el siguiente mensaje

## Cambios
| Archivo | Cambio |
|---------|--------|
| `WebChatPanel.jsx` | Dropdowns envían `chat:settings` al servidor on change |
| `WebChannel.js` | Nuevo handler `chat:settings` sincroniza provider/agent |

Closes #32

## Test plan
- [ ] Cambiar provider desde dropdown → verificar que el servidor refleja el cambio
- [ ] Cambiar agente desde dropdown → verificar sincronización
- [ ] Usar `/provider` por comando → verificar que dropdown se actualiza
- [ ] Reconectar sesión → verificar que provider persiste correctamente