### PR TITLE
feat: Telegram admin commands and inline keyboard cleanup

### DIFF
--- a/server/channels/telegram/CallbackHandler.js
+++ b/server/channels/telegram/CallbackHandler.js
@@ -124,6 +124,16 @@ class CallbackHandler {
     return { text, buttons };
   }
 
+  // ── Remover inline keyboard de un mensaje ───────────────────────────────────
+
+  _removeInlineKeyboard(bot, chatId, msgId) {
+    bot._apiCall('editMessageReplyMarkup', {
+      chat_id: chatId,
+      message_id: msgId,
+      reply_markup: JSON.stringify({ inline_keyboard: [] }),
+    }).catch(() => {}); // Ignorar si el mensaje ya fue editado
+  }
+
   // ── Ejecución de callbacks dinámicos ────────────────────────────────────────
 
   async _executeDynamicAction(bot, chatId, msgId, chat, action) {
@@ -369,7 +379,8 @@ class CallbackHandler {
             [{ text: `📁 ${listCmd}`,   id: 'menu:monitor:ls'      },
              { text: '🖥️ Consola',       id: 'menu:monitor:consola' }],
             [{ text: '📊 Status',        id: 'status_vps'           },
-             { text: '← Menú',           id: 'menu'                 }],
+             { text: '🔄 Restart',       id: 'menu:monitor:restart' }],
+            [{ text: '← Menú',           id: 'menu'                 }],
           ];
         },
       },
@@ -379,6 +390,12 @@ class CallbackHandler {
           await b._sendConsolePrompt(chatId,
             `🖥️ *Modo consola activado*\n\nEscribí comandos directamente.\n\`exit\` o /consola para salir.`,
             chat);
+        },
+      },
+      'menu:monitor:restart': {
+        action: async ({ chatId, bot: b }) => {
+          await b.sendText(chatId, '🔄 Reiniciando servidor…');
+          require('child_process').exec('pm2 restart clawmint', { timeout: 15000 }, () => {});
         },
       },
 
@@ -562,6 +579,10 @@ class CallbackHandler {
       const action = dynamicRegistry.get(data);
       if (action) {
         await this._executeDynamicAction(bot, chatId, msgId, chat, action);
+        // Remover botones del mensaje original (si la acción no editó el mensaje)
+        if (msgId && !(action.type === 'message' && action.edit)) {
+          this._removeInlineKeyboard(bot, chatId, msgId);
+        }
         return;
       }
     }
@@ -963,6 +984,8 @@ class CallbackHandler {
 
       default:
         // Fallback: enviar callback_data como prompt al AI activo
+        // Remover botones del mensaje original
+        if (msgId) this._removeInlineKeyboard(bot, chatId, msgId);
         await bot._sendToSession(chatId, data, chat);
         break;
     }

--- a/server/channels/telegram/CommandHandler.js
+++ b/server/channels/telegram/CommandHandler.js
@@ -3,6 +3,7 @@
 const fs   = require('fs');
 const path = require('path');
 const os   = require('os');
+const { exec } = require('child_process');
 
 const ClaudePrintSession   = require('../../core/ClaudePrintSession');
 const { getSystemStats }   = require('../../core/systemStats');
@@ -992,6 +993,39 @@ class CommandHandler {
           } else {
             await bot.sendText(chatId, '❌ Uso: `/tts` (ver estado) | `/tts on` | `/tts off`');
           }
+        }
+        break;
+      }
+
+      // ── Terminal directa ─────────────────────────────────────────────────
+      case 'restart': {
+        await bot.sendText(chatId, '🔄 Reiniciando servidor…');
+        exec('pm2 restart clawmint', { timeout: 15000 }, () => {});
+        break;
+      }
+
+      case 'run':
+      case 'cmd': {
+        if (args.length === 0) {
+          await bot.sendText(chatId, '❌ Uso: `/run <comando>`\nEjemplo: `/run pm2 status`');
+          break;
+        }
+        const command = args.join(' ');
+        try {
+          const output = await new Promise((resolve, reject) => {
+            exec(command, { timeout: 30000, maxBuffer: 1024 * 512 }, (err, stdout, stderr) => {
+              if (err && !stdout && !stderr) return reject(err);
+              resolve(stdout || stderr || '(sin output)');
+            });
+          });
+          const truncated = output.length > 4000 ? output.slice(0, 4000) + '\n…(truncado)' : output;
+          await bot._apiCall('sendMessage', {
+            chat_id: chatId,
+            text: `<pre>${truncated}</pre>`,
+            parse_mode: 'HTML',
+          });
+        } catch (err) {
+          await bot.sendText(chatId, `❌ Error: \`${err.message}\``);
         }
         break;
       }

--- a/server/channels/telegram/TelegramChannel.js
+++ b/server/channels/telegram/TelegramChannel.js
@@ -388,6 +388,8 @@ class TelegramBot {
           { command: 'whisper',      description: 'Ver/cambiar modelo Whisper' },
           { command: 'tts',          description: 'Ver/configurar text-to-speech' },
           { command: 'recordar',     description: 'Crear recordatorio' },
+          { command: 'restart',      description: 'Reiniciar servidor PM2' },
+          { command: 'run',          description: 'Ejecutar comando en terminal' },
           { command: 'ayuda',        description: 'Todos los comandos' },
         ],
       });


### PR DESCRIPTION
## Summary
- Add `/restart` command to restart the PM2 server directly from Telegram
- Add `/run` (alias `/cmd`) command to execute shell commands from chat (output truncated at 4KB)
- Auto-remove inline keyboard buttons after callback interaction to keep chat clean
- Add 🔄 Restart button to the monitor submenu

## Changes
- **CallbackHandler.js**: `_removeInlineKeyboard()` method, restart menu entry, auto-cleanup on callback
- **CommandHandler.js**: `/restart` and `/run`|`/cmd` command handlers
- **TelegramChannel.js**: Register new commands in bot menu

## Test plan
- [ ] Send `/restart` and verify PM2 restarts the server
- [ ] Send `/run pm2 status` and verify output is returned
- [ ] Send `/run` without args and verify usage message
- [ ] Click an inline button and verify keyboard is removed after
- [ ] Check monitor submenu shows Restart button