### PR TITLE
feat(auth): login fullscreen — branding + formulario

### DIFF
--- a/client/src/components/AuthPanel.css
+++ b/client/src/components/AuthPanel.css
@@ -1,25 +1,127 @@
+/* ── FULLSCREEN LAYOUT ── */
 .auth-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: flex;
+  width: 100vw;
+  height: 100vh;
+  background: #0d0d0d;
+}
+
+/* Panel izquierdo — branding */
+.auth-brand {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 3rem 4rem;
+  background: linear-gradient(135deg, #0f1923 0%, #141e2e 60%, #0d1520 100%);
+  border-right: 1px solid #1e2d3d;
+  position: relative;
+  overflow: hidden;
+}
+
+.auth-brand::before {
+  content: '';
+  position: absolute;
+  top: -120px;
+  left: -80px;
+  width: 500px;
+  height: 500px;
+  background: radial-gradient(circle, rgba(79,195,247,0.06) 0%, transparent 70%);
+  pointer-events: none;
+}
+
+.auth-brand-logo {
+  font-size: 2rem;
+  font-weight: 800;
+  color: #4fc3f7;
+  letter-spacing: -1px;
+  margin-bottom: 0.5rem;
+}
+
+.auth-brand-logo span {
+  color: #fff;
+}
+
+.auth-brand-tagline {
+  font-size: 1.25rem;
+  color: #e0e0e0;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+  line-height: 1.4;
+}
+
+.auth-brand-desc {
+  font-size: 0.9rem;
+  color: #7a8a9a;
+  line-height: 1.7;
+  max-width: 380px;
+}
+
+.auth-brand-features {
+  margin-top: 2.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.auth-brand-feature {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  color: #8fa8be;
+  font-size: 0.85rem;
+}
+
+.auth-brand-feature-icon {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  background: rgba(79,195,247,0.12);
+  border: 1px solid rgba(79,195,247,0.2);
   display: flex;
   align-items: center;
   justify-content: center;
-  flex: 1;
-  padding: 1rem;
+  color: #4fc3f7;
+  font-size: 0.85rem;
+  flex-shrink: 0;
 }
 
-.auth-card {
-  background: var(--bg-panel, #1e1e1e);
-  border: 1px solid var(--border-primary, #333);
-  border-radius: 8px;
-  width: 100%;
-  max-width: 340px;
-  padding: 1.25rem;
+/* Panel derecho — formulario */
+.auth-panel {
+  width: 420px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: stretch;
+  padding: 2.5rem 3rem;
+  background: #111519;
+  overflow-y: auto;
 }
 
+.auth-panel-title {
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: #e8eaed;
+  margin-bottom: 0.25rem;
+}
+
+.auth-panel-subtitle {
+  font-size: 0.82rem;
+  color: #657080;
+  margin-bottom: 2rem;
+}
+
+/* Tabs */
 .auth-tabs {
   display: flex;
   gap: 0;
-  margin-bottom: 1rem;
-  border-bottom: 1px solid var(--border-primary, #333);
+  margin-bottom: 1.5rem;
+  border-bottom: 1px solid #1e2730;
 }
 
 .auth-tab {
@@ -28,29 +130,30 @@
   align-items: center;
   justify-content: center;
   gap: 6px;
-  padding: 0.5rem;
+  padding: 0.6rem;
   background: none;
   border: none;
-  color: var(--text-secondary, #888);
-  font-size: 0.8rem;
+  color: #556070;
+  font-size: 0.82rem;
   cursor: pointer;
   border-bottom: 2px solid transparent;
   transition: color 0.2s, border-color 0.2s;
 }
 
 .auth-tab:hover {
-  color: var(--text-primary, #ddd);
+  color: #c0ccd8;
 }
 
 .auth-tab.active {
-  color: var(--accent-blue, #4fc3f7);
-  border-bottom-color: var(--accent-blue, #4fc3f7);
+  color: #4fc3f7;
+  border-bottom-color: #4fc3f7;
 }
 
+/* Formulario */
 .auth-form {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.85rem;
 }
 
 .auth-field {
@@ -61,37 +164,38 @@
 
 .auth-field-icon {
   position: absolute;
-  left: 10px;
-  color: var(--text-secondary, #888);
+  left: 12px;
+  color: #4a5568;
   pointer-events: none;
 }
 
 .auth-field input {
   width: 100%;
-  padding: 0.6rem 0.6rem 0.6rem 2rem;
-  background: var(--bg-primary, #121212);
-  border: 1px solid var(--border-primary, #333);
-  border-radius: 6px;
-  color: var(--text-primary, #ddd);
-  font-size: 0.85rem;
+  padding: 0.7rem 0.75rem 0.7rem 2.2rem;
+  background: #0d1218;
+  border: 1px solid #1e2a38;
+  border-radius: 8px;
+  color: #c8d6e0;
+  font-size: 0.88rem;
   outline: none;
-  transition: border-color 0.2s;
+  transition: border-color 0.2s, background 0.2s;
 }
 
 .auth-field input:focus {
-  border-color: var(--accent-blue, #4fc3f7);
+  border-color: #4fc3f7;
+  background: #0f161e;
 }
 
 .auth-field input::placeholder {
-  color: var(--text-secondary, #666);
+  color: #3a4858;
 }
 
 .auth-toggle-pass {
   position: absolute;
-  right: 8px;
+  right: 10px;
   background: none;
   border: none;
-  color: var(--text-secondary, #888);
+  color: #4a5568;
   cursor: pointer;
   padding: 4px;
   display: flex;
@@ -99,35 +203,50 @@
 }
 
 .auth-toggle-pass:hover {
-  color: var(--text-primary, #ddd);
+  color: #8a9ab8;
 }
 
 .auth-error {
-  color: var(--accent-red, #f44);
-  font-size: 0.78rem;
-  padding: 0.4rem 0.6rem;
-  background: rgba(244, 68, 68, 0.1);
-  border-radius: 4px;
+  color: #f87171;
+  font-size: 0.8rem;
+  padding: 0.5rem 0.75rem;
+  background: rgba(248, 113, 113, 0.08);
+  border: 1px solid rgba(248, 113, 113, 0.2);
+  border-radius: 6px;
 }
 
 .auth-submit {
-  padding: 0.6rem;
-  background: var(--accent-blue, #4fc3f7);
+  padding: 0.75rem;
+  background: #4fc3f7;
   color: #000;
   border: none;
-  border-radius: 6px;
-  font-size: 0.85rem;
-  font-weight: 600;
+  border-radius: 8px;
+  font-size: 0.88rem;
+  font-weight: 700;
   cursor: pointer;
-  transition: opacity 0.2s;
+  transition: opacity 0.2s, transform 0.1s;
+  margin-top: 0.25rem;
 }
 
-/* OAuth buttons */
+.auth-submit:hover {
+  opacity: 0.9;
+}
+
+.auth-submit:active {
+  transform: scale(0.98);
+}
+
+.auth-submit:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+/* OAuth */
 .auth-oauth {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-  margin-bottom: 0.75rem;
+  gap: 0.6rem;
+  margin-bottom: 1rem;
 }
 
 .auth-oauth-btn {
@@ -135,31 +254,33 @@
   align-items: center;
   justify-content: center;
   gap: 8px;
-  padding: 0.55rem;
-  border: 1px solid var(--border-primary, #333);
-  border-radius: 6px;
-  font-size: 0.82rem;
+  padding: 0.65rem;
+  border-radius: 8px;
+  font-size: 0.85rem;
+  font-weight: 500;
   cursor: pointer;
   transition: background 0.2s, border-color 0.2s;
 }
 
 .auth-oauth-google {
-  background: var(--bg-primary, #121212);
-  color: var(--text-primary, #ddd);
+  background: #0d1218;
+  border: 1px solid #1e2a38;
+  color: #c8d6e0;
 }
 
 .auth-oauth-google:hover {
-  background: #1a1a2e;
+  background: #111e2c;
   border-color: #4285F4;
 }
 
 .auth-oauth-github {
-  background: #24292e;
-  color: #fff;
+  background: #161b22;
+  border: 1px solid #30363d;
+  color: #f0f6fc;
 }
 
 .auth-oauth-github:hover {
-  background: #2f363d;
+  background: #1c2128;
   border-color: #6e7681;
 }
 
@@ -167,45 +288,62 @@
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  color: var(--text-secondary, #666);
+  color: #3a4858;
   font-size: 0.75rem;
+  margin: 0.25rem 0;
 }
 
 .auth-divider::before,
 .auth-divider::after {
   content: '';
   flex: 1;
-  border-top: 1px solid var(--border-primary, #333);
-}
-
-.auth-submit:hover {
-  opacity: 0.9;
-}
-
-.auth-submit:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
+  border-top: 1px solid #1a2330;
 }
 
 .auth-skip {
   display: block;
   width: 100%;
-  margin-top: 0.75rem;
+  margin-top: 1rem;
   padding: 0.5rem;
   background: none;
   border: none;
-  color: var(--text-secondary, #888);
-  font-size: 0.78rem;
+  color: #455060;
+  font-size: 0.8rem;
   cursor: pointer;
   text-align: center;
+  transition: color 0.2s;
 }
 
 .auth-skip:hover {
-  color: var(--text-primary, #ddd);
+  color: #7a8a9a;
   text-decoration: underline;
 }
 
-/* User badge in header */
+/* Mobile — ocultar branding, form full width */
+@media (max-width: 700px) {
+  .auth-brand {
+    display: none;
+  }
+
+  .auth-panel {
+    width: 100%;
+    padding: 2rem 1.5rem;
+  }
+}
+
+/* Tablet */
+@media (max-width: 1024px) and (min-width: 701px) {
+  .auth-brand {
+    padding: 2rem 2.5rem;
+  }
+
+  .auth-panel {
+    width: 380px;
+    padding: 2rem 2rem;
+  }
+}
+
+/* ── HEADER BADGES (fuera del fullscreen) ── */
 .wc-user-badge {
   display: flex;
   align-items: center;

--- a/client/src/components/AuthPanel.jsx
+++ b/client/src/components/AuthPanel.jsx
@@ -94,7 +94,39 @@ export default function AuthPanel({ onAuth, onSkip }) {
 
   return (
     <div className="auth-overlay">
-      <div className="auth-card">
+      {/* Panel izquierdo — branding */}
+      <div className="auth-brand">
+        <div className="auth-brand-logo">Claw<span>mint</span></div>
+        <div className="auth-brand-tagline">Tu terminal en la nube</div>
+        <div className="auth-brand-desc">
+          Terminal PTY en tiempo real, agentes IA multi-proveedor y control
+          remoto desde cualquier dispositivo.
+        </div>
+        <div className="auth-brand-features">
+          <div className="auth-brand-feature">
+            <div className="auth-brand-feature-icon">⚡</div>
+            Terminal PTY en tiempo real vía WebSocket
+          </div>
+          <div className="auth-brand-feature">
+            <div className="auth-brand-feature-icon">🤖</div>
+            Claude, Gemini, GPT, Grok y Ollama
+          </div>
+          <div className="auth-brand-feature">
+            <div className="auth-brand-feature-icon">📱</div>
+            Telegram + WebChat integrados
+          </div>
+        </div>
+      </div>
+
+      {/* Panel derecho — formulario */}
+      <div className="auth-panel">
+        <div className="auth-panel-title">
+          {mode === 'login' ? 'Iniciar sesión' : 'Crear cuenta'}
+        </div>
+        <div className="auth-panel-subtitle">
+          {mode === 'login' ? 'Bienvenido de vuelta' : 'Empezá gratis, sin tarjeta'}
+        </div>
+
         <div className="auth-tabs">
           <button
             className={`auth-tab ${mode === 'login' ? 'active' : ''}`}


### PR DESCRIPTION
## Summary
- Layout 100vw/100vh con `position: fixed` que reemplaza toda la pantalla al abrir login
- Panel izquierdo: branding (logo Clawmint, tagline, 3 features con íconos)
- Panel derecho: formulario login/registro con tabs, OAuth, skip
- Responsive: mobile <700px oculta branding, form full width; tablet ajusta padding

## Test plan
- [ ] Abrir WebChat → click Login → verificar fullscreen
- [ ] Desktop 1280px: branding izquierda visible, form derecha
- [ ] Mobile <700px: solo formulario, sin branding
- [ ] Login funcional (email/password) y skip ("Continuar sin cuenta")