### PR TITLE
fix: fallback clipboard para HTTP

### DIFF
--- a/client/src/components/ChatMessage.jsx
+++ b/client/src/components/ChatMessage.jsx
@@ -136,10 +136,21 @@ function CodeBlock({ node, inline, className, children, ...props }) {
   const code = String(children).replace(/\n$/, '');
 
   const handleCopy = useCallback(() => {
-    navigator.clipboard.writeText(code).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    });
+    const done = () => { setCopied(true); setTimeout(() => setCopied(false), 2000); };
+    if (navigator.clipboard) {
+      navigator.clipboard.writeText(code).then(done);
+    } else {
+      // Fallback para HTTP (sin secure context)
+      const ta = document.createElement('textarea');
+      ta.value = code;
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand('copy');
+      document.body.removeChild(ta);
+      done();
+    }
   }, [code]);
 
   if (inline) {


### PR DESCRIPTION
## Problema
`navigator.clipboard` es undefined cuando el WebClient se accede por HTTP (no HTTPS). Tiraba `TypeError: can't access property "writeText", navigator.clipboard is undefined` al intentar copiar código.

## Fix
Fallback con `document.execCommand('copy')` cuando `navigator.clipboard` no está disponible (contexto no seguro).