### PR TITLE
fix: suprimir mensaje duplicado en modo MCP

### DIFF
--- a/server/channels/telegram/TelegramChannel.js
+++ b/server/channels/telegram/TelegramChannel.js
@@ -1023,9 +1023,11 @@ class TelegramBot {
         if (sentMsg) {
           try { await this._apiCall('deleteMessage', { chat_id: chatId, message_id: sentMsg.message_id }); } catch (e) { tdbg('send', `deleteStatusMsg FAIL: ${e.message}`); }
         }
-        if (result.text) {
-          tdbg('send', `MCP mode: enviando texto (${result.text.length} chars) usedMcpTools=${result.usedMcpTools}`);
+        if (result.text && !result.usedMcpTools) {
+          tdbg('send', `MCP mode: enviando texto (${result.text.length} chars)`);
           await this._sendResult(chatId, result.text, null);
+        } else if (result.text && result.usedMcpTools) {
+          tdbg('send', `MCP mode: texto suprimido (${result.text.length} chars) — ya enviado via MCP tools`);
         }
       } else {
         // Modo normal: streaming de texto


### PR DESCRIPTION
## Summary
- Cuando Claude responde usando `telegram_send_message` via MCP tools, el servidor también enviaba `result.text` como mensaje separado, causando un mensaje duplicado/ajeno al final
- Ahora se verifica `result.usedMcpTools` y se suprime el envío si Claude ya se comunicó directamente por MCP

## Cambio
`TelegramChannel.js` línea ~1026: condición `if (result.text)` → `if (result.text && !result.usedMcpTools)`

## Test plan
- [ ] Enviar mensaje a Claude via Telegram en modo MCP (auto)
- [ ] Verificar que Claude responde SOLO via MCP tools, sin mensaje extra del servidor
- [ ] Verificar que providers API (no MCP) siguen enviando respuesta normalmente