### PR TITLE
fix(telegram): fallback for direct text responses

### DIFF
--- a/server/channels/telegram/MessageProcessor.js
+++ b/server/channels/telegram/MessageProcessor.js
@@ -203,24 +203,12 @@ class MessageProcessor {
         }
       }
 
-      if (sentMsg) {
+      if (result.text && !result.usedMcpTools) {
+        // Fallback: la IA no usó MCP tools para comunicarse → enviar texto directo
+        tdbg('send', `fallback: enviando texto directo (${result.text.length} chars, usedMcpTools=false)`);
+        await bot._responseRenderer.sendResult(bot, chatId, result.text, sentMsg);
+      } else if (sentMsg) {
         try { await bot._apiCall('deleteMessage', { chat_id: chatId, message_id: sentMsg.message_id }); } catch (e) { tdbg('send', `deleteStatusMsg FAIL: ${e.message}`); }
-      }
-      if (result.text) {
-        const suppressed = result.text.trim();
-        tdbg('send', `texto suprimido (${suppressed.length} chars) — guardando en memoria`);
-        if (suppressed.length > 10 && this._memory && agentKey) {
-          try {
-            const ts = new Date().toISOString().replace(/[:.]/g, '-');
-            const filename = `_leaked-text-${ts}.md`;
-            this._memory.write(agentKey, filename,
-              `---\ntype: leaked-response\nts: ${new Date().toISOString()}\nchatId: ${chatId}\n---\n${suppressed}`
-            );
-            tdbg('send', `texto suprimido guardado en memoria → ${filename}`);
-          } catch (e) {
-            tdbg('send', `error guardando texto suprimido: ${e.message}`);
-          }
-        }
       }
 
       if (this._tts && this._tts.isEnabled() && result.text) {

--- a/server/core/ClaudePrintSession.js
+++ b/server/core/ClaudePrintSession.js
@@ -83,7 +83,12 @@ class ClaudePrintSession {
       let exited = false;
       let eventCount = 0;
       let usedMcpTools = false;
-      const TELEGRAM_TOOLS = ['telegram_send_message', 'telegram_send_photo', 'telegram_send_document'];
+      const COMM_TOOLS = [
+        'telegram_send_message', 'telegram_send_photo', 'telegram_send_document',
+        'telegram_send_voice', 'telegram_send_video', 'telegram_edit_message',
+        'webchat_send_message', 'webchat_send_photo', 'webchat_send_document',
+        'webchat_send_voice', 'webchat_send_video', 'webchat_edit_message',
+      ];
 
       const emitStatus = (status, detail = null) => {
         if (onStatus) onStatus(status, detail);
@@ -112,8 +117,8 @@ class ClaudePrintSession {
             // Detectar inicio de tool_use para status
             if (inner.type === 'content_block_start' && inner.content_block?.type === 'tool_use') {
               const toolName = inner.content_block.name || 'herramienta';
-              if (TELEGRAM_TOOLS.includes(toolName)) usedMcpTools = true;
-              cpdbg('event', `#${eventCount} tool_use start: ${toolName} isTelegramTool=${TELEGRAM_TOOLS.includes(toolName)}`);
+              if (COMM_TOOLS.includes(toolName)) usedMcpTools = true;
+              cpdbg('event', `#${eventCount} tool_use start: ${toolName} isTelegramTool=${COMM_TOOLS.includes(toolName)}`);
               emitStatus('tool_use', toolName);
             }
             // Detectar inicio de bloque de texto
@@ -138,7 +143,7 @@ class ClaudePrintSession {
             cpdbg('event', `#${eventCount} assistant content=${Array.isArray(content) ? content.length + ' blocks' : 'none'} fullText=${fullText.length}`);
             if (Array.isArray(content)) {
               // Detectar tool_use de telegram en bloques de assistant
-              const hasTelegramTool = content.some(b => b.type === 'tool_use' && TELEGRAM_TOOLS.includes(b.name));
+              const hasTelegramTool = content.some(b => b.type === 'tool_use' && COMM_TOOLS.includes(b.name));
               if (hasTelegramTool) usedMcpTools = true;
 
               const textBlock = content.find(b => b.type === 'text');


### PR DESCRIPTION
## Summary
- When the AI responds with text but doesn't use MCP communication tools (`telegram_send_message`, etc.), the response was silently suppressed and saved to memory as "leaked text" — the user received nothing
- Now falls back to sending text directly via `ResponseRenderer.sendResult()` when `usedMcpTools` is false
- Expanded `COMM_TOOLS` detection in `ClaudePrintSession` from 3 to 12 tools (covers all telegram + webchat send/edit tools)

## Test plan
- [ ] Send a message via Telegram and verify the response arrives
- [ ] Verify that when the AI uses `telegram_send_message` tool, no duplicate message is sent
- [ ] Verify webchat responses still work correctly