### PR TITLE
perf: React.memo, memory leak fix, rAF

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -105,6 +105,10 @@ export default function App() {
   const closeSession = useCallback((id) => {
     setSessions((prev) => {
       const next = prev.filter((s) => s.id !== id);
+      // Limpiar httpIdToTabId para la sesión cerrada (evitar memory leak)
+      for (const [httpId, tabId] of httpIdToTabId.current) {
+        if (tabId === id) { httpIdToTabId.current.delete(httpId); break; }
+      }
       if (next.length === 0) {
         const s = createSession();
         setActiveId(s.id);

--- a/client/src/components/TelegramPanel.jsx
+++ b/client/src/components/TelegramPanel.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef, memo } from 'react';
 import { Lock, CheckCircle, Sparkles, Square, Play, X, ChevronUp, ChevronDown, Eye, EyeOff, Check, Plus, Bot } from 'lucide-react';
 import { API_BASE } from '../config.js';
 import './TelegramPanel.css';
@@ -13,7 +13,7 @@ function timeAgo(ts) {
   return `${Math.floor(mins / 60)}h`;
 }
 
-function ChatRow({ botKey, chat, onOpenSession, onRefresh }) {
+const ChatRow = memo(function ChatRow({ botKey, chat, onOpenSession, onRefresh }) {
   const [linking, setLinking] = useState(false);
   const [sessions, setSessions] = useState([]);
 
@@ -103,7 +103,7 @@ function ChatRow({ botKey, chat, onOpenSession, onRefresh }) {
       </div>
     </div>
   );
-}
+});
 
 function AccessConfig({ bot, onRefresh }) {
   const [ids, setIds] = useState((bot.whitelist || []).join(', '));
@@ -163,17 +163,9 @@ function AccessConfig({ bot, onRefresh }) {
   );
 }
 
-function BotCard({ bot, onOpenSession, onRefresh }) {
+const BotCard = memo(function BotCard({ bot, allAgents, onOpenSession, onRefresh }) {
   const [expanded, setExpanded] = useState(false);
   const [loading, setLoading] = useState(false);
-  const [allAgents, setAllAgents] = useState([]);
-
-  useEffect(() => {
-    fetch(`${API_BASE}/api/agents`)
-      .then(r => r.json())
-      .then(data => setAllAgents(Array.isArray(data) ? data : []))
-      .catch(() => {});
-  }, []);
 
   const handleStart = async () => {
     setLoading(true);
@@ -274,9 +266,9 @@ function BotCard({ bot, onOpenSession, onRefresh }) {
       )}
     </div>
   );
-}
+});
 
-function AddBotForm({ onAdd, onCancel }) {
+const AddBotForm = memo(function AddBotForm({ onAdd, onCancel }) {
   const [key, setKey] = useState('');
   const [token, setToken] = useState('');
   const [showToken, setShowToken] = useState(false);
@@ -347,10 +339,11 @@ function AddBotForm({ onAdd, onCancel }) {
       </div>
     </div>
   );
-}
+});
 
 export default function TelegramPanel({ onClose, onOpenSession }) {
   const [bots, setBots] = useState([]);
+  const [allAgents, setAllAgents] = useState([]);
   const [showAdd, setShowAdd] = useState(false);
   const intervalRef = useRef(null);
 
@@ -367,6 +360,14 @@ export default function TelegramPanel({ onClose, onOpenSession }) {
     intervalRef.current = setInterval(fetchBots, 3000);
     return () => clearInterval(intervalRef.current);
   }, [fetchBots]);
+
+  // Cargar agentes una sola vez (en vez de por cada BotCard)
+  useEffect(() => {
+    fetch(`${API_BASE}/api/agents`)
+      .then(r => r.json())
+      .then(data => setAllAgents(Array.isArray(data) ? data : []))
+      .catch(() => {});
+  }, []);
 
   const handleAdd = () => {
     setShowAdd(false);
@@ -409,6 +410,7 @@ export default function TelegramPanel({ onClose, onOpenSession }) {
           <BotCard
             key={bot.key}
             bot={bot}
+            allAgents={allAgents}
             onOpenSession={(sessionId) => { onOpenSession(sessionId); onClose(); }}
             onRefresh={fetchBots}
           />

--- a/client/src/components/TerminalPanel.jsx
+++ b/client/src/components/TerminalPanel.jsx
@@ -138,8 +138,8 @@ export default function TerminalPanel({ session, wsUrl, active, onSessionId }) {
   // Cuando este panel se vuelve activo, re-ajustar el tamaño
   useEffect(() => {
     if (active && fitAddonRef.current && xtermRef.current) {
-      // Pequeño delay para que el DOM se actualice antes de medir
-      const t = setTimeout(() => {
+      // Esperar al siguiente frame para que el DOM se actualice antes de medir
+      const rafId = requestAnimationFrame(() => {
         fitAddonRef.current.fit();
         const ws = wsRef.current;
         if (ws && ws.readyState === WebSocket.OPEN) {
@@ -149,8 +149,8 @@ export default function TerminalPanel({ session, wsUrl, active, onSessionId }) {
             rows: xtermRef.current.rows,
           }));
         }
-      }, 50);
-      return () => clearTimeout(t);
+      });
+      return () => cancelAnimationFrame(rafId);
     }
   }, [active]);
 


### PR DESCRIPTION
## Summary
- **React.memo** en `ChatRow`, `BotCard`, `AddBotForm` — evita re-renders innecesarios en el polling de 3s
- **Agents fetch centralizado** — movido de cada `BotCard` a `TelegramPanel` (1 fetch vs N fetches)
- **requestAnimationFrame** reemplaza `setTimeout(50)` en `TerminalPanel` para resize más preciso
- **Memory leak fix** — `httpIdToTabId` Map en `App.jsx` ahora se limpia al cerrar sesiones

Closes #53

## Test plan
- [ ] Abrir TelegramPanel con múltiples bots — verificar que no hay re-renders excesivos (React DevTools)
- [ ] Cambiar entre tabs de terminal — verificar que el resize funciona correctamente
- [ ] Abrir y cerrar múltiples sesiones desde Telegram — verificar que el Map no crece indefinidamente
- [ ] Build de producción sin errores