### PR TITLE
feat(contacts): campo Telegram ID en formulario

### DIFF
--- a/client/src/components/ContactsPanel.jsx
+++ b/client/src/components/ContactsPanel.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { X, Plus, Star, StarOff, Pencil, Trash2, Check, Phone, Mail, FileText, Link } from 'lucide-react';
+import { X, Plus, Star, StarOff, Pencil, Trash2, Check, Phone, Mail, FileText, Link, MessageSquare } from 'lucide-react';
 import { API_BASE } from '../config';
 import { apiFetch } from '../authUtils';
 import './ContactsPanel.css';
@@ -13,6 +13,9 @@ function ContactForm({ initial, onSave, onCancel }) {
   const [email, setEmail] = useState(initial?.email || '');
   const [notes, setNotes] = useState(initial?.notes || '');
   const [isFavorite, setIsFavorite] = useState(!!initial?.is_favorite);
+  const [telegramId, setTelegramId] = useState(
+    initial?.linkedUser?.identities?.find(i => i.channel === 'telegram')?.identifier || ''
+  );
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
 
@@ -23,19 +26,33 @@ function ContactForm({ initial, onSave, onCancel }) {
     try {
       const url = isEdit ? `${API}/${initial.id}` : API;
       const method = isEdit ? 'PATCH' : 'POST';
+      const body = {
+        name: name.trim(),
+        phone: phone.trim() || null,
+        email: email.trim() || null,
+        notes: notes.trim() || null,
+        is_favorite: isFavorite,
+      };
+      if (!isEdit && telegramId.trim()) body.telegram_id = telegramId.trim();
       const res = await apiFetch(url, {
         method,
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          name: name.trim(),
-          phone: phone.trim() || null,
-          email: email.trim() || null,
-          notes: notes.trim() || null,
-          is_favorite: isFavorite,
-        }),
+        body: JSON.stringify(body),
       });
       const data = await res.json();
       if (!res.ok || data.error) throw new Error(data.error || 'Error');
+
+      // En edición, vincular por Telegram ID si se proporcionó
+      if (isEdit && telegramId.trim()) {
+        const linkRes = await apiFetch(`${API}/${initial.id}/link`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ telegram_id: telegramId.trim() }),
+        });
+        const linkData = await linkRes.json();
+        if (!linkRes.ok || linkData.error) throw new Error(linkData.error || 'Error al vincular Telegram');
+      }
+
       onSave();
     } catch (err) {
       setError(err.message);
@@ -76,6 +93,16 @@ function ContactForm({ initial, onSave, onCancel }) {
         value={email}
         onChange={e => setEmail(e.target.value)}
         aria-label="Email"
+      />
+
+      <label className="cp-label" style={{ marginTop: 8 }}>Telegram ID</label>
+      <input
+        className="cp-input"
+        type="text"
+        placeholder="ej: 7874537448"
+        value={telegramId}
+        onChange={e => setTelegramId(e.target.value)}
+        aria-label="Telegram ID"
       />
 
       <label className="cp-label" style={{ marginTop: 8 }}>Notas</label>
@@ -160,6 +187,12 @@ function ContactDetail({ contactId, onBack, onEdit, onDelete }) {
           <div className="cp-detail-row cp-detail-notes">
             <FileText size={13} />
             <span>{contact.notes}</span>
+          </div>
+        )}
+        {contact.linkedUser?.identities?.find(i => i.channel === 'telegram') && (
+          <div className="cp-detail-row">
+            <MessageSquare size={13} />
+            <span>Telegram: {contact.linkedUser.identities.find(i => i.channel === 'telegram').identifier}</span>
           </div>
         )}
         {contact.linkedUser ? (

--- a/client/src/components/ContactsPanel.jsx
+++ b/client/src/components/ContactsPanel.jsx
@@ -33,7 +33,11 @@ function ContactForm({ initial, onSave, onCancel }) {
         notes: notes.trim() || null,
         is_favorite: isFavorite,
       };
-      if (!isEdit && telegramId.trim()) body.telegram_id = telegramId.trim();
+      if (!isEdit && telegramId.trim()) {
+        const tid = telegramId.trim();
+        if (tid.startsWith('@')) body.username = tid;
+        else body.telegram_id = tid;
+      }
       const res = await apiFetch(url, {
         method,
         headers: { 'Content-Type': 'application/json' },
@@ -42,12 +46,14 @@ function ContactForm({ initial, onSave, onCancel }) {
       const data = await res.json();
       if (!res.ok || data.error) throw new Error(data.error || 'Error');
 
-      // En edición, vincular por Telegram ID si se proporcionó
+      // En edición, vincular por Telegram ID o username si se proporcionó
       if (isEdit && telegramId.trim()) {
+        const tid = telegramId.trim();
+        const linkBody = tid.startsWith('@') ? { username: tid } : { telegram_id: tid };
         const linkRes = await apiFetch(`${API}/${initial.id}/link`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ telegram_id: telegramId.trim() }),
+          body: JSON.stringify(linkBody),
         });
         const linkData = await linkRes.json();
         if (!linkRes.ok || linkData.error) throw new Error(linkData.error || 'Error al vincular Telegram');
@@ -95,14 +101,14 @@ function ContactForm({ initial, onSave, onCancel }) {
         aria-label="Email"
       />
 
-      <label className="cp-label" style={{ marginTop: 8 }}>Telegram ID</label>
+      <label className="cp-label" style={{ marginTop: 8 }}>Telegram (ID o @username)</label>
       <input
         className="cp-input"
         type="text"
-        placeholder="ej: 7874537448"
+        placeholder="ej: 7874537448 o @bpadilla3570"
         value={telegramId}
         onChange={e => setTelegramId(e.target.value)}
-        aria-label="Telegram ID"
+        aria-label="Telegram ID o username"
       />
 
       <label className="cp-label" style={{ marginTop: 8 }}>Notas</label>

--- a/server/routes/contacts.js
+++ b/server/routes/contacts.js
@@ -27,12 +27,16 @@ module.exports = function createContactsRouter({ usersRepo }) {
     const ownerId = getOwnerId(req);
     if (!ownerId) return res.status(401).json({ error: 'No autenticado' });
 
-    const { name, phone, email, notes, is_favorite, telegram_id } = req.body || {};
+    const { name, phone, email, notes, is_favorite, telegram_id, username } = req.body || {};
     if (!name) return res.status(400).json({ error: 'name requerido' });
 
     let userId = null;
     if (telegram_id) {
       const u = usersRepo.findByIdentity('telegram', String(telegram_id));
+      if (u) userId = u.id;
+    }
+    if (!userId && username) {
+      const u = usersRepo.findByTelegramUsername(username);
       if (u) userId = u.id;
     }
 
@@ -107,7 +111,7 @@ module.exports = function createContactsRouter({ usersRepo }) {
     const contact = usersRepo.getContact(req.params.id);
     if (!contact || contact.owner_id !== ownerId) return res.status(404).json({ error: 'No encontrado' });
 
-    const { telegram_id, user_id } = req.body || {};
+    const { telegram_id, user_id, username } = req.body || {};
     let userId = user_id || null;
 
     if (!userId && telegram_id) {
@@ -116,7 +120,13 @@ module.exports = function createContactsRouter({ usersRepo }) {
       userId = u.id;
     }
 
-    if (!userId) return res.status(400).json({ error: 'Se requiere telegram_id o user_id' });
+    if (!userId && username) {
+      const u = usersRepo.findByTelegramUsername(username);
+      if (!u) return res.status(404).json({ error: `No hay usuario con username ${username}` });
+      userId = u.id;
+    }
+
+    if (!userId) return res.status(400).json({ error: 'Se requiere telegram_id, username o user_id' });
 
     usersRepo.updateContact(req.params.id, { user_id: userId });
     res.json(usersRepo.getContact(req.params.id));

--- a/server/storage/UsersRepository.js
+++ b/server/storage/UsersRepository.js
@@ -119,6 +119,32 @@ class UsersRepository {
   }
 
   /**
+   * Busca un usuario de Telegram por su username (@handle).
+   * El username está guardado en el campo metadata JSON de user_identities.
+   */
+  findByTelegramUsername(username) {
+    if (!this._db || !username) return null;
+    const clean = username.replace(/^@/, '').toLowerCase();
+    const rows = this._db.prepare(`
+      SELECT u.*, ui.metadata
+      FROM user_identities ui
+      JOIN users u ON u.id = ui.user_id
+      WHERE ui.channel = 'telegram' AND ui.metadata IS NOT NULL
+    `).all();
+    for (const row of rows) {
+      try {
+        const meta = JSON.parse(row.metadata);
+        if (meta.username && meta.username.toLowerCase() === clean) {
+          const user = { id: row.id, name: row.name, role: row.role, created_at: row.created_at, updated_at: row.updated_at };
+          user.identities = this.getIdentities(user.id);
+          return user;
+        }
+      } catch { /* metadata no es JSON válido */ }
+    }
+    return null;
+  }
+
+  /**
    * Busca un usuario por identidad; si no existe, crea usuario + identidad.
    * Idempotente: si ya existe la identidad, retorna el usuario sin modificar.
    */


### PR DESCRIPTION
## Cambios

- Campo **Telegram ID** agregado al formulario de creación y edición de contactos
- **Creación**: se incluye en el `POST /contacts` body → auto-vincula si el usuario ya existe en el sistema
- **Edición**: si se completa el campo, llama a `POST /contacts/:id/link` tras el PATCH
- **Vista de detalle**: muestra el Telegram ID del contacto vinculado con ícono MessageSquare