### PR TITLE
refactor(webclient): split WebChatPanel (Fase 1)

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,7 +1,9 @@
-import { useState, useCallback, useRef, useEffect, lazy, Suspense } from 'react';
+import { useState, useCallback, useRef, useEffect, useReducer, lazy, Suspense } from 'react';
 import { MessageCircle, Settings, Plug, Users, Bot } from 'lucide-react';
 import TabBar from './components/TabBar.jsx';
 import CommandBar from './components/CommandBar.jsx';
+import ErrorBoundary from './components/ErrorBoundary.jsx';
+import { AuthProvider } from './contexts/AuthContext.jsx';
 import { API_BASE, WS_URL } from './config.js';
 import './App.css';
 import './components/AgentsPanel.css';
@@ -16,6 +18,7 @@ const AgentsPanel = lazy(() => import('./components/AgentsPanel.jsx'));
 const ProvidersPanel = lazy(() => import('./components/ProvidersPanel.jsx'));
 const McpsPanel = lazy(() => import('./components/McpsPanel.jsx'));
 const WebChatPanel = lazy(() => import('./components/WebChatPanel.jsx'));
+
 let nextId = 0;
 
 function createSession(command = null, type = 'pty', httpSessionId = null, provider = null) {
@@ -35,18 +38,35 @@ function createSession(command = null, type = 'pty', httpSessionId = null, provi
   return { id, title, command, type, httpSessionId, provider };
 }
 
+// ── Panel reducer: reemplaza 5 booleans por un estado único ──────────────────
+
+function panelReducer(state, action) {
+  switch (action.type) {
+    case 'toggle':
+      return state === action.panel ? null : action.panel;
+    case 'close':
+      return null;
+    default:
+      return state;
+  }
+}
+
+const PANELS = [
+  { key: 'chat', icon: MessageCircle, label: 'Chat con IA' },
+  { key: 'providers', icon: Settings, label: 'Providers de IA' },
+  { key: 'mcps', icon: Plug, label: 'MCPs' },
+  { key: 'agents', icon: Users, label: 'Agentes personalizados' },
+  { key: 'telegram', icon: Bot, label: 'Panel de Telegram' },
+];
+
 export default function App() {
   const [sessions, setSessions] = useState(() => {
     const initial = createSession();
     return [initial];
   });
   const [activeId, setActiveId] = useState(() => nextId);
-  const [telegramOpen, setTelegramOpen] = useState(false);
+  const [activePanel, dispatchPanel] = useReducer(panelReducer, null);
   const [telegramChatsCount, setTelegramChatsCount] = useState(0);
-  const [agentsOpen, setAgentsOpen] = useState(false);
-  const [providersOpen, setProvidersOpen] = useState(false);
-  const [mcpsOpen, setMcpsOpen] = useState(false);
-  const [chatOpen, setChatOpen] = useState(false);
 
   // Mapa: httpSessionId → frontendTabId
   const httpIdToTabId = useRef(new Map());
@@ -73,28 +93,27 @@ export default function App() {
             return [...prev, s];
           });
         }
-      } catch { /* silenciar — no contaminar consola */ }
+      } catch { /* silenciar */ }
     };
-    ws.onerror = () => {}; // evitar error en consola cuando server no está disponible
+    ws.onerror = () => {};
     return () => ws.close();
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Obtener cantidad de chats activos del bot para el badge
   useEffect(() => {
-    if (!telegramOpen) {
-      const interval = setInterval(async () => {
-        try {
-          const res = await fetch(`${API_BASE}/api/telegram/bots`);
-          const bots = await res.json();
-          const chats = Array.isArray(bots)
-            ? bots.reduce((n, b) => n + (b.chats?.length || 0), 0)
-            : 0;
-          setTelegramChatsCount(chats);
-        } catch { /* silenciar — polling en background */ }
-      }, 5000);
-      return () => clearInterval(interval);
-    }
-  }, [telegramOpen]);
+    if (activePanel === 'telegram') return;
+    const interval = setInterval(async () => {
+      try {
+        const res = await fetch(`${API_BASE}/api/telegram/bots`);
+        const bots = await res.json();
+        const chats = Array.isArray(bots)
+          ? bots.reduce((n, b) => n + (b.chats?.length || 0), 0)
+          : 0;
+        setTelegramChatsCount(chats);
+      } catch { /* silenciar — polling en background */ }
+    }, 5000);
+    return () => clearInterval(interval);
+  }, [activePanel]);
 
   const openNew = useCallback((command = null, type = 'pty', httpSessionId = null, provider = null) => {
     const session = createSession(command, type, httpSessionId, provider);
@@ -106,7 +125,6 @@ export default function App() {
   const closeSession = useCallback((id) => {
     setSessions((prev) => {
       const next = prev.filter((s) => s.id !== id);
-      // Limpiar httpIdToTabId para la sesión cerrada (evitar memory leak)
       for (const [httpId, tabId] of httpIdToTabId.current) {
         if (tabId === id) { httpIdToTabId.current.delete(httpId); break; }
       }
@@ -122,133 +140,105 @@ export default function App() {
     });
   }, [activeId]);
 
-  // Registrar httpSessionId → frontendTabId
   const handleSessionId = useCallback((frontendTabId, httpId) => {
     httpIdToTabId.current.set(httpId, frontendTabId);
   }, []);
 
-  // Abrir o activar tab por httpSessionId (llamado desde TelegramPanel)
   const handleOpenSession = useCallback((httpSessionId) => {
     const tabId = httpIdToTabId.current.get(httpSessionId);
     if (tabId) {
       setActiveId(tabId);
-      setTelegramOpen(false);
+      dispatchPanel({ type: 'close' });
     } else {
-      // La sesión no tiene tab abierto → abrir uno nuevo adjunto a esa sesión HTTP
       openNew(null, 'pty', httpSessionId);
-      setTelegramOpen(false);
+      dispatchPanel({ type: 'close' });
     }
   }, [openNew]);
 
   return (
-    <div className="app">
-      <a href="#terminal-main" className="skip-link">Ir al contenido principal</a>
-      <header className="app-header">
-        <span className="dot red" aria-hidden="true" />
-        <span className="dot yellow" aria-hidden="true" />
-        <span className="dot green" aria-hidden="true" />
-        <h1 className="title">Terminal Live</h1>
+    <AuthProvider>
+      <div className="app">
+        <a href="#terminal-main" className="skip-link">Ir al contenido principal</a>
+        <header className="app-header">
+          <span className="dot red" aria-hidden="true" />
+          <span className="dot yellow" aria-hidden="true" />
+          <span className="dot green" aria-hidden="true" />
+          <h1 className="title">Terminal Live</h1>
 
-        <nav className="header-right" aria-label="Paneles">
-          <button
-            className={`telegram-btn ${chatOpen ? 'active' : ''}`}
-            onClick={() => { setChatOpen(v => !v); setProvidersOpen(false); setMcpsOpen(false); setAgentsOpen(false); setTelegramOpen(false); }}
-            aria-label="Chat con IA"
-            aria-pressed={chatOpen}
-          >
-            <MessageCircle size={16} aria-hidden="true" />
-          </button>
-          <button
-            className={`telegram-btn ${providersOpen ? 'active' : ''}`}
-            onClick={() => { setProvidersOpen(v => !v); setMcpsOpen(false); setAgentsOpen(false); setTelegramOpen(false); setChatOpen(false); }}
-            aria-label="Providers de IA"
-            aria-pressed={providersOpen}
-          >
-            <Settings size={16} aria-hidden="true" />
-          </button>
-          <button
-            className={`telegram-btn ${mcpsOpen ? 'active' : ''}`}
-            onClick={() => { setMcpsOpen(v => !v); setProvidersOpen(false); setAgentsOpen(false); setTelegramOpen(false); setChatOpen(false); }}
-            aria-label="MCPs"
-            aria-pressed={mcpsOpen}
-          >
-            <Plug size={16} aria-hidden="true" />
-          </button>
-          <button
-            className={`telegram-btn ${agentsOpen ? 'active' : ''}`}
-            onClick={() => { setAgentsOpen(v => !v); setMcpsOpen(false); setTelegramOpen(false); setProvidersOpen(false); setChatOpen(false); }}
-            aria-label="Agentes personalizados"
-            aria-pressed={agentsOpen}
-          >
-            <Users size={16} aria-hidden="true" />
-          </button>
-          <button
-            className={`telegram-btn ${telegramOpen ? 'active' : ''}`}
-            onClick={() => { setTelegramOpen(v => !v); setMcpsOpen(false); setAgentsOpen(false); setProvidersOpen(false); setChatOpen(false); }}
-            aria-label="Panel de Telegram"
-            aria-pressed={telegramOpen}
-          >
-            <Bot size={16} aria-hidden="true" />
-            {telegramChatsCount > 0 && !telegramOpen && (
-              <span className="telegram-badge">{telegramChatsCount}</span>
-            )}
-          </button>
-        </nav>
-      </header>
+          <nav className="header-right" aria-label="Paneles">
+            {PANELS.map(({ key, icon: Icon, label }) => (
+              <button
+                key={key}
+                className={`telegram-btn ${activePanel === key ? 'active' : ''}`}
+                onClick={() => dispatchPanel({ type: 'toggle', panel: key })}
+                aria-label={label}
+                aria-pressed={activePanel === key}
+              >
+                <Icon size={16} aria-hidden="true" />
+                {key === 'telegram' && telegramChatsCount > 0 && activePanel !== 'telegram' && (
+                  <span className="telegram-badge">{telegramChatsCount}</span>
+                )}
+              </button>
+            ))}
+          </nav>
+        </header>
 
-      <TabBar
-        sessions={sessions}
-        activeId={activeId}
-        onSelect={setActiveId}
-        onClose={closeSession}
-        onNew={() => openNew()}
-      />
+        <TabBar
+          sessions={sessions}
+          activeId={activeId}
+          onSelect={setActiveId}
+          onClose={closeSession}
+          onNew={() => openNew()}
+        />
 
-      <CommandBar
-        onCommand={openNew}
-        onClaude={(sys) => openNew(sys || null, 'ai', null, 'anthropic')}
-        onAI={(provider, sys) => openNew(sys || null, 'ai', null, provider)}
-      />
+        <CommandBar
+          onCommand={openNew}
+          onClaude={(sys) => openNew(sys || null, 'ai', null, 'anthropic')}
+          onAI={(provider, sys) => openNew(sys || null, 'ai', null, provider)}
+        />
 
-      <div className="app-body-wrap">
-        <main id="terminal-main" className="app-body">
-          {sessions.map((session) => (
-            <TerminalPanel
-              key={session.id}
-              session={session}
-              wsUrl={WS_URL}
-              active={session.id === activeId}
-              onClose={() => closeSession(session.id)}
-              onSessionId={(httpId) => handleSessionId(session.id, httpId)}
-            />
-          ))}
-        </main>
+        <div className="app-body-wrap">
+          <main id="terminal-main" className="app-body">
+            {sessions.map((session) => (
+              <TerminalPanel
+                key={session.id}
+                session={session}
+                wsUrl={WS_URL}
+                active={session.id === activeId}
+                onClose={() => closeSession(session.id)}
+                onSessionId={(httpId) => handleSessionId(session.id, httpId)}
+              />
+            ))}
+          </main>
 
-        <Suspense fallback={null}>
-          {telegramOpen && (
-            <TelegramPanel
-              onClose={() => setTelegramOpen(false)}
-              onOpenSession={handleOpenSession}
-            />
-          )}
+          <Suspense fallback={null}>
+            <ErrorBoundary>
+              {activePanel === 'telegram' && (
+                <TelegramPanel
+                  onClose={() => dispatchPanel({ type: 'close' })}
+                  onOpenSession={handleOpenSession}
+                />
+              )}
 
-          {agentsOpen && (
-            <AgentsPanel onClose={() => setAgentsOpen(false)} />
-          )}
+              {activePanel === 'agents' && (
+                <AgentsPanel onClose={() => dispatchPanel({ type: 'close' })} />
+              )}
 
-          {providersOpen && (
-            <ProvidersPanel onClose={() => setProvidersOpen(false)} />
-          )}
+              {activePanel === 'providers' && (
+                <ProvidersPanel onClose={() => dispatchPanel({ type: 'close' })} />
+              )}
 
-          {mcpsOpen && (
-            <McpsPanel onClose={() => setMcpsOpen(false)} />
-          )}
+              {activePanel === 'mcps' && (
+                <McpsPanel onClose={() => dispatchPanel({ type: 'close' })} />
+              )}
 
-          {chatOpen && (
-            <WebChatPanel onClose={() => setChatOpen(false)} />
-          )}
-        </Suspense>
+              {activePanel === 'chat' && (
+                <WebChatPanel onClose={() => dispatchPanel({ type: 'close' })} />
+              )}
+            </ErrorBoundary>
+          </Suspense>
+        </div>
       </div>
-    </div>
+    </AuthProvider>
   );
 }

--- a/client/src/components/ErrorBoundary.jsx
+++ b/client/src/components/ErrorBoundary.jsx
@@ -1,0 +1,35 @@
+import { Component } from 'react';
+
+export default class ErrorBoundary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true, error };
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div style={{
+          padding: '20px', textAlign: 'center', color: '#e74c3c',
+          background: '#1a1a1a', borderRadius: '8px', margin: '10px',
+        }}>
+          <p style={{ marginBottom: '10px' }}>Algo salió mal en este panel.</p>
+          <button
+            onClick={() => this.setState({ hasError: false, error: null })}
+            style={{
+              padding: '6px 16px', background: '#333', color: '#fff',
+              border: '1px solid #555', borderRadius: '4px', cursor: 'pointer',
+            }}
+          >
+            Reintentar
+          </button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/client/src/components/WebChatPanel.jsx
+++ b/client/src/components/WebChatPanel.jsx
@@ -1,8 +1,13 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
-import { Trash2, Paperclip, Volume2, Send, Mic, Square, X, Pause, Play, LogIn, LogOut, User } from 'lucide-react';
-import { API_BASE, WS_URL } from '../config.js';
-import { getStoredTokens, setStoredTokens, getStoredUser, setStoredUser, clearStoredTokens, isTokenExpired, refreshTokens as refreshAuthTokens, linkSession } from '../authUtils.js';
-import ChatMessage from './ChatMessage.jsx';
+import { useState, useEffect, useCallback } from 'react';
+import { API_BASE } from '../config.js';
+import { useAuth } from '../contexts/AuthContext.jsx';
+import useChatSocket from '../hooks/useChatSocket.js';
+import useAudioRecorder from '../hooks/useAudioRecorder.js';
+import useFileUpload from '../hooks/useFileUpload.js';
+import ChatHeader from './chat/ChatHeader.jsx';
+import StatusBar from './chat/StatusBar.jsx';
+import MessageList from './chat/MessageList.jsx';
+import ChatInput from './chat/ChatInput.jsx';
 import AuthPanel from './AuthPanel.jsx';
 import './WebChatPanel.css';
 
@@ -15,32 +20,191 @@ export default function WebChatPanel({ onClose }) {
   const [providers, setProviders] = useState([]);
   const [agentsList, setAgentsList] = useState([]);
   const [cwd, setCwd] = useState('~');
-  const [connected, setConnected] = useState(false);
-  const [recording, setRecording] = useState(false);
-  const [recPaused, setRecPaused] = useState(false);
-  const [recTime, setRecTime] = useState(0);
   const [statusText, setStatusText] = useState(null);
-  const [authUser, setAuthUser] = useState(() => getStoredUser());
-  const [showAuthPanel, setShowAuthPanel] = useState(false);
-  const wsRef = useRef(null);
-  const sessionIdRef = useRef(null);
-  const messagesEndRef = useRef(null);
-  const inputRef = useRef(null);
-  const mediaRecorderRef = useRef(null);
-  const audioChunksRef = useRef([]);
-  const recordStartRef = useRef(0);
-  const recTimerRef = useRef(null);
-  const recCancelledRef = useRef(false);
-  const recTimeRef = useRef(0);
-  const streamRef = useRef(null);
-  const fileInputRef = useRef(null);
 
-  // Scroll automático al final
-  useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [messages]);
+  const { user: authUser, showAuthPanel, setShowAuthPanel, handleAuth, handleLogout, handleWsAuthMessage, setWsRef } = useAuth();
 
-  // Cargar providers y agentes
+  // ── WebSocket ──────────────────────────────────────────────────────────────
+
+  const handleWsMessage = useCallback((msg) => {
+    // Delegar mensajes de auth al contexto
+    if (['session_id', 'auth:tokens', 'auth_error', 'session_taken'].includes(msg.type)) {
+      handleWsAuthMessage(msg);
+    }
+
+    switch (msg.type) {
+      case 'chat_chunk':
+        setMessages(prev => {
+          const last = prev[prev.length - 1];
+          if (last && last.role === 'assistant' && last.streaming) {
+            return [...prev.slice(0, -1), { ...last, content: msg.text }];
+          }
+          return [...prev, { role: 'assistant', content: msg.text, streaming: true }];
+        });
+        break;
+
+      case 'chat:message':
+      case 'chat_done':
+        setMessages(prev => {
+          const last = prev[prev.length - 1];
+          const entry = { content: msg.text, streaming: false, ...(msg.buttons ? { buttons: msg.buttons } : {}) };
+          if (last && last.role === 'assistant' && last.streaming) {
+            return [...prev.slice(0, -1), { ...last, ...entry }];
+          }
+          return [...prev, { role: 'assistant', ...entry }];
+        });
+        setSending(false);
+        setStatusText(null);
+        break;
+
+      case 'chat_error':
+        setMessages(prev => [...prev, { role: 'system', content: `Error: ${msg.error}`, error: true }]);
+        setSending(false);
+        setStatusText(null);
+        break;
+
+      case 'command_result':
+        setMessages(prev => [...prev, { role: 'system', content: msg.text }]);
+        if (msg.provider) setProvider(msg.provider);
+        if (msg.agent !== undefined) setAgent(msg.agent);
+        if (msg.cwd) setCwd(msg.cwd);
+        setSending(false);
+        break;
+
+      case 'history_restore':
+        if (Array.isArray(msg.messages) && msg.messages.length > 0) {
+          setMessages(msg.messages.map(m => ({ role: m.role, content: m.content, streaming: false })));
+        }
+        break;
+
+      case 'auth_error':
+        setMessages([{ role: 'system', content: msg.error || 'Error de autenticación', error: true }]);
+        break;
+
+      case 'chat:transcription':
+        setMessages(prev => {
+          const idx = prev.findLastIndex(m => m.role === 'user' && m.audioUrl);
+          if (idx >= 0) {
+            const updated = [...prev];
+            updated[idx] = { ...updated[idx], transcription: msg.text };
+            return updated;
+          }
+          return [...prev, { role: 'user', content: msg.text }];
+        });
+        break;
+
+      case 'chat_status':
+        if (msg.status === 'thinking') setStatusText(msg.detail ? `🤔 ${msg.detail}...` : '🤔 Pensando...');
+        else if (msg.status === 'tool_use') setStatusText(`⚡ ${msg.detail || 'Ejecutando tool'}...`);
+        else setStatusText(null);
+        break;
+
+      case 'chat_ask_permission':
+        setMessages(prev => [...prev, {
+          role: 'system',
+          content: `🔐 Permiso requerido — herramienta: ${msg.tool}\n${msg.args}`,
+          askPermission: true,
+          buttons: [
+            { text: '✅ Aprobar', callback_data: msg.approveId },
+            { text: '❌ Rechazar', callback_data: msg.rejectId },
+          ],
+        }]);
+        break;
+
+      case 'chat:status':
+        if (msg.status === 'transcribing') setStatusText('Transcribiendo...');
+        else if (msg.status === 'synthesizing') setStatusText('Generando audio...');
+        else setStatusText(null);
+        break;
+
+      case 'chat:tts_audio': {
+        const audioUrl = `data:${msg.mimeType || 'audio/wav'};base64,${msg.data}`;
+        setMessages(prev => [...prev, { role: 'tts', audioUrl }]);
+        setStatusText(null);
+        break;
+      }
+
+      case 'chat:tts_error':
+        setStatusText(null);
+        setMessages(prev => [...prev, { role: 'system', content: `TTS: ${msg.error || 'No disponible'}`, error: true }]);
+        break;
+
+      case 'chat:photo': {
+        const src = `data:${msg.mimeType || 'image/png'};base64,${msg.data}`;
+        setMessages(prev => [...prev, {
+          role: 'assistant', msgId: msg.msgId, mediaType: 'photo',
+          mediaSrc: src, caption: msg.caption, filename: msg.filename,
+        }]);
+        setSending(false);
+        setStatusText(null);
+        break;
+      }
+
+      case 'chat:document': {
+        const href = `data:${msg.mimeType || 'application/octet-stream'};base64,${msg.data}`;
+        setMessages(prev => [...prev, {
+          role: 'assistant', msgId: msg.msgId, mediaType: 'document',
+          mediaSrc: href, caption: msg.caption, filename: msg.filename, mimeType: msg.mimeType,
+        }]);
+        setSending(false);
+        setStatusText(null);
+        break;
+      }
+
+      case 'chat:voice': {
+        const voiceUrl = `data:${msg.mimeType || 'audio/ogg'};base64,${msg.data}`;
+        setMessages(prev => [...prev, {
+          role: 'assistant', msgId: msg.msgId, mediaType: 'voice',
+          mediaSrc: voiceUrl, caption: msg.caption,
+        }]);
+        setSending(false);
+        setStatusText(null);
+        break;
+      }
+
+      case 'chat:video': {
+        const videoUrl = `data:${msg.mimeType || 'video/mp4'};base64,${msg.data}`;
+        setMessages(prev => [...prev, {
+          role: 'assistant', msgId: msg.msgId, mediaType: 'video',
+          mediaSrc: videoUrl, caption: msg.caption, filename: msg.filename, mimeType: msg.mimeType,
+        }]);
+        setSending(false);
+        setStatusText(null);
+        break;
+      }
+
+      case 'chat:delete':
+        setMessages(prev => prev.filter(m => m.msgId !== msg.msgId));
+        break;
+
+      case 'chat:edit':
+        setMessages(prev => prev.map(m => m.msgId === msg.msgId ? { ...m, content: msg.text } : m));
+        break;
+
+      case 'session_taken':
+        setMessages(prev => [...prev, {
+          role: 'system', content: msg.message || 'Sesión abierta desde otro dispositivo', error: true,
+        }]);
+        break;
+
+      case 'status':
+        if (msg.provider) setProvider(msg.provider);
+        if (msg.agent !== undefined) setAgent(msg.agent);
+        if (msg.cwd) setCwd(msg.cwd);
+        break;
+    }
+  }, [handleWsAuthMessage]);
+
+  const { connected, send, getSessionId, reconnect, wsRef } = useChatSocket({
+    onMessage: handleWsMessage,
+    onAuthError: () => { handleLogout(); },
+  });
+
+  // Pasar wsRef al AuthContext para refresh proactivo
+  useEffect(() => { setWsRef(wsRef.current); }, [connected, setWsRef, wsRef]);
+
+  // ── Cargar providers y agentes ─────────────────────────────────────────────
+
   useEffect(() => {
     fetch(`${API_BASE}/api/providers`)
       .then(r => r.json())
@@ -55,818 +219,170 @@ export default function WebChatPanel({ onClose }) {
       .catch(() => setStatusText('Error cargando agentes'));
   }, []);
 
-  // Conectar WebSocket
-  useEffect(() => {
-    const ws = new WebSocket(WS_URL);
-    wsRef.current = ws;
-
-    ws.onopen = async () => {
-      const savedSessionId = localStorage.getItem('wc-session-id');
-      const authToken = localStorage.getItem('wc-auth-token') || undefined;
-      let { accessToken } = getStoredTokens();
-
-      // Si el token expiró, intentar renovar antes de conectar
-      if (accessToken && isTokenExpired(accessToken)) {
-        try {
-          const refreshed = await refreshAuthTokens();
-          accessToken = refreshed.accessToken;
-        } catch {
-          accessToken = null;
-          clearStoredTokens();
-          setAuthUser(null);
-        }
-      }
-
-      ws.send(JSON.stringify({
-        type: 'init',
-        sessionType: 'webchat',
-        ...(savedSessionId ? { sessionId: savedSessionId } : {}),
-        ...(authToken ? { authToken } : {}),
-        ...(accessToken ? { jwt: accessToken } : {}),
-      }));
-      setConnected(true);
-    };
-
-    ws.onmessage = (event) => {
-      try {
-        const msg = JSON.parse(event.data);
-        switch (msg.type) {
-          case 'session_id':
-            sessionIdRef.current = msg.id;
-            localStorage.setItem('wc-session-id', msg.id);
-            if (msg.user) {
-              setAuthUser(msg.user);
-              setStoredUser(msg.user);
-            }
-            break;
-
-          case 'auth:tokens':
-            // Tokens renovados via WS
-            if (msg.accessToken) {
-              setStoredTokens(msg.accessToken, msg.refreshToken);
-            }
-            break;
-
-          case 'chat_chunk':
-            setMessages(prev => {
-              const last = prev[prev.length - 1];
-              if (last && last.role === 'assistant' && last.streaming) {
-                return [...prev.slice(0, -1), { ...last, content: msg.text }];
-              }
-              return [...prev, { role: 'assistant', content: msg.text, streaming: true }];
-            });
-            break;
-
-          case 'chat:message':
-          case 'chat_done':
-            setMessages(prev => {
-              const last = prev[prev.length - 1];
-              const entry = { content: msg.text, streaming: false, ...(msg.buttons ? { buttons: msg.buttons } : {}) };
-              if (last && last.role === 'assistant' && last.streaming) {
-                return [...prev.slice(0, -1), { ...last, ...entry }];
-              }
-              return [...prev, { role: 'assistant', ...entry }];
-            });
-            setSending(false);
-            setStatusText(null);
-            break;
-
-          case 'chat_error':
-            setMessages(prev => [
-              ...prev,
-              { role: 'system', content: `Error: ${msg.error}`, error: true },
-            ]);
-            setSending(false);
-            setStatusText(null);
-            break;
-
-          case 'command_result':
-            setMessages(prev => [
-              ...prev,
-              { role: 'system', content: msg.text },
-            ]);
-            if (msg.provider) setProvider(msg.provider);
-            if (msg.agent !== undefined) setAgent(msg.agent);
-            if (msg.cwd) setCwd(msg.cwd);
-            setSending(false);
-            break;
-
-          case 'history_restore':
-            if (Array.isArray(msg.messages) && msg.messages.length > 0) {
-              setMessages(msg.messages.map(m => ({
-                role: m.role,
-                content: m.content,
-                streaming: false,
-              })));
-            }
-            break;
-
-          case 'auth_error':
-            if (msg.code === 'TOKEN_EXPIRED' || msg.code === 'REFRESH_FAILED') {
-              clearStoredTokens();
-              setAuthUser(null);
-              setShowAuthPanel(true);
-            }
-            setMessages([{ role: 'system', content: msg.error || 'Error de autenticación', error: true }]);
-            setConnected(false);
-            break;
-
-          case 'chat:transcription':
-            // Agregar transcripción al último mensaje de audio del usuario
-            setMessages(prev => {
-              const idx = prev.findLastIndex(m => m.role === 'user' && m.audioUrl);
-              if (idx >= 0) {
-                const updated = [...prev];
-                updated[idx] = { ...updated[idx], transcription: msg.text };
-                return updated;
-              }
-              return [...prev, { role: 'user', content: msg.text }];
-            });
-            break;
-
-          case 'chat_status':
-            if (msg.status === 'thinking') setStatusText(msg.detail ? `🤔 ${msg.detail}...` : '🤔 Pensando...');
-            else if (msg.status === 'tool_use') setStatusText(`⚡ ${msg.detail || 'Ejecutando tool'}...`);
-            else setStatusText(null);
-            break;
-
-          case 'chat_ask_permission':
-            setMessages(prev => [...prev, {
-              role: 'system',
-              content: `🔐 Permiso requerido — herramienta: ${msg.tool}\n${msg.args}`,
-              askPermission: true,
-              buttons: [
-                { text: '✅ Aprobar', callback_data: msg.approveId },
-                { text: '❌ Rechazar', callback_data: msg.rejectId },
-              ],
-            }]);
-            break;
-
-          case 'chat:status':
-            if (msg.status === 'transcribing') setStatusText('Transcribiendo...');
-            else if (msg.status === 'synthesizing') setStatusText('Generando audio...');
-            else setStatusText(null);
-            break;
-
-          case 'chat:tts_audio': {
-            // Mostrar audio TTS como mensaje con reproductor
-            const audioUrl = `data:${msg.mimeType || 'audio/wav'};base64,${msg.data}`;
-            setMessages(prev => [...prev, { role: 'tts', audioUrl }]);
-            setStatusText(null);
-            break;
-          }
-
-          case 'chat:tts_error':
-            setStatusText(null);
-            setMessages(prev => [
-              ...prev,
-              { role: 'system', content: `TTS: ${msg.error || 'No disponible'}`, error: true },
-            ]);
-            break;
-
-          case 'chat:photo': {
-            const src = `data:${msg.mimeType || 'image/png'};base64,${msg.data}`;
-            setMessages(prev => [...prev, {
-              role: 'assistant', msgId: msg.msgId, mediaType: 'photo',
-              mediaSrc: src, caption: msg.caption, filename: msg.filename,
-            }]);
-            setSending(false);
-            setStatusText(null);
-            break;
-          }
-
-          case 'chat:document': {
-            const href = `data:${msg.mimeType || 'application/octet-stream'};base64,${msg.data}`;
-            setMessages(prev => [...prev, {
-              role: 'assistant', msgId: msg.msgId, mediaType: 'document',
-              mediaSrc: href, caption: msg.caption, filename: msg.filename,
-              mimeType: msg.mimeType,
-            }]);
-            setSending(false);
-            setStatusText(null);
-            break;
-          }
-
-          case 'chat:voice': {
-            const voiceUrl = `data:${msg.mimeType || 'audio/ogg'};base64,${msg.data}`;
-            setMessages(prev => [...prev, {
-              role: 'assistant', msgId: msg.msgId, mediaType: 'voice',
-              mediaSrc: voiceUrl, caption: msg.caption,
-            }]);
-            setSending(false);
-            setStatusText(null);
-            break;
-          }
-
-          case 'chat:video': {
-            const videoUrl = `data:${msg.mimeType || 'video/mp4'};base64,${msg.data}`;
-            setMessages(prev => [...prev, {
-              role: 'assistant', msgId: msg.msgId, mediaType: 'video',
-              mediaSrc: videoUrl, caption: msg.caption, filename: msg.filename,
-              mimeType: msg.mimeType,
-            }]);
-            setSending(false);
-            setStatusText(null);
-            break;
-          }
-
-          case 'chat:delete':
-            setMessages(prev => prev.filter(m => m.msgId !== msg.msgId));
-            break;
-
-          case 'chat:edit':
-            setMessages(prev => prev.map(m =>
-              m.msgId === msg.msgId ? { ...m, content: msg.text } : m
-            ));
-            break;
-
-          case 'session_taken':
-            setMessages(prev => [...prev, {
-              role: 'system',
-              content: msg.message || 'Sesión abierta desde otro dispositivo',
-              error: true,
-            }]);
-            setConnected(false);
-            break;
-
-          case 'status':
-            if (msg.provider) setProvider(msg.provider);
-            if (msg.agent !== undefined) setAgent(msg.agent);
-            if (msg.cwd) setCwd(msg.cwd);
-            break;
-        }
-      } catch (err) {
-        /* silenciar — no contaminar consola */
-      }
-    };
-
-    ws.onclose = () => setConnected(false);
-    ws.onerror = () => setStatusText('Error de conexión WebSocket');
-
-    return () => ws.close();
-  }, []);
-
-  // Refresh proactivo del JWT antes de que expire
-  useEffect(() => {
-    const { accessToken } = getStoredTokens();
-    if (!accessToken) return;
-
-    const payload = (() => { try { const b = accessToken.split('.')[1].replace(/-/g, '+').replace(/_/g, '/'); return JSON.parse(atob(b)); } catch { return null; } })();
-    if (!payload?.exp) return;
-
-    const expiresIn = payload.exp * 1000 - Date.now();
-    // Renovar 2 minutos antes de que expire
-    const refreshIn = Math.max(expiresIn - 2 * 60 * 1000, 5000);
-
-    const timer = setTimeout(async () => {
-      try {
-        const refreshed = await refreshAuthTokens();
-        // Enviar nuevo token por WS si está conectado
-        const ws = wsRef.current;
-        if (ws && ws.readyState === WebSocket.OPEN) {
-          ws.send(JSON.stringify({ type: 'auth:refresh', refreshToken: refreshed.refreshToken }));
-        }
-      } catch {
-        clearStoredTokens();
-        setAuthUser(null);
-      }
-    }, refreshIn);
-
-    return () => clearTimeout(timer);
-  }, [authUser]);
-
-  // Cleanup de grabación al desmontar el componente
-  useEffect(() => {
-    return () => {
-      streamRef.current?.getTracks().forEach(t => t.stop());
-      streamRef.current = null;
-      clearInterval(recTimerRef.current);
-    };
-  }, []);
-
   // ── Enviar mensaje ─────────────────────────────────────────────────────────
 
   const sendMessage = useCallback(() => {
     const text = input.trim();
     if (!text || sending) return;
-    const ws = wsRef.current;
-    if (!ws || ws.readyState !== WebSocket.OPEN) return;
-
     setMessages(prev => [...prev, { role: 'user', content: text }]);
     setInput('');
     setSending(true);
+    send({ type: 'chat', text, provider, agent });
+  }, [input, sending, provider, agent, send]);
 
-    ws.send(JSON.stringify({ type: 'chat', text, provider, agent }));
-  }, [input, sending, provider, agent]);
-
-  const handleKeyDown = (e) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault();
-      sendMessage();
-    }
-  };
-
-  const clearChat = () => {
+  const clearChat = useCallback(() => {
     setMessages([]);
-    const ws = wsRef.current;
-    if (ws && ws.readyState === WebSocket.OPEN) {
-      ws.send(JSON.stringify({ type: 'chat', text: '/nueva', provider, agent }));
-    }
-  };
-
-  // ── Auth ─────────────────────────────────────────────────────────────────────
-
-  const handleAuth = useCallback(async (result) => {
-    setAuthUser(result.user);
-    setShowAuthPanel(false);
-
-    // Vincular sesión anónima existente al usuario nuevo
-    const anonSessionId = sessionIdRef.current;
-    if (anonSessionId && anonSessionId !== result.user.id) {
-      try { await linkSession(anonSessionId); } catch {}
-    }
-
-    // Reconectar WS con JWT
-    const ws = wsRef.current;
-    if (ws) {
-      try { ws.close(); } catch {}
-    }
-    // El useEffect de WS se encargará de reconectar
-  }, []);
-
-  const handleLogout = useCallback(() => {
-    const oldSessionId = sessionIdRef.current;
-    clearStoredTokens();
-    setAuthUser(null);
-    // Reconectar como anónimo
-    const ws = wsRef.current;
-    if (ws) {
-      try { ws.close(); } catch {}
-    }
-  }, []);
+    send({ type: 'chat', text: '/nueva', provider, agent });
+  }, [provider, agent, send]);
 
   // ── Botones inline ─────────────────────────────────────────────────────────
 
   const handleButtonClick = useCallback((btn) => {
-    const ws = wsRef.current;
-    if (!ws || ws.readyState !== WebSocket.OPEN) return;
     const data = btn.callback_data || btn.data || btn.text || btn.label;
-    ws.send(JSON.stringify({ type: 'chat:action', data }));
+    send({ type: 'chat:action', data });
     setSending(true);
-  }, []);
+  }, [send]);
 
-  // ── Audio (grabación) ──────────────────────────────────────────────────────
+  // ── Audio ──────────────────────────────────────────────────────────────────
 
-  // Formatear segundos a m:ss
-  const formatRecTime = (s) => {
-    const m = Math.floor(s / 60);
-    const sec = String(s % 60).padStart(2, '0');
-    return `${m}:${sec}`;
-  };
+  const handleRecordingComplete = useCallback(({ blob, audioUrl, audioDuration, mimeType }) => {
+    setMessages(prev => [...prev, { role: 'user', audioUrl, audioDuration, transcription: null }]);
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      const base64 = reader.result.split(',')[1];
+      setSending(true);
+      send({ type: 'chat:audio', data: base64, mimeType });
+    };
+    reader.readAsDataURL(blob);
+  }, [send]);
 
-  // Timer de grabación
-  useEffect(() => {
-    if (recording && !recPaused) {
-      recTimerRef.current = setInterval(() => setRecTime(t => { recTimeRef.current = t + 1; return t + 1; }), 1000);
-    } else {
-      clearInterval(recTimerRef.current);
-    }
-    return () => clearInterval(recTimerRef.current);
-  }, [recording, recPaused]);
+  const recorder = useAudioRecorder({ onRecordingComplete: handleRecordingComplete });
 
-  // Limpiar estado de grabación
-  const cleanupRecording = useCallback(() => {
-    clearInterval(recTimerRef.current);
-    streamRef.current?.getTracks().forEach(t => t.stop());
-    streamRef.current = null;
-    mediaRecorderRef.current = null;
-    setRecording(false);
-    setRecPaused(false);
-    setRecTime(0);
-  }, []);
-
-  // Iniciar grabación
-  const startRecording = useCallback(async () => {
-    if (!navigator.mediaDevices?.getUserMedia) {
-      const hint = !window.isSecureContext
-        ? 'Necesitás acceder via HTTPS o localhost para usar el micrófono'
-        : 'Tu navegador no soporta grabación de audio';
-      setStatusText(hint);
-      setTimeout(() => setStatusText(null), 5000);
-      return;
-    }
-    try {
-      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-      streamRef.current = stream;
-      const mimeType = MediaRecorder.isTypeSupported('audio/webm;codecs=opus')
-        ? 'audio/webm;codecs=opus'
-        : MediaRecorder.isTypeSupported('audio/webm') ? 'audio/webm' : '';
-      const mediaRecorder = mimeType
-        ? new MediaRecorder(stream, { mimeType })
-        : new MediaRecorder(stream);
-      mediaRecorderRef.current = mediaRecorder;
-      audioChunksRef.current = [];
-      recCancelledRef.current = false;
-      recTimeRef.current = 0;
-
-      mediaRecorder.ondataavailable = (e) => {
-        if (e.data.size > 0) audioChunksRef.current.push(e.data);
-      };
-
-      mediaRecorder.onstop = async () => {
-        stream.getTracks().forEach(t => t.stop());
-        streamRef.current = null;
-        if (recCancelledRef.current) return; // Descartado
-        const ws = wsRef.current;
-        if (!ws || ws.readyState !== WebSocket.OPEN) return;
-        const actualMime = mediaRecorder.mimeType || 'audio/webm';
-        const blob = new Blob(audioChunksRef.current, { type: actualMime });
-        const audioUrl = URL.createObjectURL(blob);
-        const audioDuration = recTimeRef.current;
-        setMessages(prev => [...prev, { role: 'user', audioUrl, audioDuration, transcription: null }]);
-        const reader = new FileReader();
-        reader.onloadend = () => {
-          const base64 = reader.result.split(',')[1];
-          setSending(true);
-          ws.send(JSON.stringify({ type: 'chat:audio', data: base64, mimeType: actualMime }));
-        };
-        reader.readAsDataURL(blob);
-      };
-
-      mediaRecorder.start();
-      recordStartRef.current = Date.now();
-      setRecording(true);
-      setRecPaused(false);
-      setRecTime(0);
-    } catch (err) {
-      let errorMsg = 'Micrófono no disponible';
-      if (err.name === 'NotAllowedError') errorMsg = 'Permiso de micrófono denegado. Revisá los permisos del navegador';
-      else if (err.name === 'NotFoundError') errorMsg = 'No se encontró ningún micrófono';
-      else if (err.name === 'NotReadableError') errorMsg = 'El micrófono está siendo usado por otra aplicación';
-      setStatusText(errorMsg);
+  const handleStartRecording = useCallback(async () => {
+    const result = await recorder.start();
+    if (result?.error) {
+      setStatusText(result.error);
       setTimeout(() => setStatusText(null), 5000);
     }
-  }, []);
+  }, [recorder]);
 
-  // Cancelar grabación (descartar)
-  const cancelRecording = useCallback(() => {
-    recCancelledRef.current = true;
-    const mr = mediaRecorderRef.current;
-    if (mr && mr.state !== 'inactive') mr.stop();
-    cleanupRecording();
-  }, [cleanupRecording]);
-
-  // Pausar / reanudar grabación
-  const togglePauseRecording = useCallback(() => {
-    const mr = mediaRecorderRef.current;
-    if (!mr) return;
-    if (mr.state === 'recording') {
-      mr.pause();
-      setRecPaused(true);
-    } else if (mr.state === 'paused') {
-      mr.resume();
-      setRecPaused(false);
-    }
-  }, []);
-
-  // Enviar grabación
-  const sendRecording = useCallback(() => {
-    recCancelledRef.current = false;
-    const mr = mediaRecorderRef.current;
-    if (mr && mr.state !== 'inactive') mr.stop();
-    setRecording(false);
-    setRecPaused(false);
-    setRecTime(0);
-  }, []);
-
-  // ── TTS (reproducir última respuesta) ──────────────────────────────────────
+  // ── TTS ────────────────────────────────────────────────────────────────────
 
   const playTTS = useCallback(() => {
-    const ws = wsRef.current;
-    if (!ws || ws.readyState !== WebSocket.OPEN) return;
-    // Buscar última respuesta del asistente
     const lastAssistant = [...messages].reverse().find(m => m.role === 'assistant');
     if (!lastAssistant) return;
-    ws.send(JSON.stringify({ type: 'chat:tts', text: lastAssistant.content }));
+    send({ type: 'chat:tts', text: lastAssistant.content });
     setStatusText('Generando audio...');
-  }, [messages]);
+  }, [messages, send]);
 
   // ── File upload ────────────────────────────────────────────────────────────
 
-  const handleFileSelect = useCallback((e) => {
-    const files = e.target.files;
-    if (!files || files.length === 0) return;
-    const ws = wsRef.current;
-    if (!ws || ws.readyState !== WebSocket.OPEN) return;
-
-    const file = files[0];
-    const isImage = file.type.startsWith('image/');
-    const reader = new FileReader();
-    reader.onloadend = () => {
-      const base64 = reader.result.split(',')[1];
-      const mediaType = file.type || 'application/octet-stream';
-
-      if (isImage) {
-        const text = input.trim() || 'Describe esta imagen';
-        setMessages(prev => [...prev, {
-          role: 'user',
-          content: `[Imagen: ${file.name}] ${text}`,
-        }]);
-        setInput('');
-        setSending(true);
-        ws.send(JSON.stringify({
-          type: 'chat',
-          text,
-          provider,
-          agent,
-          images: [{ base64, mediaType }],
-        }));
-      } else {
-        const text = input.trim() || 'Analiza este archivo';
-        setMessages(prev => [...prev, {
-          role: 'user',
-          content: `[Archivo: ${file.name}] ${text}`,
-        }]);
-        setInput('');
-        setSending(true);
-        ws.send(JSON.stringify({
-          type: 'chat',
-          text,
-          provider,
-          agent,
-          files: [{ base64, mediaType, name: file.name }],
-        }));
-      }
-    };
-    reader.onerror = () => {
-      setSending(false);
-      setStatusText(`Error leyendo archivo: ${file.name}`);
+  const handleFile = useCallback(({ file, base64, mediaType, isImage, inputText, error }) => {
+    if (error) {
+      setStatusText(error);
       setTimeout(() => setStatusText(null), 5000);
-    };
-    reader.readAsDataURL(file);
-    // Reset input para permitir seleccionar el mismo archivo
-    e.target.value = '';
-  }, [input, provider, agent]);
+      return;
+    }
+    if (isImage) {
+      const text = inputText || 'Describe esta imagen';
+      setMessages(prev => [...prev, { role: 'user', content: `[Imagen: ${file.name}] ${text}` }]);
+      setInput('');
+      setSending(true);
+      send({ type: 'chat', text, provider, agent, images: [{ base64, mediaType }] });
+    } else {
+      const text = inputText || 'Analiza este archivo';
+      setMessages(prev => [...prev, { role: 'user', content: `[Archivo: ${file.name}] ${text}` }]);
+      setInput('');
+      setSending(true);
+      send({ type: 'chat', text, provider, agent, files: [{ base64, mediaType, name: file.name }] });
+    }
+  }, [provider, agent, send]);
 
-  // ── Drag & drop ────────────────────────────────────────────────────────────
+  const { fileInputRef, openPicker, handleFileSelect, handleDrop, handleDragOver } = useFileUpload({ onFile: handleFile });
 
-  const handleDrop = useCallback((e) => {
-    e.preventDefault();
-    const files = e.dataTransfer?.files;
-    if (!files || files.length === 0) return;
-    const ws = wsRef.current;
-    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+  // ── Auth handlers ──────────────────────────────────────────────────────────
 
-    const file = files[0];
-    const isImage = file.type.startsWith('image/');
+  const onAuth = useCallback(async (result) => {
+    await handleAuth(result, getSessionId());
+    reconnect();
+  }, [handleAuth, getSessionId, reconnect]);
 
-    const reader = new FileReader();
-    reader.onloadend = () => {
-      const base64 = reader.result.split(',')[1];
-      const mediaType = file.type || 'application/octet-stream';
+  const onLogout = useCallback(() => {
+    handleLogout();
+    reconnect();
+  }, [handleLogout, reconnect]);
 
-      if (isImage) {
-        const text = input.trim() || 'Describe esta imagen';
-        setMessages(prev => [...prev, {
-          role: 'user',
-          content: `[Imagen: ${file.name}] ${text}`,
-        }]);
-        setInput('');
-        setSending(true);
-        ws.send(JSON.stringify({
-          type: 'chat',
-          text,
-          provider,
-          agent,
-          images: [{ base64, mediaType }],
-        }));
-      } else {
-        const text = input.trim() || 'Analiza este archivo';
-        setMessages(prev => [...prev, {
-          role: 'user',
-          content: `[Archivo: ${file.name}] ${text}`,
-        }]);
-        setInput('');
-        setSending(true);
-        ws.send(JSON.stringify({
-          type: 'chat',
-          text,
-          provider,
-          agent,
-          files: [{ base64, mediaType, name: file.name }],
-        }));
-      }
-    };
-    reader.onerror = () => {
-      setSending(false);
-      setStatusText(`Error leyendo archivo: ${file.name}`);
-      setTimeout(() => setStatusText(null), 5000);
-    };
-    reader.readAsDataURL(file);
-  }, [input, provider, agent]);
+  const handleSettingsChange = useCallback((settings) => {
+    send({ type: 'chat:settings', ...settings });
+  }, [send]);
 
-  const handleDragOver = (e) => e.preventDefault();
+  // ── Render ─────────────────────────────────────────────────────────────────
 
   const providerLabel = providers.find(p => p.name === provider)?.label || provider;
 
   return (
     <div className="wc-panel" onDrop={handleDrop} onDragOver={handleDragOver} role="region" aria-label="Panel de chat web">
-      <div className="wc-header">
-        <span className="wc-header-title">Chat</span>
-        <div className="wc-header-controls">
-          <select
-            className="wc-select"
-            value={provider}
-            aria-label="Proveedor"
-            onChange={e => {
-              const val = e.target.value;
-              setProvider(val);
-              const ws = wsRef.current;
-              if (ws && ws.readyState === WebSocket.OPEN) {
-                ws.send(JSON.stringify({ type: 'chat:settings', provider: val }));
-              }
-            }}
-          >
-            {providers.filter(p => p.configured).map(p => (
-              <option key={p.name} value={p.name}>{p.label || p.name}</option>
-            ))}
-          </select>
-          <select
-            className="wc-select"
-            value={agent || ''}
-            aria-label="Agente"
-            onChange={e => {
-              const val = e.target.value || null;
-              setAgent(val);
-              const ws = wsRef.current;
-              if (ws && ws.readyState === WebSocket.OPEN) {
-                ws.send(JSON.stringify({ type: 'chat:settings', agent: val }));
-              }
-            }}
-          >
-            <option value="">Sin agente</option>
-            {agentsList.map(a => (
-              <option key={a.key} value={a.key}>{a.key}</option>
-            ))}
-          </select>
-          {authUser ? (
-            <button className="wc-user-badge" onClick={handleLogout} title="Cerrar sesión">
-              {authUser.avatar_url
-                ? <img src={authUser.avatar_url} alt="" className="wc-user-avatar" />
-                : <User size={12} />
-              }
-              {authUser.name || authUser.email}
-              <LogOut size={10} />
-            </button>
-          ) : (
-            <button className="wc-login-btn" onClick={() => setShowAuthPanel(true)} title="Iniciar sesión">
-              <LogIn size={12} /> Login
-            </button>
-          )}
-          <button className="wc-btn-icon" onClick={clearChat} title="Nueva conversación" aria-label="Nueva conversación"><Trash2 size={14} /></button>
-          <button className="wc-close" onClick={onClose} aria-label="Cerrar panel de chat"><X size={16} /></button>
-        </div>
-      </div>
+      <ChatHeader
+        providers={providers}
+        provider={provider}
+        setProvider={setProvider}
+        agentsList={agentsList}
+        agent={agent}
+        setAgent={setAgent}
+        authUser={authUser}
+        onLogout={onLogout}
+        onShowAuth={() => setShowAuthPanel(true)}
+        onClear={clearChat}
+        onClose={onClose}
+        onSettingsChange={handleSettingsChange}
+      />
 
-      <div className="wc-status-bar">
-        <span className={`wc-dot ${connected ? 'on' : 'off'}`} />
-        <span>{providerLabel}</span>
-        {agent && <span> &middot; {agent}</span>}
-        <span className="wc-cwd"> &middot; {cwd}</span>
-        {statusText && <span className="wc-status-text"> &middot; {statusText}</span>}
-      </div>
+      <StatusBar
+        connected={connected}
+        providerLabel={providerLabel}
+        agent={agent}
+        cwd={cwd}
+        statusText={statusText}
+      />
 
       {showAuthPanel && (
         <AuthPanel
-          onAuth={handleAuth}
+          onAuth={onAuth}
           onSkip={() => setShowAuthPanel(false)}
         />
       )}
 
-      {!showAuthPanel && <div className="wc-messages">
-        {messages.length === 0 && (
-          <div className="wc-empty">
-            {connected ? (
-              <>
-                <p>Escribí algo para comenzar</p>
-                <p className="wc-hint">Usá / para comandos: /ayuda</p>
-              </>
-            ) : (
-              <>
-                <p>Sin conexión al servidor</p>
-                <p className="wc-hint">Verificá que el servidor esté corriendo y recargá la página</p>
-              </>
-            )}
-          </div>
-        )}
-        {messages.map((msg, i) => (
-          <ChatMessage
-            key={msg.msgId || i}
-            content={msg.content}
-            role={msg.role}
-            streaming={msg.streaming}
-            error={msg.error}
-            providerLabel={providerLabel}
-            buttons={msg.buttons}
-            onButtonClick={handleButtonClick}
-            audioUrl={msg.audioUrl}
-            audioDuration={msg.audioDuration}
-            transcription={msg.transcription}
-            mediaType={msg.mediaType}
-            mediaSrc={msg.mediaSrc}
-            caption={msg.caption}
-            filename={msg.filename}
-            mimeType={msg.mimeType}
-          />
-        ))}
-        {sending && !messages.some(m => m.streaming) && (
-          <div className="wc-msg wc-msg-assistant">
-            <div className="wc-msg-label">{providerLabel}</div>
-            <div className="wc-msg-content wc-typing-indicator">
-              <span className="wc-typing-dot" />
-              <span className="wc-typing-dot" />
-              <span className="wc-typing-dot" />
-            </div>
-          </div>
-        )}
-        <div ref={messagesEndRef} />
-      </div>}
+      {!showAuthPanel && (
+        <MessageList
+          messages={messages}
+          sending={sending}
+          connected={connected}
+          providerLabel={providerLabel}
+          onButtonClick={handleButtonClick}
+        />
+      )}
 
-      {!showAuthPanel && <div className="wc-input-area">
-        {recording ? (
-          /* ── Barra de grabación ── */
-          <div className="wc-rec-bar">
-            <button className="wc-rec-btn wc-rec-cancel" onClick={cancelRecording} title="Cancelar grabación">
-              <Trash2 size={16} />
-            </button>
-            <div className="wc-rec-indicator">
-              <span className={`wc-rec-dot ${recPaused ? 'wc-rec-dot-paused' : ''}`} />
-              <span className="wc-rec-time">{formatRecTime(recTime)}</span>
-            </div>
-            <button className="wc-rec-btn wc-rec-pause" onClick={togglePauseRecording} title={recPaused ? 'Reanudar' : 'Pausar'}>
-              {recPaused ? <Mic size={16} /> : <Pause size={16} />}
-            </button>
-            <button className="wc-rec-btn wc-rec-send" onClick={sendRecording} title="Enviar audio">
-              <Send size={16} />
-            </button>
-          </div>
-        ) : (
-          /* ── Barra normal de input ── */
-          <>
-            <input
-              type="file"
-              ref={fileInputRef}
-              className="wc-file-input"
-              accept="image/*,.pdf,.txt,.doc,.docx,.xls,.xlsx,.csv,.json,.xml,.zip,.rar,.7z,.mp3,.wav,.ogg,.mp4,.webm"
-              onChange={handleFileSelect}
-            />
-            <button
-              className="wc-btn-icon wc-attach-btn"
-              onClick={() => fileInputRef.current?.click()}
-              disabled={!connected || sending}
-              title="Adjuntar archivo"
-            >
-              <Paperclip size={16} />
-            </button>
-            <textarea
-              ref={inputRef}
-              className="wc-input"
-              value={input}
-              onChange={e => setInput(e.target.value)}
-              onKeyDown={handleKeyDown}
-              placeholder="Escribí un mensaje..."
-              rows={1}
-              disabled={!connected}
-            />
-            <button
-              className="wc-btn-icon wc-tts-btn"
-              onClick={playTTS}
-              disabled={!connected || !messages.some(m => m.role === 'assistant')}
-              title="Escuchar última respuesta (TTS)"
-            >
-              <Volume2 size={16} />
-            </button>
-            {input.trim() ? (
-              <button
-                className="wc-send"
-                onClick={sendMessage}
-                disabled={sending || !connected}
-              >
-                {sending ? '...' : <Send size={16} />}
-              </button>
-            ) : (
-              <button
-                className="wc-send wc-send-mic"
-                onClick={startRecording}
-                disabled={!connected || sending}
-                title="Grabar audio"
-              >
-                <Mic size={16} />
-              </button>
-            )}
-          </>
-        )}
-      </div>}
+      {!showAuthPanel && (
+        <ChatInput
+          input={input}
+          setInput={setInput}
+          connected={connected}
+          sending={sending}
+          onSend={sendMessage}
+          onPlayTTS={playTTS}
+          hasTTSContent={messages.some(m => m.role === 'assistant')}
+          recording={recorder.recording}
+          recPaused={recorder.recPaused}
+          recTime={recorder.recTime}
+          onStartRecording={handleStartRecording}
+          onCancelRecording={recorder.cancel}
+          onTogglePause={recorder.togglePause}
+          onSendRecording={recorder.send}
+          fileInputRef={fileInputRef}
+          onOpenFilePicker={openPicker}
+          onFileSelect={handleFileSelect}
+        />
+      )}
     </div>
   );
 }

--- a/client/src/components/chat/ChatHeader.jsx
+++ b/client/src/components/chat/ChatHeader.jsx
@@ -1,0 +1,59 @@
+import { Trash2, X, LogIn, LogOut, User } from 'lucide-react';
+
+export default function ChatHeader({
+  providers, provider, setProvider, agentsList, agent, setAgent,
+  authUser, onLogout, onShowAuth, onClear, onClose, onSettingsChange,
+}) {
+  return (
+    <div className="wc-header">
+      <span className="wc-header-title">Chat</span>
+      <div className="wc-header-controls">
+        <select
+          className="wc-select"
+          value={provider}
+          aria-label="Proveedor"
+          onChange={e => {
+            const val = e.target.value;
+            setProvider(val);
+            onSettingsChange?.({ provider: val });
+          }}
+        >
+          {providers.filter(p => p.configured).map(p => (
+            <option key={p.name} value={p.name}>{p.label || p.name}</option>
+          ))}
+        </select>
+        <select
+          className="wc-select"
+          value={agent || ''}
+          aria-label="Agente"
+          onChange={e => {
+            const val = e.target.value || null;
+            setAgent(val);
+            onSettingsChange?.({ agent: val });
+          }}
+        >
+          <option value="">Sin agente</option>
+          {agentsList.map(a => (
+            <option key={a.key} value={a.key}>{a.key}</option>
+          ))}
+        </select>
+        {authUser ? (
+          <button className="wc-user-badge" onClick={onLogout} title="Cerrar sesión">
+            {authUser.avatar_url
+              ? <img src={authUser.avatar_url} alt="" className="wc-user-avatar" />
+              : <User size={12} />
+            }
+            {authUser.name || authUser.email}
+            <LogOut size={10} />
+          </button>
+        ) : (
+          <button className="wc-login-btn" onClick={onShowAuth} title="Iniciar sesión">
+            <LogIn size={12} /> Login
+          </button>
+        )}
+        <button className="wc-btn-icon" onClick={onClear} title="Nueva conversación" aria-label="Nueva conversación"><Trash2 size={14} /></button>
+        <button className="wc-close" onClick={onClose} aria-label="Cerrar panel de chat"><X size={16} /></button>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/chat/ChatInput.jsx
+++ b/client/src/components/chat/ChatInput.jsx
@@ -1,0 +1,92 @@
+import { useRef, useCallback } from 'react';
+import { Paperclip, Volume2, Send, Mic } from 'lucide-react';
+import RecordingBar from './RecordingBar.jsx';
+
+export default function ChatInput({
+  input, setInput, connected, sending,
+  onSend, onPlayTTS, hasTTSContent,
+  // Audio recorder
+  recording, recPaused, recTime,
+  onStartRecording, onCancelRecording, onTogglePause, onSendRecording,
+  // File upload
+  fileInputRef, onOpenFilePicker, onFileSelect,
+}) {
+  const inputRef = useRef(null);
+
+  const handleKeyDown = useCallback((e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      onSend();
+    }
+  }, [onSend]);
+
+  if (recording) {
+    return (
+      <div className="wc-input-area">
+        <RecordingBar
+          recTime={recTime}
+          recPaused={recPaused}
+          onCancel={onCancelRecording}
+          onTogglePause={onTogglePause}
+          onSend={onSendRecording}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="wc-input-area">
+      <input
+        type="file"
+        ref={fileInputRef}
+        className="wc-file-input"
+        accept="image/*,.pdf,.txt,.doc,.docx,.xls,.xlsx,.csv,.json,.xml,.zip,.rar,.7z,.mp3,.wav,.ogg,.mp4,.webm"
+        onChange={(e) => onFileSelect(e, input.trim())}
+      />
+      <button
+        className="wc-btn-icon wc-attach-btn"
+        onClick={onOpenFilePicker}
+        disabled={!connected || sending}
+        title="Adjuntar archivo"
+      >
+        <Paperclip size={16} />
+      </button>
+      <textarea
+        ref={inputRef}
+        className="wc-input"
+        value={input}
+        onChange={e => setInput(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder="Escribí un mensaje..."
+        rows={1}
+        disabled={!connected}
+      />
+      <button
+        className="wc-btn-icon wc-tts-btn"
+        onClick={onPlayTTS}
+        disabled={!connected || !hasTTSContent}
+        title="Escuchar última respuesta (TTS)"
+      >
+        <Volume2 size={16} />
+      </button>
+      {input.trim() ? (
+        <button
+          className="wc-send"
+          onClick={onSend}
+          disabled={sending || !connected}
+        >
+          {sending ? '...' : <Send size={16} />}
+        </button>
+      ) : (
+        <button
+          className="wc-send wc-send-mic"
+          onClick={onStartRecording}
+          disabled={!connected || sending}
+          title="Grabar audio"
+        >
+          <Mic size={16} />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/chat/MessageList.jsx
+++ b/client/src/components/chat/MessageList.jsx
@@ -1,0 +1,61 @@
+import { useRef, useEffect } from 'react';
+import ChatMessage from '../ChatMessage.jsx';
+
+export default function MessageList({ messages, sending, connected, providerLabel, onButtonClick }) {
+  const messagesEndRef = useRef(null);
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  return (
+    <div className="wc-messages">
+      {messages.length === 0 && (
+        <div className="wc-empty">
+          {connected ? (
+            <>
+              <p>Escribí algo para comenzar</p>
+              <p className="wc-hint">Usá / para comandos: /ayuda</p>
+            </>
+          ) : (
+            <>
+              <p>Sin conexión al servidor</p>
+              <p className="wc-hint">Verificá que el servidor esté corriendo y recargá la página</p>
+            </>
+          )}
+        </div>
+      )}
+      {messages.map((msg, i) => (
+        <ChatMessage
+          key={msg.msgId || i}
+          content={msg.content}
+          role={msg.role}
+          streaming={msg.streaming}
+          error={msg.error}
+          providerLabel={providerLabel}
+          buttons={msg.buttons}
+          onButtonClick={onButtonClick}
+          audioUrl={msg.audioUrl}
+          audioDuration={msg.audioDuration}
+          transcription={msg.transcription}
+          mediaType={msg.mediaType}
+          mediaSrc={msg.mediaSrc}
+          caption={msg.caption}
+          filename={msg.filename}
+          mimeType={msg.mimeType}
+        />
+      ))}
+      {sending && !messages.some(m => m.streaming) && (
+        <div className="wc-msg wc-msg-assistant">
+          <div className="wc-msg-label">{providerLabel}</div>
+          <div className="wc-msg-content wc-typing-indicator">
+            <span className="wc-typing-dot" />
+            <span className="wc-typing-dot" />
+            <span className="wc-typing-dot" />
+          </div>
+        </div>
+      )}
+      <div ref={messagesEndRef} />
+    </div>
+  );
+}

--- a/client/src/components/chat/RecordingBar.jsx
+++ b/client/src/components/chat/RecordingBar.jsx
@@ -1,0 +1,27 @@
+import { Trash2, Mic, Pause, Send } from 'lucide-react';
+
+const formatRecTime = (s) => {
+  const m = Math.floor(s / 60);
+  const sec = String(s % 60).padStart(2, '0');
+  return `${m}:${sec}`;
+};
+
+export default function RecordingBar({ recTime, recPaused, onCancel, onTogglePause, onSend }) {
+  return (
+    <div className="wc-rec-bar">
+      <button className="wc-rec-btn wc-rec-cancel" onClick={onCancel} title="Cancelar grabación">
+        <Trash2 size={16} />
+      </button>
+      <div className="wc-rec-indicator">
+        <span className={`wc-rec-dot ${recPaused ? 'wc-rec-dot-paused' : ''}`} />
+        <span className="wc-rec-time">{formatRecTime(recTime)}</span>
+      </div>
+      <button className="wc-rec-btn wc-rec-pause" onClick={onTogglePause} title={recPaused ? 'Reanudar' : 'Pausar'}>
+        {recPaused ? <Mic size={16} /> : <Pause size={16} />}
+      </button>
+      <button className="wc-rec-btn wc-rec-send" onClick={onSend} title="Enviar audio">
+        <Send size={16} />
+      </button>
+    </div>
+  );
+}

--- a/client/src/components/chat/StatusBar.jsx
+++ b/client/src/components/chat/StatusBar.jsx
@@ -1,0 +1,11 @@
+export default function StatusBar({ connected, providerLabel, agent, cwd, statusText }) {
+  return (
+    <div className="wc-status-bar">
+      <span className={`wc-dot ${connected ? 'on' : 'off'}`} />
+      <span>{providerLabel}</span>
+      {agent && <span> &middot; {agent}</span>}
+      <span className="wc-cwd"> &middot; {cwd}</span>
+      {statusText && <span className="wc-status-text"> &middot; {statusText}</span>}
+    </div>
+  );
+}

--- a/client/src/contexts/AuthContext.jsx
+++ b/client/src/contexts/AuthContext.jsx
@@ -1,0 +1,102 @@
+import { createContext, useContext, useState, useCallback, useEffect, useRef } from 'react';
+import {
+  getStoredUser, setStoredUser, getStoredTokens, setStoredTokens,
+  clearStoredTokens, isTokenExpired, refreshTokens as refreshAuthTokens, linkSession,
+} from '../authUtils.js';
+
+const AuthContext = createContext(null);
+
+export function AuthProvider({ children }) {
+  const [user, setUser] = useState(() => getStoredUser());
+  const [showAuthPanel, setShowAuthPanel] = useState(false);
+  const wsRef = useRef(null);
+
+  // Permitir que useChatSocket pase su wsRef para refresh proactivo
+  const setWsRef = useCallback((ref) => { wsRef.current = ref; }, []);
+
+  // Refresh proactivo del JWT antes de que expire
+  useEffect(() => {
+    const { accessToken } = getStoredTokens();
+    if (!accessToken) return;
+
+    const payload = (() => {
+      try {
+        const b = accessToken.split('.')[1].replace(/-/g, '+').replace(/_/g, '/');
+        return JSON.parse(atob(b));
+      } catch { return null; }
+    })();
+    if (!payload?.exp) return;
+
+    const expiresIn = payload.exp * 1000 - Date.now();
+    const refreshIn = Math.max(expiresIn - 2 * 60 * 1000, 5000);
+
+    const timer = setTimeout(async () => {
+      try {
+        const refreshed = await refreshAuthTokens();
+        const ws = wsRef.current;
+        if (ws && ws.readyState === WebSocket.OPEN) {
+          ws.send(JSON.stringify({ type: 'auth:refresh', refreshToken: refreshed.refreshToken }));
+        }
+      } catch {
+        clearStoredTokens();
+        setUser(null);
+      }
+    }, refreshIn);
+
+    return () => clearTimeout(timer);
+  }, [user]);
+
+  const handleAuth = useCallback(async (result, sessionId) => {
+    setUser(result.user);
+    setShowAuthPanel(false);
+
+    if (sessionId && sessionId !== result.user.id) {
+      try { await linkSession(sessionId); } catch {}
+    }
+  }, []);
+
+  const handleLogout = useCallback(() => {
+    clearStoredTokens();
+    setUser(null);
+  }, []);
+
+  const handleWsAuthMessage = useCallback((msg) => {
+    switch (msg.type) {
+      case 'session_id':
+        if (msg.user) {
+          setUser(msg.user);
+          setStoredUser(msg.user);
+        }
+        break;
+      case 'auth:tokens':
+        if (msg.accessToken) {
+          setStoredTokens(msg.accessToken, msg.refreshToken);
+        }
+        break;
+      case 'auth_error':
+        if (msg.code === 'TOKEN_EXPIRED' || msg.code === 'REFRESH_FAILED') {
+          clearStoredTokens();
+          setUser(null);
+          setShowAuthPanel(true);
+        }
+        break;
+      case 'session_taken':
+        break;
+    }
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{
+      user, showAuthPanel, setShowAuthPanel,
+      handleAuth, handleLogout, handleWsAuthMessage, setWsRef,
+    }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider');
+  return ctx;
+}

--- a/client/src/hooks/useAudioRecorder.js
+++ b/client/src/hooks/useAudioRecorder.js
@@ -1,0 +1,129 @@
+import { useState, useRef, useCallback, useEffect } from 'react';
+
+/**
+ * Hook para grabación de audio con MediaRecorder.
+ * Retorna estado de grabación y funciones de control.
+ */
+export default function useAudioRecorder({ onRecordingComplete }) {
+  const [recording, setRecording] = useState(false);
+  const [recPaused, setRecPaused] = useState(false);
+  const [recTime, setRecTime] = useState(0);
+
+  const mediaRecorderRef = useRef(null);
+  const audioChunksRef = useRef([]);
+  const streamRef = useRef(null);
+  const recTimerRef = useRef(null);
+  const recCancelledRef = useRef(false);
+  const recTimeRef = useRef(0);
+
+  // Timer de grabación
+  useEffect(() => {
+    if (recording && !recPaused) {
+      recTimerRef.current = setInterval(() => {
+        setRecTime(t => { recTimeRef.current = t + 1; return t + 1; });
+      }, 1000);
+    } else {
+      clearInterval(recTimerRef.current);
+    }
+    return () => clearInterval(recTimerRef.current);
+  }, [recording, recPaused]);
+
+  // Cleanup al desmontar
+  useEffect(() => {
+    return () => {
+      streamRef.current?.getTracks().forEach(t => t.stop());
+      streamRef.current = null;
+      clearInterval(recTimerRef.current);
+    };
+  }, []);
+
+  const cleanupRecording = useCallback(() => {
+    clearInterval(recTimerRef.current);
+    streamRef.current?.getTracks().forEach(t => t.stop());
+    streamRef.current = null;
+    mediaRecorderRef.current = null;
+    setRecording(false);
+    setRecPaused(false);
+    setRecTime(0);
+  }, []);
+
+  const start = useCallback(async () => {
+    if (!navigator.mediaDevices?.getUserMedia) {
+      const hint = !window.isSecureContext
+        ? 'Necesitás acceder via HTTPS o localhost para usar el micrófono'
+        : 'Tu navegador no soporta grabación de audio';
+      return { error: hint };
+    }
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      streamRef.current = stream;
+      const mimeType = MediaRecorder.isTypeSupported('audio/webm;codecs=opus')
+        ? 'audio/webm;codecs=opus'
+        : MediaRecorder.isTypeSupported('audio/webm') ? 'audio/webm' : '';
+      const mediaRecorder = mimeType
+        ? new MediaRecorder(stream, { mimeType })
+        : new MediaRecorder(stream);
+      mediaRecorderRef.current = mediaRecorder;
+      audioChunksRef.current = [];
+      recCancelledRef.current = false;
+      recTimeRef.current = 0;
+
+      mediaRecorder.ondataavailable = (e) => {
+        if (e.data.size > 0) audioChunksRef.current.push(e.data);
+      };
+
+      mediaRecorder.onstop = () => {
+        stream.getTracks().forEach(t => t.stop());
+        streamRef.current = null;
+        if (recCancelledRef.current) return;
+        const actualMime = mediaRecorder.mimeType || 'audio/webm';
+        const blob = new Blob(audioChunksRef.current, { type: actualMime });
+        const audioUrl = URL.createObjectURL(blob);
+        const audioDuration = recTimeRef.current;
+        onRecordingComplete?.({ blob, audioUrl, audioDuration, mimeType: actualMime });
+      };
+
+      mediaRecorder.start();
+      setRecording(true);
+      setRecPaused(false);
+      setRecTime(0);
+      return { error: null };
+    } catch (err) {
+      let errorMsg = 'Micrófono no disponible';
+      if (err.name === 'NotAllowedError') errorMsg = 'Permiso de micrófono denegado. Revisá los permisos del navegador';
+      else if (err.name === 'NotFoundError') errorMsg = 'No se encontró ningún micrófono';
+      else if (err.name === 'NotReadableError') errorMsg = 'El micrófono está siendo usado por otra aplicación';
+      return { error: errorMsg };
+    }
+  }, [onRecordingComplete]);
+
+  const cancel = useCallback(() => {
+    recCancelledRef.current = true;
+    const mr = mediaRecorderRef.current;
+    if (mr && mr.state !== 'inactive') mr.stop();
+    cleanupRecording();
+  }, [cleanupRecording]);
+
+  const togglePause = useCallback(() => {
+    const mr = mediaRecorderRef.current;
+    if (!mr) return;
+    if (mr.state === 'recording') {
+      mr.pause();
+      setRecPaused(true);
+    } else if (mr.state === 'paused') {
+      mr.resume();
+      setRecPaused(false);
+    }
+  }, []);
+
+  const send = useCallback(() => {
+    recCancelledRef.current = false;
+    const mr = mediaRecorderRef.current;
+    if (mr && mr.state !== 'inactive') mr.stop();
+    setRecording(false);
+    setRecPaused(false);
+    setRecTime(0);
+  }, []);
+
+  return { recording, recPaused, recTime, start, cancel, togglePause, send };
+}

--- a/client/src/hooks/useChatSocket.js
+++ b/client/src/hooks/useChatSocket.js
@@ -1,0 +1,79 @@
+import { useState, useRef, useCallback, useEffect } from 'react';
+import { WS_URL } from '../config.js';
+import { getStoredTokens, setStoredTokens, clearStoredTokens, isTokenExpired, refreshTokens as refreshAuthTokens } from '../authUtils.js';
+
+/**
+ * Hook para la conexión WebSocket del WebChat.
+ * Maneja init, reconexión, y dispatch de mensajes entrantes.
+ */
+export default function useChatSocket({ onMessage, onAuthError }) {
+  const [connected, setConnected] = useState(false);
+  const wsRef = useRef(null);
+  const sessionIdRef = useRef(null);
+
+  useEffect(() => {
+    const ws = new WebSocket(WS_URL);
+    wsRef.current = ws;
+
+    ws.onopen = async () => {
+      const savedSessionId = localStorage.getItem('wc-session-id');
+      const authToken = localStorage.getItem('wc-auth-token') || undefined;
+      let { accessToken } = getStoredTokens();
+
+      if (accessToken && isTokenExpired(accessToken)) {
+        try {
+          const refreshed = await refreshAuthTokens();
+          accessToken = refreshed.accessToken;
+        } catch {
+          accessToken = null;
+          clearStoredTokens();
+          onAuthError?.();
+        }
+      }
+
+      ws.send(JSON.stringify({
+        type: 'init',
+        sessionType: 'webchat',
+        ...(savedSessionId ? { sessionId: savedSessionId } : {}),
+        ...(authToken ? { authToken } : {}),
+        ...(accessToken ? { jwt: accessToken } : {}),
+      }));
+      setConnected(true);
+    };
+
+    ws.onmessage = (event) => {
+      try {
+        const msg = JSON.parse(event.data);
+        if (msg.type === 'session_id') {
+          sessionIdRef.current = msg.id;
+          localStorage.setItem('wc-session-id', msg.id);
+        }
+        onMessage?.(msg);
+      } catch { /* silenciar */ }
+    };
+
+    ws.onclose = () => setConnected(false);
+    ws.onerror = () => {};
+
+    return () => ws.close();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const send = useCallback((data) => {
+    const ws = wsRef.current;
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(typeof data === 'string' ? data : JSON.stringify(data));
+    }
+  }, []);
+
+  const getSessionId = useCallback(() => sessionIdRef.current, []);
+
+  const reconnect = useCallback(() => {
+    const ws = wsRef.current;
+    if (ws) {
+      try { ws.close(); } catch {}
+    }
+    // El useEffect se encargará de reconectar al re-mount
+  }, []);
+
+  return { connected, send, getSessionId, reconnect, wsRef };
+}

--- a/client/src/hooks/useFileUpload.js
+++ b/client/src/hooks/useFileUpload.js
@@ -1,0 +1,45 @@
+import { useRef, useCallback } from 'react';
+
+/**
+ * Hook para manejo de upload de archivos (click + drag & drop).
+ * Retorna ref del input file y handlers.
+ */
+export default function useFileUpload({ onFile }) {
+  const fileInputRef = useRef(null);
+
+  const openPicker = useCallback(() => {
+    fileInputRef.current?.click();
+  }, []);
+
+  const processFile = useCallback((file, inputText) => {
+    const isImage = file.type.startsWith('image/');
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      const base64 = reader.result.split(',')[1];
+      const mediaType = file.type || 'application/octet-stream';
+      onFile?.({ file, base64, mediaType, isImage, inputText });
+    };
+    reader.onerror = () => {
+      onFile?.({ error: `Error leyendo archivo: ${file.name}` });
+    };
+    reader.readAsDataURL(file);
+  }, [onFile]);
+
+  const handleFileSelect = useCallback((e, inputText = '') => {
+    const files = e.target.files;
+    if (!files || files.length === 0) return;
+    processFile(files[0], inputText);
+    e.target.value = '';
+  }, [processFile]);
+
+  const handleDrop = useCallback((e, inputText = '') => {
+    e.preventDefault();
+    const files = e.dataTransfer?.files;
+    if (!files || files.length === 0) return;
+    processFile(files[0], inputText);
+  }, [processFile]);
+
+  const handleDragOver = useCallback((e) => e.preventDefault(), []);
+
+  return { fileInputRef, openPicker, handleFileSelect, handleDrop, handleDragOver };
+}


### PR DESCRIPTION
## Summary

- **WebChatPanel** (872 LOC) spliteado en componentes focalizados:
  - `ChatHeader` — controles de provider, agente, auth, clear/close
  - `StatusBar` — estado de conexión, provider activo, cwd
  - `MessageList` — renderizado de mensajes con auto-scroll
  - `ChatInput` — textarea + envío + attach + TTS + mic
  - `RecordingBar` — UI de grabación de audio
- **3 hooks extraídos:**
  - `useChatSocket` — conexión WS, init, send
  - `useAudioRecorder` — grabación con MediaRecorder
  - `useFileUpload` — file picker + drag & drop
- **AuthContext** global — auth state compartido, refresh proactivo de JWT
- **App.jsx** refactorizado: 5 booleans → `useReducer` con `activePanel` único
- **ErrorBoundary** wrapper para paneles lazy-loaded con botón reintentar

WebChatPanel pasa de 872 a ~280 LOC (orquestador).

## Test plan
- [x] Build exitoso (`npm run build`)
- [ ] Verificar WebChat funciona: enviar mensaje, recibir respuesta
- [ ] Verificar grabación de audio
- [ ] Verificar file upload (click + drag & drop)
- [ ] Verificar login/logout
- [ ] Verificar cambio de provider/agente
- [ ] Verificar paneles laterales (Telegram, Agents, Providers, MCPs) abren/cierran correctamente
- [ ] Verificar ErrorBoundary: simular error en panel