### PR TITLE
fix: update outdated tests for current tool definitions

### DIFF
--- a/server/test/mcp.router.test.js
+++ b/server/test/mcp.router.test.js
@@ -16,11 +16,12 @@ describe('getToolDefs()', () => {
     expect(defs.length).toBeGreaterThan(0);
   });
 
-  test('cada tool tiene name, description y params', () => {
+  test('cada tool tiene name, description y params o inputSchema', () => {
     for (const t of getToolDefs()) {
       expect(typeof t.name).toBe('string');
       expect(typeof t.description).toBe('string');
-      expect(typeof t.params).toBe('object');
+      const hasParams = typeof t.params === 'object' || typeof t.inputSchema === 'object';
+      expect(hasParams).toBe(true);
     }
   });
 });

--- a/server/test/mcp.tools.test.js
+++ b/server/test/mcp.tools.test.js
@@ -10,8 +10,12 @@ const ptyTools   = require('../mcp/tools/pty');     // array
 const toolsIndex = require('../mcp/tools');
 const { destroy: destroyShell, destroyAll } = require('../mcp/ShellSession');
 
-const [READ_FILE, WRITE_FILE, LIST_DIR, SEARCH_FILES] = filesTools;
-const [PTY_WRITE, PTY_READ]                            = ptyTools;
+const READ_FILE    = filesTools.find(t => t.name === 'read_file');
+const WRITE_FILE   = filesTools.find(t => t.name === 'write_file');
+const LIST_DIR     = filesTools.find(t => t.name === 'list_dir');
+const SEARCH_FILES = filesTools.find(t => t.name === 'search_files');
+const PTY_WRITE = ptyTools.find(t => t.name === 'pty_write');
+const PTY_READ  = ptyTools.find(t => t.name === 'pty_read');
 
 afterAll(() => destroyAll());
 
@@ -50,7 +54,8 @@ describe('bash tool', () => {
     const cwdCmd = isWin ? 'cd' : 'pwd';
     await bash.execute({ command: `cd ${tmpDir}`, session_id: id });
     const r = await bash.execute({ command: cwdCmd, session_id: id });
-    expect(r.trim().toLowerCase()).toContain(tmpDir.toLowerCase().replace(/\//g, '\\'));
+    const expected = process.platform === 'win32' ? tmpDir.toLowerCase().replace(/\//g, '\\') : tmpDir.toLowerCase();
+    expect(r.trim().toLowerCase()).toContain(expected);
     destroyShell(id);
   });
 });
@@ -215,15 +220,15 @@ describe('pty tools', () => {
 // ── tools/index.js ────────────────────────────────────────────────────────────
 
 describe('tools/index.js', () => {
-  const EXPECTED_TOOLS = ['bash', 'read_file', 'write_file', 'list_dir', 'search_files', 'pty_write', 'pty_read'];
+  const EXPECTED_CORE_TOOLS = ['bash', 'git', 'read_file', 'write_file', 'edit_file', 'list_dir', 'search_files', 'pty_create', 'pty_exec', 'pty_write', 'pty_read'];
 
-  test('all() retorna un array con 7 tools', () => {
-    expect(toolsIndex.all()).toHaveLength(7);
+  test('all() retorna un array con al menos los core tools', () => {
+    expect(toolsIndex.all().length).toBeGreaterThanOrEqual(EXPECTED_CORE_TOOLS.length);
   });
 
-  test('all() incluye los tools esperados', () => {
+  test('all() incluye los core tools esperados', () => {
     const names = toolsIndex.all().map(t => t.name);
-    for (const name of EXPECTED_TOOLS) {
+    for (const name of EXPECTED_CORE_TOOLS) {
       expect(names).toContain(name);
     }
   });


### PR DESCRIPTION
## Summary
- Fix test destructuring that broke when new tools were added (edit_file, pty_create, pty_exec)
- Use `.find()` by name instead of positional array destructuring for resilience
- Update tool count assertion to `greaterThanOrEqual` instead of hardcoded `7`
- Accept both `params` and `inputSchema` in router test
- Fix bash persistence test path comparison on Linux

## Results
✅ **218/218 tests passing** (excluding provider integration tests that require API keys)

## Test plan
- [x] `npx jest --forceExit --testPathIgnorePatterns=providers` → 218 passed, 0 failed