### PR TITLE
feat: complete session 5 — #51 #54 #55 #56

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -131,20 +131,40 @@
     padding: 6px 10px;
     gap: 6px;
   }
-  .app-body-wrap {
-    flex-direction: column;
+  .title {
+    display: none;
   }
-  .app-body-wrap > * {
+  .dot {
+    display: none;
+  }
+  .app-body-wrap {
+    position: relative;
+  }
+  /* Side panels become fullscreen overlay on mobile */
+  .app-body-wrap > *:not(.app-body) {
+    position: absolute;
+    inset: 0;
     width: 100% !important;
     min-width: 0 !important;
     max-width: 100% !important;
     border-left: none !important;
+    z-index: 20;
   }
 }
 
 /* ─── Responsive: tablet (768px-1000px) ───────────────────────────────────── */
 @media (max-width: 1000px) and (min-width: 769px) {
-  .app-body-wrap > * {
+  /* Side panels become overlay on tablet */
+  .app-body-wrap > *:not(.app-body) {
+    position: absolute;
+    right: 0;
+    top: 0;
+    bottom: 0;
     min-width: 0 !important;
+    z-index: 20;
+    box-shadow: -4px 0 16px rgba(0, 0, 0, 0.4);
+  }
+  .app-body-wrap {
+    position: relative;
   }
 }

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -7,6 +7,7 @@ import './App.css';
 import './components/AgentsPanel.css';
 import './components/TelegramPanel.css';
 import './components/WebChatPanel.css';
+import './components/ProvidersPanel.css';
 
 // Lazy-load paneles que se abren bajo demanda
 const TerminalPanel = lazy(() => import('./components/TerminalPanel.jsx'));

--- a/client/src/components/AgentsPanel.css
+++ b/client/src/components/AgentsPanel.css
@@ -165,7 +165,7 @@
   font-family: inherit;
 }
 
-.ap-input:focus { border-color: #667eea; }
+.ap-input:focus { border-color: var(--focus-ring); }
 
 .ap-textarea {
   width: 100%;
@@ -182,7 +182,7 @@
   line-height: 1.5;
 }
 
-.ap-textarea:focus { border-color: #667eea; }
+.ap-textarea:focus { border-color: var(--focus-ring); }
 
 .ap-hint {
   font-size: 10px;
@@ -217,10 +217,10 @@
 .ap-btn:disabled { opacity: 0.45; cursor: not-allowed; }
 
 .ap-btn-primary {
-  background: #667eea;
+  background: var(--btn-primary-bg);
   color: #fff;
 }
-.ap-btn-primary:hover:not(:disabled) { background: #7b8ff0; }
+.ap-btn-primary:hover:not(:disabled) { background: var(--btn-primary-hover); }
 
 .ap-btn-ghost {
   background: transparent;
@@ -232,8 +232,8 @@
 .ap-btn-add {
   width: 100%;
   background: transparent;
-  color: #667eea;
-  border: 1px dashed #445;
+  color: var(--accent-blue);
+  border: 1px dashed var(--border-primary);
   font-size: 12px;
   padding: 8px;
   border-radius: 6px;
@@ -241,7 +241,7 @@
   transition: all 0.15s;
   margin-top: 4px;
 }
-.ap-btn-add:hover { background: #1e2235; border-color: #667eea; }
+.ap-btn-add:hover { background: #1a2235; border-color: var(--accent-blue); }
 
 /* ─── Empty state ─── */
 
@@ -330,7 +330,7 @@
 
 .ap-skill-slug {
   font-size: 10px;
-  color: #667eea;
+  color: var(--accent-blue);
   font-family: monospace;
 }
 

--- a/client/src/components/AgentsPanel.jsx
+++ b/client/src/components/AgentsPanel.jsx
@@ -173,7 +173,7 @@ function SkillsSection() {
       </div>
       {error && <p className="ap-error">{error}</p>}
       {skillsList.length === 0 && (
-        <p className="ap-skills-empty">Sin skills instalados</p>
+        <p className="ap-skills-empty">Sin skills instalados. Escribí un slug arriba para instalar uno.</p>
       )}
       {skillsList.map(s => (
         <div key={s.slug} className="ap-skill-row">
@@ -246,6 +246,9 @@ export default function AgentsPanel({ onClose }) {
           <div className="ap-empty-state">
             <p>Sin agentes configurados</p>
             <p className="ap-empty-hint">Creá un agente con un prompt de rol para usarlo en Telegram con /{'<key>'}</p>
+            <button className="ap-btn ap-btn-primary" style={{ marginTop: 10 }} onClick={handleNewClick}>
+              <Plus size={13} /> Crear primer agente
+            </button>
           </div>
         )}
 

--- a/client/src/components/DirPicker.jsx
+++ b/client/src/components/DirPicker.jsx
@@ -48,10 +48,26 @@ export default function DirPicker({ value, onChange, onClose }) {
     inputRef.current?.focus();
   }, []);
 
-  // Cerrar con Escape
+  // Cerrar con Escape + focus trap
+  const dialogRef = useRef(null);
   useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
     const handleKeyDown = (e) => {
-      if (e.key === 'Escape') onClose();
+      if (e.key === 'Escape') { onClose(); return; }
+      if (e.key === 'Tab') {
+        const focusable = dialog.querySelectorAll('button:not([disabled]), input, select, textarea, [tabindex]:not([tabindex="-1"])');
+        if (focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
     };
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
@@ -72,7 +88,7 @@ export default function DirPicker({ value, onChange, onClose }) {
 
   return (
     <div className="dirpicker-overlay" onClick={onClose}>
-      <div className="dirpicker" onClick={e => e.stopPropagation()} role="dialog" aria-modal="true" aria-labelledby="dirpicker-title">
+      <div ref={dialogRef} className="dirpicker" onClick={e => e.stopPropagation()} role="dialog" aria-modal="true" aria-labelledby="dirpicker-title">
         <div className="dirpicker-header">
           <span id="dirpicker-title">Directorio de trabajo</span>
           <button className="dirpicker-close" onClick={onClose} aria-label="Cerrar"><X size={14} /></button>

--- a/client/src/components/McpsPanel.jsx
+++ b/client/src/components/McpsPanel.jsx
@@ -304,6 +304,9 @@ export default function McpsPanel({ onClose }) {
           <div className="ap-empty-state">
             <p>Sin MCPs configurados</p>
             <p className="ap-empty-hint">Agregá un MCP para extender las capacidades de Claude con herramientas externas.</p>
+            <button className="ap-btn ap-btn-primary" style={{ marginTop: 10 }} onClick={() => { setEditMcp(null); setShowForm(true); }}>
+              <Plus size={13} /> Agregar primer MCP
+            </button>
           </div>
         )}
 

--- a/client/src/components/ProvidersPanel.css
+++ b/client/src/components/ProvidersPanel.css
@@ -1,0 +1,100 @@
+/* ─── ProvidersPanel ───────────────────────────────────────────────────────── */
+
+.pp-msg {
+  padding: 6px 10px;
+  margin-bottom: 8px;
+  background: #1a2a1a;
+  border-radius: 4px;
+  color: var(--accent-green);
+  font-size: 12px;
+}
+
+.pp-section-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  margin-bottom: 6px;
+}
+
+.pp-default-select {
+  width: 100%;
+  padding: 6px 8px;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-primary);
+  border-radius: 4px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.pp-default-select:focus {
+  border-color: var(--focus-ring);
+  outline: none;
+}
+
+.pp-provider-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  margin-bottom: 6px;
+}
+
+.pp-status-badge {
+  padding: 1px 6px;
+  border-radius: 10px;
+  font-size: 10px;
+}
+
+.pp-status-badge.configured {
+  background: #1a3a1a;
+  color: var(--accent-green);
+}
+
+.pp-status-badge.unconfigured {
+  background: #3a1a1a;
+  color: var(--accent-red);
+}
+
+.pp-field-label {
+  font-size: 11px;
+  color: var(--text-hint);
+  display: block;
+  margin-bottom: 3px;
+}
+
+.pp-input {
+  width: 100%;
+  margin-bottom: 6px;
+  padding: 5px 8px;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-primary);
+  border-radius: 4px;
+  font-size: 12px;
+  box-sizing: border-box;
+}
+
+.pp-input:focus {
+  border-color: var(--focus-ring);
+  outline: none;
+}
+
+.pp-select {
+  width: 100%;
+  margin-bottom: 8px;
+  padding: 5px 8px;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-primary);
+  border-radius: 4px;
+  font-size: 12px;
+  box-sizing: border-box;
+}
+
+.pp-select:focus {
+  border-color: var(--focus-ring);
+  outline: none;
+}

--- a/client/src/components/ProvidersPanel.jsx
+++ b/client/src/components/ProvidersPanel.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Settings, X, CheckCircle } from 'lucide-react';
 import { API_BASE } from '../config.js';
+import './ProvidersPanel.css';
 
 const API = API_BASE;
 
@@ -82,19 +83,16 @@ export default function ProvidersPanel({ onClose }) {
       </div>
 
       <div className="ap-body">
-        {msg && (
-          <div style={{ padding: '6px 10px', marginBottom: 8, background: '#1a2a1a', borderRadius: 4, color: '#7ec87e', fontSize: 12 }}>
-            {msg}
-          </div>
-        )}
+        {msg && <div className="pp-msg">{msg}</div>}
 
         {/* Provider por defecto */}
         <div className="ap-section">
-          <div className="ap-section-title">Provider por defecto (Telegram)</div>
+          <div className="pp-section-title">Provider por defecto (Telegram)</div>
           <select
+            className="pp-default-select"
             value={defaultProvider}
             onChange={e => saveDefault(e.target.value)}
-            style={{ width: '100%', padding: '6px 8px', background: '#1e1e2e', color: '#cdd6f4', border: '1px solid #45475a', borderRadius: 4 }}
+            aria-label="Provider por defecto"
           >
             {providers.map(p => (
               <option key={p.name} value={p.name}>{p.label}</option>
@@ -105,33 +103,31 @@ export default function ProvidersPanel({ onClose }) {
         {/* API Keys por provider */}
         {configurable.map(p => (
           <div key={p.name} className="ap-section">
-            <div className="ap-section-title" style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+            <div className="pp-provider-title">
               {p.label}
-              <span style={{
-                padding: '1px 6px', borderRadius: 10, fontSize: 10,
-                background: (p.configured || p.name === 'ollama') ? '#1a3a1a' : '#3a1a1a',
-                color: (p.configured || p.name === 'ollama') ? '#7ec87e' : '#f38ba8',
-              }}>
+              <span className={`pp-status-badge ${(p.configured || p.name === 'ollama') ? 'configured' : 'unconfigured'}`}>
                 {p.name === 'ollama' ? '● local' : p.configured ? '● configurado' : '○ sin key'}
               </span>
             </div>
 
             {p.name !== 'ollama' && (<>
-            <label style={{ fontSize: 11, color: '#6c7086', display: 'block', marginBottom: 3 }}>API Key</label>
+            <label className="pp-field-label">API Key</label>
             <input
+              className="pp-input"
               type="password"
               placeholder="sk-... / AIza... / sk-ant-..."
               value={keys[p.name]?.apiKey || ''}
               onChange={e => setKeys(k => ({ ...k, [p.name]: { ...k[p.name], apiKey: e.target.value } }))}
-              style={{ width: '100%', marginBottom: 6, padding: '5px 8px', background: '#1e1e2e', color: '#cdd6f4', border: '1px solid #45475a', borderRadius: 4, fontSize: 12, boxSizing: 'border-box' }}
+              aria-label={`API Key para ${p.label}`}
             />
             </>)}
 
-            <label style={{ fontSize: 11, color: '#6c7086', display: 'block', marginBottom: 3 }}>Modelo</label>
+            <label className="pp-field-label">Modelo</label>
             <select
+              className="pp-select"
               value={keys[p.name]?.model || p.defaultModel || ''}
               onChange={e => setKeys(k => ({ ...k, [p.name]: { ...k[p.name], model: e.target.value } }))}
-              style={{ width: '100%', marginBottom: 8, padding: '5px 8px', background: '#1e1e2e', color: '#cdd6f4', border: '1px solid #45475a', borderRadius: 4, fontSize: 12, boxSizing: 'border-box' }}
+              aria-label={`Modelo para ${p.label}`}
             >
               {(p.models || []).map(m => (
                 <option key={m} value={m}>{m}</option>
@@ -139,7 +135,7 @@ export default function ProvidersPanel({ onClose }) {
             </select>
 
             <button
-              className="ap-btn"
+              className="ap-btn ap-btn-primary"
               onClick={() => saveProvider(p.name)}
               disabled={saving[p.name]}
             >

--- a/client/src/components/TelegramPanel.css
+++ b/client/src/components/TelegramPanel.css
@@ -388,7 +388,7 @@
   max-width: 110px;
 }
 
-.tg-agent-select:focus { border-color: #667eea; color: var(--text-primary); }
+.tg-agent-select:focus { border-color: var(--focus-ring); color: var(--text-primary); }
 .tg-agent-select option { background: var(--bg-primary); }
 
 /* ─── Agent chip ──────────────────────────────────────────────────────────── */

--- a/client/src/components/WebChatPanel.jsx
+++ b/client/src/components/WebChatPanel.jsx
@@ -621,10 +621,17 @@ export default function WebChatPanel({ onClose }) {
       <div className="wc-messages">
         {messages.length === 0 && (
           <div className="wc-empty">
-            <p>Escribí algo para comenzar</p>
-            <p className="wc-hint">
-              Usá / para comandos: /ayuda
-            </p>
+            {connected ? (
+              <>
+                <p>Escribí algo para comenzar</p>
+                <p className="wc-hint">Usá / para comandos: /ayuda</p>
+              </>
+            ) : (
+              <>
+                <p>Sin conexión al servidor</p>
+                <p className="wc-hint">Verificá que el servidor esté corriendo y recargá la página</p>
+              </>
+            )}
           </div>
         )}
         {messages.map((msg, i) => (


### PR DESCRIPTION
## Summary
Completa los issues pendientes de sesión 5 (Frontend).

- **#51** DirPicker: focus trap (Tab/Shift+Tab cycling) + ref al diálogo
- **#54** Responsive: paneles laterales como overlay en móvil (<768px fullscreen) y tablet (<1000px con shadow)
- **#55** Colores unificados: `#667eea` → `var(--btn-primary-bg)` / `var(--focus-ring)` en AgentsPanel, TelegramPanel. ProvidersPanel migrado de inline styles a CSS classes con design tokens
- **#56** Empty states con CTAs: botón "Crear primer agente" en AgentsPanel, "Agregar primer MCP" en McpsPanel, estado desconectado en WebChatPanel

## Test plan
- [ ] Verificar focus trap en DirPicker (Tab no sale del modal)
- [ ] Probar responsive en móvil (DevTools 375px) — paneles overlay fullscreen
- [ ] Probar responsive en tablet (DevTools 900px) — paneles overlay con shadow
- [ ] Verificar colores consistentes en AgentsPanel, ProvidersPanel, TelegramPanel
- [ ] Verificar empty states con botones en Agents y MCPs vacíos
- [ ] Verificar WebChatPanel muestra estado desconectado cuando no hay WS

Closes #51, #54, #55, #56