### PR TITLE
feat: WebChat chat_status + ask_permission — completes roadmap 5.5

### DIFF
--- a/client/src/components/WebChatPanel.jsx
+++ b/client/src/components/WebChatPanel.jsx
@@ -149,6 +149,24 @@ export default function WebChatPanel({ onClose }) {
             });
             break;
 
+          case 'chat_status':
+            if (msg.status === 'thinking') setStatusText(msg.detail ? `🤔 ${msg.detail}...` : '🤔 Pensando...');
+            else if (msg.status === 'tool_use') setStatusText(`⚡ ${msg.detail || 'Ejecutando tool'}...`);
+            else setStatusText(null);
+            break;
+
+          case 'chat_ask_permission':
+            setMessages(prev => [...prev, {
+              role: 'system',
+              content: `🔐 Permiso requerido — herramienta: ${msg.tool}\n${msg.args}`,
+              askPermission: true,
+              buttons: [
+                { text: '✅ Aprobar', callback_data: msg.approveId },
+                { text: '❌ Rechazar', callback_data: msg.rejectId },
+              ],
+            }]);
+            break;
+
           case 'chat:status':
             if (msg.status === 'transcribing') setStatusText('Transcribiendo...');
             else if (msg.status === 'synthesizing') setStatusText('Generando audio...');


### PR DESCRIPTION
## Summary
- `chat_status` `thinking` → muestra `🤔 Pensando...` en la barra de estado
- `chat_status` `tool_use` → muestra `⚡ <tool>...`
- `chat_status` `done` → limpia la barra de estado
- `chat_ask_permission` → agrega mensaje de sistema con botones **✅ Aprobar / ❌ Rechazar**

## Comportamiento anterior
Los eventos `chat_status` y `chat_ask_permission` llegaban del servidor pero eran ignorados silenciosamente. El modo `ask` en WebChat no podía funcionar.

## Test plan
- [ ] Enviar mensaje con provider API en modo `auto` → ver `🤔 Pensando...` y `⚡ tool...` en status bar
- [ ] Cambiar a modo `ask` (`/modo ask`) → al invocar tool aparece mensaje con botones Aprobar/Rechazar
- [ ] Click en Aprobar → tool se ejecuta
- [ ] Click en Rechazar → tool se cancela