### PR TITLE
fix(auth): internal token bypass for MCP tools

### DIFF
--- a/server/mcp/tools/telegram.js
+++ b/server/mcp/tools/telegram.js
@@ -5,10 +5,26 @@ const fs   = require('fs');
 
 const API_BASE = `http://localhost:${process.env.PORT || 3002}`;
 
+// Token interno para bypass de auth en requests localhost
+let _internalToken = null;
+function getInternalToken() {
+  if (!_internalToken) {
+    _internalToken = require('../../middleware/authMiddleware').INTERNAL_TOKEN;
+  }
+  return _internalToken;
+}
+
 // Helper: HTTP request a la API local
 function apiGet(path) {
   return new Promise((resolve, reject) => {
-    http.get(`${API_BASE}${path}`, (res) => {
+    const url = new URL(`${API_BASE}${path}`);
+    const options = {
+      hostname: url.hostname,
+      port: url.port,
+      path: url.pathname + url.search,
+      headers: { 'X-Internal-Token': getInternalToken() },
+    };
+    http.get(options, (res) => {
       let raw = '';
       res.on('data', c => { raw += c; });
       res.on('end', () => {
@@ -33,6 +49,7 @@ function apiPost(path, body, contentType = 'application/json') {
       headers: {
         'Content-Type': contentType,
         'Content-Length': Buffer.byteLength(data),
+        'X-Internal-Token': getInternalToken(),
       },
     };
 

--- a/server/mcp/tools/webchat.js
+++ b/server/mcp/tools/webchat.js
@@ -5,10 +5,26 @@ const fs   = require('fs');
 
 const API_BASE = `http://localhost:${process.env.PORT || 3002}`;
 
+// Token interno para bypass de auth en requests localhost
+let _internalToken = null;
+function getInternalToken() {
+  if (!_internalToken) {
+    _internalToken = require('../../middleware/authMiddleware').INTERNAL_TOKEN;
+  }
+  return _internalToken;
+}
+
 // Helper: HTTP request a la API local
 function apiGet(path) {
   return new Promise((resolve, reject) => {
-    http.get(`${API_BASE}${path}`, (res) => {
+    const url = new URL(`${API_BASE}${path}`);
+    const options = {
+      hostname: url.hostname,
+      port: url.port,
+      path: url.pathname + url.search,
+      headers: { 'X-Internal-Token': getInternalToken() },
+    };
+    http.get(options, (res) => {
       let raw = '';
       res.on('data', c => { raw += c; });
       res.on('end', () => {
@@ -33,6 +49,7 @@ function apiPost(path, body, contentType = 'application/json') {
       headers: {
         'Content-Type': contentType,
         'Content-Length': Buffer.byteLength(data),
+        'X-Internal-Token': getInternalToken(),
       },
     };
 

--- a/server/middleware/authMiddleware.js
+++ b/server/middleware/authMiddleware.js
@@ -1,16 +1,29 @@
 'use strict';
 
+const crypto = require('crypto');
+
+// Token interno para requests MCP/localhost que no pasan por login
+const INTERNAL_TOKEN = process.env.INTERNAL_API_TOKEN || crypto.randomBytes(32).toString('hex');
+
 /**
  * authMiddleware — extrae y verifica JWT del header Authorization.
  *
  * Si el token es válido, setea req.user = { id, role }.
  * Si no hay token o es inválido, req.user = null (no bloquea).
+ * Requests internos con X-Internal-Token bypasean auth.
  *
  * Para rutas que requieren auth, usar requireAuth().
  */
 function createAuthMiddleware(authService) {
   function authMiddleware(req, _res, next) {
     req.user = null;
+
+    // Bypass: requests internos (MCP tools, etc.)
+    if (req.headers['x-internal-token'] === INTERNAL_TOKEN) {
+      req.user = { id: '__internal__', internal: true };
+      return next();
+    }
+
     const header = req.headers.authorization;
     if (!header || !header.startsWith('Bearer ')) return next();
 
@@ -31,5 +44,7 @@ function createAuthMiddleware(authService) {
 
   return { authMiddleware, requireAuth };
 }
+
+createAuthMiddleware.INTERNAL_TOKEN = INTERNAL_TOKEN;
 
 module.exports = createAuthMiddleware;


### PR DESCRIPTION
## Summary
- MCP tools (telegram, webchat) call REST API via localhost HTTP
- The new requireAuth middleware from PR #93 was blocking these internal requests
- Added `X-Internal-Token` header bypass with random per-instance secret
- Internal calls authenticate as `__internal__` user

## Test plan
- [x] 276 unit tests pass
- [ ] Restart server and verify MCP telegram tools work