### PR TITLE
fix: mobile viewport dvh + eager panel CSS

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -2,7 +2,7 @@
 <html lang="es">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="description" content="Terminal web interactiva con soporte para múltiples sesiones, IA y Telegram" />
     <meta name="theme-color" content="#1a1a1a" />

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -18,6 +18,7 @@
   display: flex;
   flex-direction: column;
   height: 100vh;
+  height: 100dvh;
   overflow: hidden;
 }
 

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -5,6 +5,9 @@ import CommandBar from './components/CommandBar.jsx';
 import TerminalPanel from './components/TerminalPanel.jsx';
 import { API_BASE, WS_URL } from './config.js';
 import './App.css';
+import './components/AgentsPanel.css';
+import './components/TelegramPanel.css';
+import './components/WebChatPanel.css';
 
 // Lazy-load paneles que se abren bajo demanda
 const TelegramPanel = lazy(() => import('./components/TelegramPanel.jsx'));

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -9,11 +9,13 @@ body {
   color: #f0f0f0;
   font-family: 'Courier New', monospace;
   height: 100vh;
+  height: 100dvh;
   overflow: hidden;
 }
 
 #root {
   height: 100vh;
+  height: 100dvh;
   display: flex;
   flex-direction: column;
 }


### PR DESCRIPTION
## Summary
- Reemplaza `100vh` por `100dvh` (con fallback a `vh`) en `body`, `#root` y `.app` para que el layout se adapte a la barra del navegador móvil
- Agrega `viewport-fit=cover` e `interactive-widget=resizes-content` al meta viewport
- Importa los CSS de paneles lazy-loaded (`AgentsPanel`, `TelegramPanel`, `WebChatPanel`) en `App.jsx` para que los estilos estén disponibles desde el inicio

## Test plan
- [x] Verificado en celular: el contenido ya no queda tapado por la barra del navegador
- [x] Verificado que al abrir secciones (chat, agentes) los estilos cargan correctamente