### PR TITLE
feat: gemini-cli provider

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -9,6 +9,7 @@ import { AuthProvider } from './contexts/AuthContext.jsx';
 import { ThemeProvider, useTheme } from './contexts/ThemeContext.jsx';
 import { ToastProvider } from './contexts/ToastContext.jsx';
 import { API_BASE, WS_URL } from './config';
+import { apiFetch } from './authUtils';
 import './App.css';
 import './components/AgentsPanel.css';
 import './components/TelegramPanel.css';
@@ -126,7 +127,7 @@ function AppContent() {
     if (activePanel === 'telegram') return;
     const interval = setInterval(async () => {
       try {
-        const res = await fetch(`${API_BASE}/api/telegram/bots`);
+        const res = await apiFetch(`${API_BASE}/api/telegram/bots`);
         const bots = await res.json();
         const chats = Array.isArray(bots)
           ? bots.reduce((n, b) => n + (b.chats?.length || 0), 0)

--- a/client/src/authUtils.ts
+++ b/client/src/authUtils.ts
@@ -136,6 +136,21 @@ export async function fetchMe(): Promise<User | null> {
 }
 
 /**
+ * fetch autenticado: agrega Authorization: Bearer <token> automáticamente.
+ * Usar en todos los paneles en lugar del fetch() nativo.
+ */
+export function apiFetch(url: string, options: RequestInit = {}): Promise<Response> {
+  const { accessToken } = getStoredTokens();
+  const authHeader: Record<string, string> = accessToken
+    ? { Authorization: `Bearer ${accessToken}` }
+    : {};
+  return fetch(url, {
+    ...options,
+    headers: { ...authHeader, ...(options.headers as Record<string, string> || {}) },
+  });
+}
+
+/**
  * Vincula una sesión anónima al usuario autenticado.
  */
 export async function linkSession(sessionId: string): Promise<boolean> {

--- a/client/src/components/AgentsPanel.jsx
+++ b/client/src/components/AgentsPanel.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Check, Pencil, Trash2, X, Plus, Users, Sparkles } from 'lucide-react';
 import { API_BASE } from '../config';
+import { apiFetch } from '../authUtils';
 import './AgentsPanel.css';
 
 const API = `${API_BASE}/api/agents`;
@@ -21,7 +22,7 @@ function AgentForm({ initial, onSave, onCancel }) {
     try {
       const url = isEdit ? `${API}/${initial.key}` : API;
       const method = isEdit ? 'PATCH' : 'POST';
-      const res = await fetch(url, {
+      const res = await apiFetch(url, {
         method,
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ key: key.trim(), description: description.trim(), prompt: prompt.trim() }),
@@ -123,7 +124,7 @@ function SkillsSection() {
   const [error, setError] = useState('');
 
   const loadSkills = useCallback(() => {
-    fetch(SKILLS_API).then(r => r.json()).then(setSkillsList).catch(() => setError('Error cargando skills'));
+    apiFetch(SKILLS_API).then(r => r.json()).then(setSkillsList).catch(() => setError('Error cargando skills'));
   }, []);
 
   useEffect(() => { loadSkills(); }, [loadSkills]);
@@ -133,7 +134,7 @@ function SkillsSection() {
     setInstalling(true);
     setError('');
     try {
-      const res = await fetch(`${SKILLS_API}/install`, {
+      const res = await apiFetch(`${SKILLS_API}/install`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ slug: slug.trim() }),
@@ -150,7 +151,7 @@ function SkillsSection() {
   };
 
   const uninstall = async (s) => {
-    await fetch(`${SKILLS_API}/${s}`, { method: 'DELETE' });
+    await apiFetch(`${SKILLS_API}/${s}`, { method: 'DELETE' });
     loadSkills();
   };
 
@@ -198,7 +199,7 @@ export default function AgentsPanel({ onClose }) {
   const fetchAgents = useCallback(async () => {
     try {
       setLoadError('');
-      const res = await fetch(API);
+      const res = await apiFetch(API);
       const data = await res.json();
       setAgents(Array.isArray(data) ? data : []);
     } catch { setLoadError('Error cargando agentes'); }
@@ -220,7 +221,7 @@ export default function AgentsPanel({ onClose }) {
   const handleDelete = async (key) => {
     if (!confirm(`¿Eliminar el agente "${key}"?`)) return;
     try {
-      await fetch(`${API}/${key}`, { method: 'DELETE' });
+      await apiFetch(`${API}/${key}`, { method: 'DELETE' });
       fetchAgents();
     } catch { setLoadError('Error eliminando agente'); }
   };

--- a/client/src/components/McpsPanel.jsx
+++ b/client/src/components/McpsPanel.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Check, Pencil, Trash2, X, Plus, Plug } from 'lucide-react';
 import { API_BASE } from '../config';
+import { apiFetch } from '../authUtils';
 
 const API = `${API_BASE}/api/mcps`;
 
@@ -81,7 +82,7 @@ function McpForm({ initial, onSave, onCancel }) {
     try {
       const endpoint = isEdit ? `${API}/${initial.name}` : API;
       const method = isEdit ? 'PATCH' : 'POST';
-      const res = await fetch(endpoint, {
+      const res = await apiFetch(endpoint, {
         method,
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
@@ -246,7 +247,7 @@ export default function McpsPanel({ onClose }) {
   const fetchMcps = useCallback(async () => {
     try {
       setCliError('');
-      const res = await fetch(API);
+      const res = await apiFetch(API);
       const data = await res.json();
       setMcpList(Array.isArray(data) ? data : []);
     } catch { setCliError('Error cargando MCPs'); }
@@ -268,7 +269,7 @@ export default function McpsPanel({ onClose }) {
   const handleDelete = async (name) => {
     if (!confirm(`¿Eliminar el MCP "${name}"?`)) return;
     try {
-      await fetch(`${API}/${name}`, { method: 'DELETE' });
+      await apiFetch(`${API}/${name}`, { method: 'DELETE' });
       fetchMcps();
     } catch { setCliError('Error eliminando MCP'); }
   };
@@ -278,7 +279,7 @@ export default function McpsPanel({ onClose }) {
     setToggling(mcp.name);
     try {
       const action = mcp.enabled ? 'disable' : 'enable';
-      const res = await fetch(`${API}/${mcp.name}/${action}`, { method: 'POST' });
+      const res = await apiFetch(`${API}/${mcp.name}/${action}`, { method: 'POST' });
       const data = await res.json();
       if (!res.ok || data.error) throw new Error(data.error || 'Error CLI');
       fetchMcps();

--- a/client/src/components/ProvidersPanel.jsx
+++ b/client/src/components/ProvidersPanel.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Settings, X, CheckCircle } from 'lucide-react';
 import { API_BASE } from '../config';
+import { apiFetch } from '../authUtils';
 import './ProvidersPanel.css';
 
 const API = API_BASE;
@@ -27,7 +28,7 @@ export default function ProvidersPanel({ onClose }) {
 
   async function fetchProviders() {
     try {
-      const res = await fetch(`${API}/api/providers`);
+      const res = await apiFetch(`${API}/api/providers`);
       const data = await res.json();
       setProviders(data.providers || []);
       setDefaultProvider(data.default || 'claude-code');
@@ -45,7 +46,7 @@ export default function ProvidersPanel({ onClose }) {
     setSaving(s => ({ ...s, [name]: true }));
     try {
       const { apiKey, model } = keys[name] || {};
-      await fetch(`${API}/api/providers/${name}`, {
+      await apiFetch(`${API}/api/providers/${name}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ apiKey: apiKey || undefined, model: model || undefined }),
@@ -61,7 +62,7 @@ export default function ProvidersPanel({ onClose }) {
 
   async function saveDefault(name) {
     try {
-      await fetch(`${API}/api/providers/default`, {
+      await apiFetch(`${API}/api/providers/default`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ provider: name }),

--- a/client/src/components/TelegramPanel.jsx
+++ b/client/src/components/TelegramPanel.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef, memo } from 'react';
 import { Lock, CheckCircle, Sparkles, Square, Play, X, ChevronUp, ChevronDown, Eye, EyeOff, Check, Plus, Bot } from 'lucide-react';
 import { API_BASE } from '../config';
+import { apiFetch } from '../authUtils';
 import './TelegramPanel.css';
 
 const API = `${API_BASE}/api/telegram`;
@@ -20,7 +21,7 @@ const ChatRow = memo(function ChatRow({ botKey, chat, onOpenSession, onRefresh }
   const handleLink = async () => {
     if (linking) { setLinking(false); return; }
     try {
-      const res = await fetch(`${API_BASE}/api/sessions`);
+      const res = await apiFetch(`${API_BASE}/api/sessions`);
       const data = await res.json();
       setSessions(Array.isArray(data) ? data.filter(s => s.active) : []);
     } catch { setSessions([]); }
@@ -30,7 +31,7 @@ const ChatRow = memo(function ChatRow({ botKey, chat, onOpenSession, onRefresh }
   const handleSelectSession = async (sessionId) => {
     setLinking(false);
     try {
-      await fetch(`${API}/bots/${botKey}/chats/${chat.chatId}/session`, {
+      await apiFetch(`${API}/bots/${botKey}/chats/${chat.chatId}/session`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ sessionId }),
@@ -41,7 +42,7 @@ const ChatRow = memo(function ChatRow({ botKey, chat, onOpenSession, onRefresh }
 
   const handleDisconnect = async () => {
     try {
-      await fetch(`${API}/bots/${botKey}/chats/${chat.chatId}`, { method: 'DELETE' });
+      await apiFetch(`${API}/bots/${botKey}/chats/${chat.chatId}`, { method: 'DELETE' });
       onRefresh();
     } catch { /* ignorar */ }
   };
@@ -117,7 +118,7 @@ function AccessConfig({ bot, onRefresh }) {
     setSaving(true);
     const whitelist = ids.split(',').map(s => Number(s.trim())).filter(Boolean);
     const groupWhitelist = groupIds.split(',').map(s => Number(s.trim())).filter(Boolean);
-    await fetch(`${API}/bots/${bot.key}`, {
+    await apiFetch(`${API}/bots/${bot.key}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ whitelist, groupWhitelist, rateLimit: Number(limit), rateLimitKeyword: keyword }),
@@ -170,7 +171,7 @@ const BotCard = memo(function BotCard({ bot, allAgents, onOpenSession, onRefresh
   const handleStart = async () => {
     setLoading(true);
     try {
-      await fetch(`${API}/bots/${bot.key}/start`, { method: 'POST' });
+      await apiFetch(`${API}/bots/${bot.key}/start`, { method: 'POST' });
       onRefresh();
     } catch { /* ignorar */ } finally { setLoading(false); }
   };
@@ -178,7 +179,7 @@ const BotCard = memo(function BotCard({ bot, allAgents, onOpenSession, onRefresh
   const handleStop = async () => {
     setLoading(true);
     try {
-      await fetch(`${API}/bots/${bot.key}/stop`, { method: 'POST' });
+      await apiFetch(`${API}/bots/${bot.key}/stop`, { method: 'POST' });
       onRefresh();
     } catch { /* ignorar */ } finally { setLoading(false); }
   };
@@ -187,7 +188,7 @@ const BotCard = memo(function BotCard({ bot, allAgents, onOpenSession, onRefresh
     if (!confirm(`¿Eliminar el bot "${bot.key}"?`)) return;
     setLoading(true);
     try {
-      await fetch(`${API}/bots/${bot.key}`, { method: 'DELETE' });
+      await apiFetch(`${API}/bots/${bot.key}`, { method: 'DELETE' });
       onRefresh();
     } catch { /* ignorar */ } finally { setLoading(false); }
   };
@@ -195,7 +196,7 @@ const BotCard = memo(function BotCard({ bot, allAgents, onOpenSession, onRefresh
   const handleChangeAgent = async (e) => {
     e.stopPropagation();
     try {
-      await fetch(`${API}/bots/${bot.key}`, {
+      await apiFetch(`${API}/bots/${bot.key}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ defaultAgent: e.target.value }),
@@ -280,7 +281,7 @@ const AddBotForm = memo(function AddBotForm({ onAdd, onCancel }) {
     if (!key.trim() || !token.trim()) { setError('Completá ambos campos'); return; }
     setLoading(true);
     try {
-      const res = await fetch(`${API}/bots`, {
+      const res = await apiFetch(`${API}/bots`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ key: key.trim(), token: token.trim() }),
@@ -349,7 +350,7 @@ export default function TelegramPanel({ onClose, onOpenSession }) {
 
   const fetchBots = useCallback(async () => {
     try {
-      const res = await fetch(`${API}/bots`);
+      const res = await apiFetch(`${API}/bots`);
       const data = await res.json();
       setBots(Array.isArray(data) ? data : []);
     } catch { /* ignorar */ }
@@ -363,7 +364,7 @@ export default function TelegramPanel({ onClose, onOpenSession }) {
 
   // Cargar agentes una sola vez (en vez de por cada BotCard)
   useEffect(() => {
-    fetch(`${API_BASE}/api/agents`)
+    apiFetch(`${API_BASE}/api/agents`)
       .then(r => r.json())
       .then(data => setAllAgents(Array.isArray(data) ? data : []))
       .catch(() => {});

--- a/client/src/components/WebChatPanel.jsx
+++ b/client/src/components/WebChatPanel.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { API_BASE } from '../config';
 import { useAuth } from '../contexts/AuthContext.jsx';
+import { apiFetch } from '../authUtils';
 import useChatSocket from '../hooks/useChatSocket.js';
 import useChat from '../hooks/useChat.js';
 import useAudioRecorder from '../hooks/useAudioRecorder.js';
@@ -45,14 +46,14 @@ export default function WebChatPanel({ onClose }) {
   // ── Cargar providers y agentes ─────────────────────────────────────────────
 
   useEffect(() => {
-    fetch(`${API_BASE}/api/providers`)
+    apiFetch(`${API_BASE}/api/providers`)
       .then(r => r.json())
       .then(data => {
         setProviders(data.providers || []);
         if (data.default) setProvider(data.default);
       })
       .catch(() => setStatusText('Error cargando providers'));
-    fetch(`${API_BASE}/api/agents`)
+    apiFetch(`${API_BASE}/api/agents`)
       .then(r => r.json())
       .then(data => setAgentsList(Array.isArray(data) ? data : []))
       .catch(() => setStatusText('Error cargando agentes'));

--- a/server/agents.js
+++ b/server/agents.js
@@ -56,26 +56,32 @@ class AgentManager {
     }
   }
 
-  list() {
-    return [...this.agents.values()];
+  list(userId = null) {
+    const all = [...this.agents.values()];
+    if (!userId || userId === '__internal__') return all;
+    return all.filter(a => !a.userId || a.userId === userId);
   }
 
   get(key) {
     return this.agents.get(key);
   }
 
-  add(key, command, description = '', prompt = '', provider = '') {
+  add(key, command, description = '', prompt = '', provider = '', userId = null) {
     if (!/^[a-zA-Z0-9_-]+$/.test(key)) throw new Error('key inválida (solo letras, números, _ y -)');
     const agent = { key, command: command || null, description, prompt };
     if (provider) agent.provider = provider;
+    if (userId) agent.userId = userId;
     this.agents.set(key, agent);
     this._save();
     return agent;
   }
 
-  update(key, { command, description, prompt, provider }) {
+  update(key, { command, description, prompt, provider }, userId = null) {
     const agent = this.agents.get(key);
     if (!agent) throw new Error(`Agente "${key}" no encontrado`);
+    if (agent.userId && userId && agent.userId !== userId && userId !== '__internal__') {
+      throw new Error(`Sin permisos para editar el agente "${key}"`);
+    }
     if (command !== undefined) agent.command = command || null;
     if (description !== undefined) agent.description = description;
     if (prompt !== undefined) agent.prompt = prompt;
@@ -87,8 +93,10 @@ class AgentManager {
     return agent;
   }
 
-  remove(key) {
-    if (!this.agents.has(key)) return false;
+  remove(key, userId = null) {
+    const agent = this.agents.get(key);
+    if (!agent) return false;
+    if (agent.userId && userId && agent.userId !== userId && userId !== '__internal__') return false;
     this.agents.delete(key);
     this._save();
     return true;
@@ -98,9 +106,9 @@ class AgentManager {
 const manager = new AgentManager();
 
 module.exports = {
-  list:   ()                        => manager.list(),
-  get:    (key)                     => manager.get(key),
-  add:    (key, command, desc, prompt, provider) => manager.add(key, command, desc, prompt, provider),
-  update: (key, opts)               => manager.update(key, opts),
-  remove: (key)                     => manager.remove(key),
+  list:   (userId)                              => manager.list(userId),
+  get:    (key)                                 => manager.get(key),
+  add:    (key, command, desc, prompt, provider, userId) => manager.add(key, command, desc, prompt, provider, userId),
+  update: (key, opts, userId)                   => manager.update(key, opts, userId),
+  remove: (key, userId)                         => manager.remove(key, userId),
 };

--- a/server/channels/telegram/MessageProcessor.js
+++ b/server/channels/telegram/MessageProcessor.js
@@ -162,6 +162,7 @@ class MessageProcessor {
         images:        images || null,
         history:       chat.aiHistory || [],
         claudeSession: chat.claudeSession,
+        geminiSession: chat.geminiSession,
         claudeMode:    mode,
         onChunk,
         onStatus,
@@ -181,8 +182,9 @@ class MessageProcessor {
 
       stopAnim();
 
-      if (result.newSession)       chat.claudeSession = result.newSession;
-      if (result.history)          chat.aiHistory     = result.history;
+      if (result.newSession)       chat.claudeSession  = result.newSession;
+      if (result.newGeminiSession) chat.geminiSession  = result.newGeminiSession;
+      if (result.history)          chat.aiHistory      = result.history;
 
       if (chat.claudeSession?.claudeSessionId && this._chatSettings) {
         this._chatSettings.saveSession(bot.key, chatId, {
@@ -192,7 +194,7 @@ class MessageProcessor {
         });
       }
 
-      if (result.history && this._chatSettings && chatProvider !== 'claude-code') {
+      if (result.history && this._chatSettings && !['claude-code', 'gemini-cli'].includes(chatProvider)) {
         this._chatSettings.saveHistory(bot.key, chatId, result.history);
       }
 

--- a/server/channels/telegram/TelegramBot.js
+++ b/server/channels/telegram/TelegramBot.js
@@ -483,13 +483,15 @@ class TelegramBot {
     let chat = this.chats.get(chatId);
     if (!chat) {
       const saved = this._chatSettings ? this._chatSettings.load(this.key, chatId) : null;
+      const agentDef = this._agents ? this._agents.get(this.defaultAgent) : null;
+      const defaultCwd = saved?.cwd || agentDef?.cwd || process.env.HOME;
 
       let restoredSession = null;
       if (saved?.claude_session_id && saved.message_count > 0) {
         restoredSession = new ClaudePrintSession({
           claudeSessionId: saved.claude_session_id,
           messageCount:    saved.message_count,
-          cwd:             saved.cwd || process.env.HOME,
+          cwd:             defaultCwd,
           model:           saved.model || null,
           permissionMode:  saved.claude_mode || 'auto',
         });
@@ -508,7 +510,7 @@ class TelegramBot {
         lastPreview:    '',
         rateLimited:    false,
         rateLimitedUntil: 0,
-        monitorCwd:     saved?.cwd || process.env.HOME,
+        monitorCwd:     defaultCwd,
         busy:           false,
         provider:       saved?.provider || 'claude-code',
         model:          saved?.model    || 'sonnet',

--- a/server/core/GeminiCliSession.js
+++ b/server/core/GeminiCliSession.js
@@ -1,0 +1,142 @@
+'use strict';
+
+const crypto = require('crypto');
+const { spawn } = require('child_process');
+
+/**
+ * GeminiCliSession — modo no-interactivo via `gemini -p`.
+ * Análogo a ClaudePrintSession pero para Gemini CLI.
+ *
+ * Modos:
+ *   permissionMode 'auto'  → --yolo
+ *   permissionMode 'ask'   → --approval-mode default
+ *   permissionMode 'plan'  → --approval-mode plan
+ */
+class GeminiCliSession {
+  constructor({
+    model           = null,
+    permissionMode  = 'auto',
+    cwd             = null,
+    geminiSessionId = null,
+    messageCount    = 0,
+  } = {}) {
+    this.id             = crypto.randomUUID();
+    this.createdAt      = Date.now();
+    this.active         = true;
+    this.messageCount   = messageCount;
+    this.title          = 'gemini';
+    this.model          = model;
+    this.permissionMode = permissionMode;
+    this.geminiSessionId = geminiSessionId;
+    this.cwd            = cwd || process.env.HOME;
+    this.totalInputTokens  = 0;
+    this.totalOutputTokens = 0;
+  }
+
+  async sendMessage(text, onChunk = null, onStatus = null) {
+    const args = ['-p', text, '--output-format', 'stream-json'];
+
+    // Modo de permisos
+    if (this.permissionMode === 'auto') {
+      args.push('--yolo');
+    } else if (this.permissionMode === 'plan') {
+      args.push('--approval-mode', 'plan');
+    }
+    // 'ask' → approval-mode default (es el comportamiento por omisión, no hace falta flag)
+
+    if (this.model) args.push('--model', this.model);
+
+    // Reanudar sesión previa
+    if (this.messageCount > 0 && this.geminiSessionId) {
+      args.push('--resume', this.geminiSessionId);
+    }
+
+    const emitStatus = (status, detail = null) => {
+      if (onStatus) onStatus(status, detail);
+    };
+
+    emitStatus('thinking');
+
+    return new Promise((resolve, reject) => {
+      const child = spawn('gemini', args, {
+        cwd:  this.cwd,
+        env:  process.env,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        windowsHide: true,
+      });
+
+      let lineBuffer  = '';
+      let fullText    = '';
+      let exited      = false;
+      let initSessionId = null;
+
+      const killTimer = setTimeout(() => {
+        try { child.kill('SIGTERM'); } catch {}
+        reject(new Error('Timeout: gemini -p no respondió en 10 min'));
+      }, 600000);
+
+      const processLine = (line) => {
+        const jsonStr = line.trim();
+        // Omitir líneas no-JSON (ej: warnings MCP "MCP issues detected…")
+        if (!jsonStr || !jsonStr.startsWith('{')) return;
+
+        try {
+          const event = JSON.parse(jsonStr);
+
+          if (event.type === 'init') {
+            initSessionId = event.session_id || null;
+            if (event.model && !this.model) this.model = event.model;
+          }
+          else if (event.type === 'message' && event.role === 'assistant') {
+            const chunk = event.content || '';
+            if (event.delta === true) {
+              // Chunk incremental de streaming
+              fullText += chunk;
+              if (onChunk) onChunk(fullText);
+            } else if (!fullText && chunk) {
+              // Mensaje completo (no-streaming)
+              fullText = chunk;
+              if (onChunk) onChunk(fullText);
+            }
+            if (chunk) emitStatus('thinking');
+          }
+          else if (event.type === 'result') {
+            if (initSessionId) this.geminiSessionId = initSessionId;
+            const stats = event.stats || {};
+            this.totalInputTokens  += stats.input_tokens  || 0;
+            this.totalOutputTokens += stats.output_tokens || 0;
+            emitStatus('done');
+          }
+        } catch { /* ignorar líneas no-JSON */ }
+      };
+
+      child.stdout.on('data', (chunk) => {
+        lineBuffer += chunk.toString();
+        const lines = lineBuffer.split('\n');
+        lineBuffer  = lines.pop();
+        for (const line of lines) processLine(line);
+      });
+
+      child.on('error', (err) => {
+        if (exited) return;
+        exited = true;
+        clearTimeout(killTimer);
+        reject(new Error(`No se pudo ejecutar gemini: ${err.message}`));
+      });
+
+      child.on('close', (exitCode) => {
+        if (exited) return;
+        exited = true;
+        clearTimeout(killTimer);
+        if (lineBuffer.trim()) processLine(lineBuffer);
+        if (exitCode !== 0 && !fullText) {
+          return reject(new Error(`gemini salió con código ${exitCode}`));
+        }
+        this.messageCount++;
+        resolve({ text: fullText.trim(), usedMcpTools: false });
+      });
+    });
+  }
+}
+
+module.exports = GeminiCliSession;

--- a/server/providers/gemini-cli.js
+++ b/server/providers/gemini-cli.js
@@ -1,0 +1,47 @@
+'use strict';
+
+/**
+ * Provider: Gemini CLI (gemini -p)
+ * Wrapper sobre GeminiCliSession — análogo a claude-code.js.
+ * Gemini gestiona sus herramientas MCP internamente via ~/.gemini/settings.json.
+ */
+module.exports = {
+  name: 'gemini-cli',
+  label: 'Gemini CLI',
+  defaultModel: null,
+  models: ['gemini-2.5-flash', 'gemini-2.5-pro', 'gemini-2.0-flash'],
+
+  /**
+   * @param {{ systemPrompt, history, model, geminiSession, onChunk }} opts
+   * geminiSession: instancia de GeminiCliSession (requerida)
+   * onChunk: callback(partialText) para streaming progresivo
+   */
+  async *chat({ systemPrompt, history, model, geminiSession, onChunk }) {
+    if (!geminiSession) {
+      yield { type: 'done', fullText: 'Error: geminiSession requerida para gemini-cli provider' };
+      return;
+    }
+
+    const lastMsg = history[history.length - 1];
+    let messageText = lastMsg?.content || '';
+
+    // Primer mensaje: inyectar system prompt al inicio
+    if (geminiSession.messageCount === 0 && systemPrompt) {
+      messageText = `${systemPrompt}\n\n---\n\n${messageText}`;
+    }
+
+    if (model && !geminiSession.model) geminiSession.model = model;
+
+    try {
+      const { text } = await geminiSession.sendMessage(messageText, onChunk);
+      yield {
+        type: 'usage',
+        promptTokens:     geminiSession.totalInputTokens,
+        completionTokens: geminiSession.totalOutputTokens,
+      };
+      yield { type: 'done', fullText: text };
+    } catch (err) {
+      yield { type: 'done', fullText: `Error Gemini CLI: ${err.message}` };
+    }
+  },
+};

--- a/server/providers/index.js
+++ b/server/providers/index.js
@@ -2,6 +2,7 @@
 
 const providers = {
   'claude-code': require('./claude-code'),
+  'gemini-cli':  require('./gemini-cli'),
   'anthropic':   require('./anthropic'),
   'gemini':      require('./gemini'),
   'openai':      require('./openai'),

--- a/server/routes/agents.js
+++ b/server/routes/agents.js
@@ -4,39 +4,44 @@ const express = require('express');
 module.exports = function createAgentsRouter({ agents }) {
   const router = express.Router();
 
-  // GET /agents — listar agentes
-  router.get('/', (_req, res) => {
-    res.json(agents.list());
+  // GET /agents — listar agentes (globales + propios del usuario)
+  router.get('/', (req, res) => {
+    const userId = req.user?.internal ? null : req.user?.id;
+    res.json(agents.list(userId));
   });
 
-  // POST /agents — crear agente
+  // POST /agents — crear agente (se asigna al usuario autenticado)
   // Body: { key, command?, description?, prompt?, provider? }
   router.post('/', (req, res) => {
     const { key, command, description, prompt, provider } = req.body || {};
     if (!key) return res.status(400).json({ error: 'key requerida' });
+    const userId = req.user?.internal ? null : req.user?.id;
     try {
-      const agent = agents.add(key, command, description, prompt, provider);
+      const agent = agents.add(key, command, description, prompt, provider, userId);
       res.status(201).json(agent);
     } catch (err) {
       res.status(400).json({ error: err.message });
     }
   });
 
-  // PATCH /agents/:key — actualizar agente
+  // PATCH /agents/:key — actualizar agente (solo el dueño puede editar los privados)
   // Body: { command?, description? }
   router.patch('/:key', (req, res) => {
+    const userId = req.user?.internal ? null : req.user?.id;
     try {
-      const agent = agents.update(req.params.key, req.body || {});
+      const agent = agents.update(req.params.key, req.body || {}, userId);
       res.json(agent);
     } catch (err) {
-      res.status(404).json({ error: err.message });
+      const status = err.message.includes('permisos') ? 403 : 404;
+      res.status(status).json({ error: err.message });
     }
   });
 
-  // DELETE /agents/:key — eliminar agente
+  // DELETE /agents/:key — eliminar agente (solo el dueño puede borrar los privados)
   router.delete('/:key', (req, res) => {
-    const ok = agents.remove(req.params.key);
-    if (!ok) return res.status(404).json({ error: 'Agente no encontrado' });
+    const userId = req.user?.internal ? null : req.user?.id;
+    const ok = agents.remove(req.params.key, userId);
+    if (!ok) return res.status(404).json({ error: 'Agente no encontrado o sin permisos' });
     res.json({ ok: true });
   });
 

--- a/server/services/ConversationService.js
+++ b/server/services/ConversationService.js
@@ -41,6 +41,7 @@ class ConversationService {
     agents         = null,
     skills         = null,
     ClaudePrintSession,
+    GeminiCliSession = null,
     consolidator   = null,
     logger         = console,
   }) {
@@ -60,6 +61,9 @@ class ConversationService {
     this._agents             = agents;
     this._skills             = skills;
     this._ClaudePrintSession = ClaudePrintSession;
+    this._GeminiCliSession   = GeminiCliSession || (() => {
+      try { return require('../core/GeminiCliSession'); } catch { return null; }
+    })();
     this._consolidator       = consolidator;
     this._logger             = logger;
 
@@ -265,6 +269,7 @@ class ConversationService {
     files         = null,
     history       = [],
     claudeSession = null,
+    geminiSession = null,
     claudeMode    = 'auto',
     onChunk       = null,
     onStatus      = null,
@@ -281,8 +286,9 @@ class ConversationService {
     const resolvedShellId = shellId || String(chatId);
     csdbg('msg', `chatId=${chatId} provider=${provider} agent=${agentKey} model=${model} textLen=${text.length} images=${images?.length || 0} histLen=${history.length} hasSession=${!!claudeSession}`);
 
-    // Rate limiting: 10 mensajes/minuto por chat (solo providers API)
-    if (provider !== 'claude-code') {
+    // Rate limiting: 10 mensajes/minuto por chat (solo providers API, no CLI)
+    const CLI_PROVIDERS = new Set(['claude-code', 'gemini-cli']);
+    if (!CLI_PROVIDERS.has(provider)) {
       const MAX_PER_MIN = 10;
       const now = Date.now();
       const key = `${botKey || 'web'}:${chatId}`;
@@ -299,10 +305,17 @@ class ConversationService {
       this._rateLimits.set(key, rl);
     }
 
-    if (provider !== 'claude-code' && this._providers) {
+    if (!CLI_PROVIDERS.has(provider) && this._providers) {
       csdbg('msg', `→ _processApiProvider mode=${claudeMode}`);
       return this._processApiProvider({
         chatId, agentKey, provider, model, text, images, history, onChunk, onStatus, onAskPermission, claudeMode, shellId: resolvedShellId, botKey, channel,
+      });
+    }
+
+    if (provider === 'gemini-cli') {
+      csdbg('msg', `→ _processGeminiCli mode=${claudeMode}`);
+      return this._processGeminiCli({
+        chatId, agentKey, text, geminiSession, claudeMode, onChunk, onStatus, botKey, channel,
       });
     }
 
@@ -379,6 +392,105 @@ class ConversationService {
       return `[El usuario adjuntó ${files.length} archivo(s):]\n\n${fileContext}\n\n[Mensaje del usuario: "${text}"]`;
     }
     return text;
+  }
+
+  // ── Proveedor gemini-cli (GeminiCliSession) ───────────────────────────────
+
+  async _processGeminiCli({ chatId, agentKey, text, geminiSession, claudeMode, onChunk, onStatus, botKey, channel }) {
+    const MAX_SESSION_MESSAGES = 10;
+    let session = geminiSession;
+    let isNewSession = false;
+
+    const isWebChannel = channel === 'web' || botKey === 'web';
+    const channelCtx = (botKey && chatId)
+      ? `\n\n## Contexto del canal\n- Canal: ${channel || 'telegram'}\n- Bot key: ${botKey}\n- Chat ID: ${chatId}\n- Agente activo: ${agentKey || 'default'}\nPara herramientas de memoria, usa agent="${agentKey || 'default'}".`
+      : '';
+
+    // Auto-reset de sesión y guardado de resumen en memoria
+    if (session && session.messageCount >= MAX_SESSION_MESSAGES) {
+      csdbg('gemini', `auto-reset: session tiene ${session.messageCount} msgs`);
+      if (agentKey && this._memory) {
+        try {
+          const ts = new Date().toISOString().slice(0, 16).replace('T', ' ');
+          const summary = `---\nSesión anterior (${ts}, ${session.messageCount} mensajes, chatId: ${chatId})\n---\n` +
+            `Último mensaje del usuario: ${text.slice(0, 500)}`;
+          this._memory.write(agentKey, 'last-session-summary.md', summary);
+        } catch {}
+      }
+      session = null;
+    }
+
+    if (!session) {
+      if (!this._GeminiCliSession) {
+        return { text: 'Error: GeminiCliSession no disponible. Instalá gemini CLI.' };
+      }
+      session = new this._GeminiCliSession({
+        permissionMode: claudeMode || 'auto',
+      });
+      isNewSession = true;
+      csdbg('gemini', `nueva GeminiCliSession mode=${claudeMode}`);
+    }
+
+    // Detección de señales de memoria e inyección de contexto
+    const { shouldNudge, signals } = (agentKey && this._memory)
+      ? this._memory.detectSignals(agentKey, text)
+      : { shouldNudge: false, signals: [] };
+
+    let messageText = text;
+    if (agentKey && this._memory && (session.messageCount <= 1 || isNewSession)) {
+      let memCtxRaw = this._memory.buildMemoryContext(agentKey, text, { provider: 'local' });
+      if (memCtxRaw && typeof memCtxRaw.then === 'function') {
+        memCtxRaw = await memCtxRaw.catch(() => '');
+      }
+      const memCtx = memCtxRaw || '';
+      const toolInstr = shouldNudge ? this._memory.TOOL_INSTRUCTIONS : '';
+      let sessionSummary = '';
+      try {
+        const summary = this._memory.read(agentKey, 'last-session-summary.md');
+        if (summary) sessionSummary = `## Resumen de sesión anterior\n${summary}`;
+      } catch {}
+      const parts = [sessionSummary, memCtx, channelCtx, toolInstr].filter(Boolean);
+      if (parts.length > 0) messageText = `${parts.join('\n\n')}\n\n---\n\n${text}`;
+    }
+    if (shouldNudge && this._memory) messageText += this._memory.buildNudge(signals);
+
+    csdbg('gemini', `→ session.sendMessage() textLen=${messageText.length}`);
+    let result;
+    try {
+      result = await session.sendMessage(messageText, onChunk, onStatus);
+    } catch (err) {
+      // Reintentar como nueva sesión si --resume falló
+      if (session.geminiSessionId && session.messageCount > 0) {
+        csdbg('gemini', `--resume falló (${err.message}), reintentando sin resume`);
+        session.geminiSessionId = null;
+        session.messageCount    = 0;
+        isNewSession = true;
+        result = await session.sendMessage(messageText, onChunk, onStatus);
+      } else {
+        throw err;
+      }
+    }
+
+    const rawResponse = typeof result === 'string' ? result : (result?.text || '');
+
+    // Extraer y aplicar operaciones de memoria
+    let response = rawResponse;
+    const savedMemoryFiles = [];
+    if (agentKey && rawResponse && this._memory) {
+      const { clean, ops } = this._memory.extractMemoryOps(rawResponse);
+      if (ops.length > 0) {
+        const saved = this._memory.applyOps(agentKey, ops);
+        response = clean || rawResponse;
+        savedMemoryFiles.push(...saved);
+      }
+    }
+
+    return {
+      text: response || '',
+      usedMcpTools: false,
+      savedMemoryFiles,
+      ...(isNewSession ? { newGeminiSession: session } : {}),
+    };
   }
 
   // ── Proveedor claude-code (ClaudePrintSession) ────────────────────────────

--- a/server/sessionManager.js
+++ b/server/sessionManager.js
@@ -20,7 +20,7 @@ function stripAnsi(str) {
 }
 
 class PtySession {
-  constructor({ type = 'pty', command, cols = 80, rows = 24 } = {}) {
+  constructor({ type = 'pty', command, cols = 80, rows = 24, cwd } = {}) {
     this.id = crypto.randomUUID();
     this.type = type;
     this.title = command || DEFAULT_SHELL;
@@ -32,10 +32,10 @@ class PtySession {
     this._outputListeners = new Map();
     this._pty = null;
 
-    this._spawn({ command, cols, rows });
+    this._spawn({ command, cols, rows, cwd });
   }
 
-  _spawn({ command, cols, rows }) {
+  _spawn({ command, cols, rows, cwd }) {
     const isWin = os.platform() === 'win32';
     const args = command
       ? (isWin ? ['-Command', command] : ['-c', command])
@@ -49,7 +49,7 @@ class PtySession {
       name: 'xterm-color',
       cols,
       rows,
-      cwd: process.env.HOME,
+      cwd: cwd || process.env.HOME,
       env,
     });
 


### PR DESCRIPTION
## Summary
- Nuevo provider `gemini-cli` (análogo a `claude-code`, usa CLI en lugar de API)
- `GeminiCliSession.js` en `server/core/`
- `ConversationService`: rutas gemini-cli sin rate limit, vía `_processGeminiCli`
- Actualizaciones en agentes, sesiones, canales Telegram y paneles del cliente

## Test plan
- [ ] Cambiar provider a `gemini-cli` desde Telegram o WebChat
- [ ] Verificar respuestas fluidas sin rate limit errors
- [ ] Verificar que otros providers no se vean afectados