### PR TITLE
release: v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ Formato basado en [Keep a Changelog](https://keepachangelog.com/es-ES/1.1.0/).
 
 ---
 
+## [1.4.0] — 2026-03-25
+
+### Added
+- Comando `/restart` para reiniciar servidor PM2 desde Telegram
+- Comando `/run` (alias `/cmd`) para ejecutar comandos de terminal desde el chat
+- Botón 🔄 Restart en el submenú de monitor de Telegram
+- Registro de nuevos comandos en el menú del bot
+
+### Fixed
+- Suprimir mensaje duplicado cuando Claude ya respondió via MCP tools (#70)
+- Auto-remove de botones inline después de interacción con callback
+- Tests desactualizados: destructuring de tools, conteo hardcodeado, path comparison Linux (#72)
+
+---
+
 ## [1.3.0] — 2026-03-24
 
 ### Added

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terminal-live-server",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Backend WebSocket + node-pty para terminal en tiempo real",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Release v1.4.0

### Added
- `/restart` command to restart PM2 server from Telegram
- `/run` (alias `/cmd`) to execute shell commands from chat
- 🔄 Restart button in monitor submenu
- New commands registered in bot menu

### Fixed
- Suppress duplicate message when Claude already responded via MCP tools (#70)
- Auto-remove inline keyboard buttons after callback interaction (#71)
- Outdated tests: tool destructuring, hardcoded count, Linux path comparison (#72)

### Changelog
Updated CHANGELOG.md and bumped version to 1.4.0