### PR TITLE
feat(client): rediseño Fase 1 — sidebar + secciones

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1,3 +1,4 @@
+/* ── Skip link ────────────────────────────────────────────────────────────── */
 .skip-link {
   position: absolute;
   top: -40px;
@@ -9,11 +10,9 @@
   font-size: 14px;
   text-decoration: none;
 }
+.skip-link:focus { top: 0; }
 
-.skip-link:focus {
-  top: 0;
-}
-
+/* ── Root ─────────────────────────────────────────────────────────────────── */
 .app {
   display: flex;
   flex-direction: column;
@@ -22,6 +21,7 @@
   overflow: hidden;
 }
 
+/* ── Header ───────────────────────────────────────────────────────────────── */
 .app-header {
   display: flex;
   align-items: center;
@@ -31,14 +31,10 @@
   border-bottom: 1px solid var(--border-primary);
   user-select: none;
   flex-shrink: 0;
+  height: 42px;
 }
 
-.dot {
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-}
-
+.dot { width: 12px; height: 12px; border-radius: 50%; }
 .dot.red    { background: #ff5f57; }
 .dot.yellow { background: #febc2e; }
 .dot.green  { background: #28c840; }
@@ -46,12 +42,12 @@
 .title {
   margin: 0 0 0 8px;
   font-size: 12px;
-  font-weight: normal;
+  font-weight: 600;
   color: var(--text-muted);
-  letter-spacing: 0.05em;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
-/* Empuja los botones a la derecha */
 .header-right {
   margin-left: auto;
   display: flex;
@@ -59,152 +55,301 @@
   gap: 8px;
 }
 
-/* ─── Header buttons ──────────────────────────────────────────────────────── */
+.header-user {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-primary);
+  border-radius: 20px;
+  padding: 3px 10px 3px 4px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
 
-.telegram-btn {
-  position: relative;
+.header-user-avatar {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--accent-green), #16a34a);
+  color: #000;
+  font-size: 11px;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.header-user-name {
+  font-size: 12px;
+  color: var(--text-muted);
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.header-icon-btn {
   background: none;
   border: 1px solid transparent;
   border-radius: 6px;
   color: var(--text-muted);
-  font-size: 16px;
   cursor: pointer;
-  padding: 6px 10px;
+  padding: 5px 8px;
   line-height: 1;
+  display: flex;
+  align-items: center;
   transition: color 0.15s, border-color 0.15s, background 0.15s;
 }
-
-.telegram-btn:hover {
-  color: var(--accent-cyan);
-  border-color: #29b6f633;
-  background: #29b6f611;
-}
-
-.telegram-btn:focus-visible {
-  outline: 2px solid var(--accent-cyan);
-  outline-offset: 2px;
-}
-
-.telegram-btn.active {
-  color: var(--accent-cyan);
-  border-color: #29b6f644;
-  background: #29b6f618;
-}
-
-/* Theme toggle — warm colors */
-.theme-toggle:hover {
+.header-icon-btn:hover {
   color: var(--accent-yellow);
   border-color: rgba(254, 188, 46, 0.2);
   background: rgba(254, 188, 46, 0.07);
 }
+.header-icon-btn:focus-visible {
+  outline: 2px solid var(--accent-cyan);
+  outline-offset: 2px;
+}
 
-/* Badge con conteo de chats */
-.telegram-badge {
+/* ── Layout principal ─────────────────────────────────────────────────────── */
+.app-layout {
+  flex: 1;
+  display: flex;
+  overflow: hidden;
+}
+
+/* ── Sidebar ──────────────────────────────────────────────────────────────── */
+.app-sidebar {
+  width: 60px;
+  background: var(--bg-header);
+  border-right: 1px solid var(--border-primary);
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+  padding: 8px 0;
+}
+
+.sidebar-nav {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding: 0 8px;
+  flex: 1;
+}
+
+.sidebar-bottom {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0 8px 4px;
+}
+
+.sidebar-item {
+  width: 44px;
+  min-height: 44px;
+  border-radius: 10px;
+  border: 1px solid transparent;
+  background: none;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+  cursor: pointer;
+  color: var(--text-muted);
+  position: relative;
+  transition: color 0.15s, background 0.15s, border-color 0.15s;
+  padding: 6px 2px;
+}
+
+.sidebar-item:hover {
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+}
+
+.sidebar-item.active {
+  color: var(--accent-cyan);
+  background: color-mix(in srgb, var(--accent-cyan) 10%, transparent);
+  border-color: color-mix(in srgb, var(--accent-cyan) 25%, transparent);
+}
+
+.sidebar-item:focus-visible {
+  outline: 2px solid var(--accent-cyan);
+  outline-offset: 2px;
+}
+
+.sidebar-label {
+  font-size: 9px;
+  font-weight: 500;
+  letter-spacing: 0.2px;
+  line-height: 1;
+}
+
+.sidebar-badge {
   position: absolute;
-  top: -4px;
-  right: -5px;
+  top: 4px;
+  right: 4px;
   background: var(--accent-green);
   color: #000;
-  font-size: 9px;
+  font-size: 8px;
   font-weight: 700;
-  border-radius: 50%;
-  width: 14px;
+  border-radius: 8px;
+  min-width: 14px;
   height: 14px;
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: 0 3px;
   line-height: 1;
 }
 
-/* ─── Layout con panel lateral ────────────────────────────────────────────── */
-
-.app-body-wrap {
-  flex: 1;
-  display: flex;
-  overflow: hidden;
+.sidebar-divider {
+  width: 28px;
+  height: 1px;
+  background: var(--border-primary);
+  margin: 6px 0;
 }
 
-.app-body {
+/* ── Content area ─────────────────────────────────────────────────────────── */
+.app-content {
   flex: 1;
   min-width: 0;
+  display: flex;
   overflow: hidden;
   position: relative;
 }
 
-/* ─── Responsive: móvil (<640px) ──────────────────────────────────────────── */
-@media (max-width: 640px) {
-  .app-header {
-    padding: 6px 10px;
-    gap: 6px;
-  }
-  .title {
-    display: none;
-  }
-  .dot {
-    display: none;
-  }
-
-  /* Hide desktop header nav on mobile — bottom nav replaces it */
-  .header-right .telegram-btn:not(.theme-toggle) {
-    display: none;
-  }
-
-  .app-body-wrap {
-    position: relative;
-    /* Leave space for bottom nav */
-    margin-bottom: 56px;
-  }
-
-  /* Side panels become fullscreen overlay on mobile */
-  .app-body-wrap > *:not(.app-body) {
-    position: absolute;
-    inset: 0;
-    width: 100% !important;
-    min-width: 0 !important;
-    max-width: 100% !important;
-    border-left: none !important;
-    z-index: 20;
-  }
+/* ── Secciones ────────────────────────────────────────────────────────────── */
+.section {
+  display: none;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
 }
 
-/* ─── Responsive: tablet (641px-768px) ────────────────────────────────────── */
-@media (max-width: 768px) and (min-width: 641px) {
-  .app-header {
-    padding: 6px 10px;
-    gap: 6px;
-  }
-  .title {
-    display: none;
-  }
-  .dot {
-    display: none;
-  }
-  .app-body-wrap {
-    position: relative;
-  }
-  .app-body-wrap > *:not(.app-body) {
-    position: absolute;
-    inset: 0;
-    width: 100% !important;
-    min-width: 0 !important;
-    max-width: 100% !important;
-    border-left: none !important;
-    z-index: 20;
-  }
+.section.section-active {
+  display: flex;
+  flex-direction: column;
 }
 
-/* ─── Responsive: tablet (769px-1000px) ───────────────────────────────────── */
-@media (max-width: 1000px) and (min-width: 769px) {
-  .app-body-wrap > *:not(.app-body) {
-    position: absolute;
-    right: 0;
-    top: 0;
-    bottom: 0;
-    min-width: 0 !important;
-    z-index: 20;
-    box-shadow: -4px 0 16px rgba(0, 0, 0, 0.4);
-  }
-  .app-body-wrap {
-    position: relative;
-  }
+/* Terminal section */
+.section-terminal {
+  flex-direction: column;
+}
+
+.terminal-body {
+  flex: 1;
+  overflow: hidden;
+  position: relative;
+}
+
+/* Full-width sections (chat, telegram, contacts, config) */
+.section-full {
+  flex-direction: column;
+}
+
+/* ── Config section ───────────────────────────────────────────────────────── */
+.section-config {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.config-tab-bar {
+  display: flex;
+  gap: 0;
+  background: var(--bg-header);
+  border-bottom: 1px solid var(--border-primary);
+  padding: 0 20px;
+  flex-shrink: 0;
+}
+
+.config-tab {
+  height: 44px;
+  padding: 0 18px;
+  border: none;
+  border-bottom: 2px solid transparent;
+  background: none;
+  color: var(--text-muted);
+  font-size: 13px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  transition: color 0.15s, border-color 0.15s;
+}
+.config-tab:hover { color: var(--text-primary); }
+.config-tab.active {
+  color: var(--accent-yellow);
+  border-bottom-color: var(--accent-yellow);
+}
+.config-tab:focus-visible {
+  outline: 2px solid var(--accent-cyan);
+  outline-offset: -2px;
+}
+
+.config-tab-body {
+  flex: 1;
+  overflow: hidden;
+  display: flex;
+}
+
+/* Los paneles embebidos (sin el header/close propio) llenan el espacio */
+.config-tab-body > *,
+.section-full > * {
+  flex: 1;
+  width: 100% !important;
+  min-width: 0 !important;
+  max-width: 100% !important;
+  border-left: none !important;
+  border-radius: 0 !important;
+  box-shadow: none !important;
+}
+
+/* ── Mobile bottom nav ────────────────────────────────────────────────────── */
+.mobile-bottom-nav {
+  display: none;
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 56px;
+  background: var(--bg-header);
+  border-top: 1px solid var(--border-primary);
+  z-index: 50;
+}
+
+.mobile-bottom-nav button {
+  flex: 1;
+  height: 100%;
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+  font-size: 9px;
+  cursor: pointer;
+  transition: color 0.15s;
+}
+.mobile-bottom-nav button.active { color: var(--accent-cyan); }
+.mobile-bottom-nav button:hover  { color: var(--text-primary); }
+
+/* ── Responsive ───────────────────────────────────────────────────────────── */
+@media (max-width: 768px) {
+  .app-sidebar { display: none; }
+  .mobile-bottom-nav { display: flex; }
+  .app-layout { margin-bottom: 56px; }
+  .dot, .title { display: none; }
+  .app-header { padding: 6px 10px; }
+}
+
+@media (max-width: 480px) {
+  .header-user-name { display: none; }
+  .header-user { padding: 3px 6px; }
 }

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -128,6 +128,12 @@
   flex-direction: column;
   flex-shrink: 0;
   padding: 8px 0;
+  transition: width 0.2s ease;
+  overflow: hidden;
+}
+
+.app-sidebar.sidebar-expanded {
+  width: 180px;
 }
 
 .sidebar-nav {
@@ -137,6 +143,7 @@
   gap: 2px;
   padding: 0 8px;
   flex: 1;
+  overflow: hidden;
 }
 
 .sidebar-bottom {
@@ -144,6 +151,13 @@
   flex-direction: column;
   align-items: center;
   padding: 0 8px 4px;
+  overflow: hidden;
+}
+
+/* Expanded: items stretch full width */
+.app-sidebar.sidebar-expanded .sidebar-nav,
+.app-sidebar.sidebar-expanded .sidebar-bottom {
+  align-items: stretch;
 }
 
 .sidebar-item {
@@ -162,6 +176,18 @@
   position: relative;
   transition: color 0.15s, background 0.15s, border-color 0.15s;
   padding: 6px 2px;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+/* Expanded: items are rows */
+.app-sidebar.sidebar-expanded .sidebar-item {
+  width: auto;
+  flex-direction: row;
+  justify-content: flex-start;
+  padding: 9px 12px;
+  gap: 10px;
+  border-radius: 8px;
 }
 
 .sidebar-item:hover {
@@ -187,6 +213,12 @@
   line-height: 1;
 }
 
+.app-sidebar.sidebar-expanded .sidebar-label {
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0;
+}
+
 .sidebar-badge {
   position: absolute;
   top: 4px;
@@ -205,12 +237,27 @@
   line-height: 1;
 }
 
+.app-sidebar.sidebar-expanded .sidebar-badge {
+  position: static;
+  margin-left: auto;
+}
+
 .sidebar-divider {
   width: 28px;
   height: 1px;
   background: var(--border-primary);
   margin: 6px 0;
+  flex-shrink: 0;
 }
+
+.app-sidebar.sidebar-expanded .sidebar-divider {
+  width: 100%;
+}
+
+.sidebar-toggle-btn {
+  opacity: 0.6;
+}
+.sidebar-toggle-btn:hover { opacity: 1; }
 
 /* ── Content area ─────────────────────────────────────────────────────────── */
 .app-content {
@@ -248,6 +295,38 @@
 /* Full-width sections (chat, telegram, contacts, config) */
 .section-full {
   flex-direction: column;
+}
+
+/* ── Barra de sección ─────────────────────────────────────────────────────── */
+.section-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  height: 36px;
+  padding: 0 16px;
+  background: var(--bg-header);
+  border-bottom: 1px solid var(--border-primary);
+  flex-shrink: 0;
+}
+
+.section-bar-icon {
+  color: var(--accent-cyan);
+}
+
+.section-bar-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.section-bar-badge {
+  font-size: 11px;
+  color: var(--text-muted);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-primary);
+  border-radius: 10px;
+  padding: 1px 7px;
+  margin-left: 2px;
 }
 
 /* ── Config section ───────────────────────────────────────────────────────── */
@@ -297,9 +376,13 @@
   display: flex;
 }
 
-/* Los paneles embebidos (sin el header/close propio) llenan el espacio */
+/* Paneles embebidos llenan el espacio — section-bar queda excluida */
+.section-full > .section-bar {
+  flex: none;
+}
+
 .config-tab-body > *,
-.section-full > * {
+.section-full > :not(.section-bar) {
   flex: 1;
   width: 100% !important;
   min-width: 0 !important;

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useRef, useEffect, lazy, Suspense } from 'react';
 import {
-  Terminal, MessageCircle, Send, Users, BookUser, Settings,
-  Plug, Bot, Sun, Moon,
+  Terminal, MessageCircle, Send, BookUser, Settings,
+  Plug, Bot, Sun, Moon, ChevronLeft, ChevronRight,
 } from 'lucide-react';
 import TabBar from './components/TabBar.jsx';
 import CommandBar from './components/CommandBar.jsx';
@@ -37,73 +37,87 @@ function createSession(command = null, type = 'pty', httpSessionId = null, provi
   return { id, title, command, type, httpSessionId, provider };
 }
 
-// ── Secciones de navegación ───────────────────────────────────────────────────
+// ── Metadatos de secciones ────────────────────────────────────────────────────
 
-const NAV_TOP = [
-  { key: 'terminal',  Icon: Terminal,        label: 'Terminal' },
-  { key: 'chat',      Icon: MessageCircle,   label: 'Chat' },
-];
-const NAV_MID = [
-  { key: 'telegram',  Icon: Send,            label: 'Telegram' },
-  { key: 'contacts',  Icon: BookUser,        label: 'Contactos' },
-];
+const SECTION_META = {
+  terminal: { Icon: Terminal,      label: 'Terminal'       },
+  chat:     { Icon: MessageCircle, label: 'Chat IA'        },
+  telegram: { Icon: Send,          label: 'Telegram'       },
+  contacts: { Icon: BookUser,      label: 'Contactos'      },
+  config:   { Icon: Settings,      label: 'Configuración'  },
+};
+
+const NAV_TOP = ['terminal', 'chat'];
+const NAV_MID = ['telegram', 'contacts'];
+
 const CONFIG_TABS = [
-  { key: 'agents',    Icon: Bot,             label: 'Agentes' },
-  { key: 'providers', Icon: Settings,        label: 'Providers' },
-  { key: 'mcps',      Icon: Plug,            label: 'MCPs' },
+  { key: 'agents',    Icon: Bot,      label: 'Agentes'  },
+  { key: 'providers', Icon: Settings, label: 'Providers' },
+  { key: 'mcps',      Icon: Plug,     label: 'MCPs'     },
 ];
 
 // ── Sidebar ───────────────────────────────────────────────────────────────────
 
-function Sidebar({ section, onSection, telegramBadge }) {
+function Sidebar({ section, onSection, telegramBadge, expanded, onToggle }) {
+  const renderItem = (key) => {
+    const { Icon, label } = SECTION_META[key];
+    return (
+      <button
+        key={key}
+        className={`sidebar-item ${section === key ? 'active' : ''}`}
+        onClick={() => onSection(key)}
+        title={!expanded ? label : undefined}
+        aria-label={label}
+        aria-current={section === key ? 'page' : undefined}
+      >
+        <Icon size={18} aria-hidden="true" />
+        <span className="sidebar-label">{label}</span>
+        {key === 'telegram' && telegramBadge > 0 && (
+          <span className="sidebar-badge" aria-label={`${telegramBadge} chats`}>{telegramBadge}</span>
+        )}
+      </button>
+    );
+  };
+
   return (
-    <aside className="app-sidebar" aria-label="Navegación principal">
+    <aside className={`app-sidebar${expanded ? ' sidebar-expanded' : ''}`} aria-label="Navegación principal">
       <nav className="sidebar-nav">
-        {NAV_TOP.map(({ key, Icon, label }) => (
-          <button
-            key={key}
-            className={`sidebar-item ${section === key ? 'active' : ''}`}
-            onClick={() => onSection(key)}
-            aria-label={label}
-            aria-current={section === key ? 'page' : undefined}
-          >
-            <Icon size={18} aria-hidden="true" />
-            <span className="sidebar-label">{label}</span>
-          </button>
-        ))}
-
+        {NAV_TOP.map(renderItem)}
         <div className="sidebar-divider" aria-hidden="true" />
-
-        {NAV_MID.map(({ key, Icon, label }) => (
-          <button
-            key={key}
-            className={`sidebar-item ${section === key ? 'active' : ''}`}
-            onClick={() => onSection(key)}
-            aria-label={label}
-            aria-current={section === key ? 'page' : undefined}
-          >
-            <Icon size={18} aria-hidden="true" />
-            <span className="sidebar-label">{label}</span>
-            {key === 'telegram' && telegramBadge > 0 && (
-              <span className="sidebar-badge" aria-label={`${telegramBadge} chats`}>{telegramBadge}</span>
-            )}
-          </button>
-        ))}
+        {NAV_MID.map(renderItem)}
       </nav>
 
       <div className="sidebar-bottom">
         <div className="sidebar-divider" aria-hidden="true" />
+        {renderItem('config')}
         <button
-          className={`sidebar-item ${section === 'config' ? 'active' : ''}`}
-          onClick={() => onSection('config')}
-          aria-label="Configuración"
-          aria-current={section === 'config' ? 'page' : undefined}
+          className="sidebar-item sidebar-toggle-btn"
+          onClick={onToggle}
+          title={expanded ? 'Colapsar sidebar' : 'Expandir sidebar'}
+          aria-label={expanded ? 'Colapsar sidebar' : 'Expandir sidebar'}
         >
-          <Settings size={18} aria-hidden="true" />
-          <span className="sidebar-label">Config</span>
+          {expanded
+            ? <ChevronLeft  size={16} aria-hidden="true" />
+            : <ChevronRight size={16} aria-hidden="true" />}
         </button>
       </div>
     </aside>
+  );
+}
+
+// ── Barra de sección ──────────────────────────────────────────────────────────
+
+function SectionBar({ section, telegramBadge }) {
+  if (!['chat', 'telegram', 'contacts'].includes(section)) return null;
+  const { Icon, label } = SECTION_META[section];
+  return (
+    <div className="section-bar">
+      <Icon size={14} className="section-bar-icon" aria-hidden="true" />
+      <span className="section-bar-title">{label}</span>
+      {section === 'telegram' && telegramBadge > 0 && (
+        <span className="section-bar-badge">{telegramBadge} chats</span>
+      )}
+    </div>
   );
 }
 
@@ -145,12 +159,30 @@ function AppContent() {
   const { user } = useAuth();
 
   const [section, setSection]   = useState('terminal');
+  const [mounted, setMounted]   = useState({ terminal: true });
   const [sessions, setSessions] = useState(() => { const s = createSession(); return [s]; });
   const [activeId, setActiveId] = useState(() => nextId);
   const [telegramChatsCount, setTelegramChatsCount] = useState(0);
   const [wsConnected, setWsConnected] = useState(true);
+  const [sidebarExpanded, setSidebarExpanded] = useState(() => {
+    try { return localStorage.getItem('sidebar-expanded') === 'true'; } catch { return false; }
+  });
 
   const httpIdToTabId = useRef(new Map());
+
+  // Cambia de sección y monta la sección si es la primera vez
+  const handleSection = useCallback((key) => {
+    setMounted(prev => prev[key] ? prev : { ...prev, [key]: true });
+    setSection(key);
+  }, []);
+
+  const toggleSidebar = useCallback(() => {
+    setSidebarExpanded(v => {
+      const next = !v;
+      try { localStorage.setItem('sidebar-expanded', String(next)); } catch {}
+      return next;
+    });
+  }, []);
 
   // Listener WebSocket global (eventos de Telegram → nuevas tabs)
   useEffect(() => {
@@ -201,9 +233,9 @@ function AppContent() {
     const s = createSession(command, type, httpSessionId, provider);
     setSessions((prev) => [...prev, s]);
     setActiveId(s.id);
-    setSection('terminal');
+    handleSection('terminal');
     return s;
-  }, []);
+  }, [handleSection]);
 
   const closeSession = useCallback((id) => {
     setSessions((prev) => {
@@ -221,14 +253,14 @@ function AppContent() {
     });
   }, [activeId]);
 
-  const handleSessionId  = useCallback((frontendTabId, httpId) => { httpIdToTabId.current.set(httpId, frontendTabId); }, []);
+  const handleSessionId   = useCallback((frontendTabId, httpId) => { httpIdToTabId.current.set(httpId, frontendTabId); }, []);
   const handleOpenSession = useCallback((httpSessionId) => {
     const tabId = httpIdToTabId.current.get(httpSessionId);
     if (tabId) { setActiveId(tabId); } else { openNew(null, 'pty', httpSessionId); }
-    setSection('terminal');
-  }, [openNew]);
+    handleSection('terminal');
+  }, [openNew, handleSection]);
 
-  const toTerminal = useCallback(() => setSection('terminal'), []);
+  const toTerminal = useCallback(() => handleSection('terminal'), [handleSection]);
 
   return (
     <div className="app">
@@ -265,8 +297,10 @@ function AppContent() {
       <div className="app-layout">
         <Sidebar
           section={section}
-          onSection={setSection}
+          onSection={handleSection}
           telegramBadge={telegramChatsCount}
+          expanded={sidebarExpanded}
+          onToggle={toggleSidebar}
         />
 
         <div id="app-main" className="app-content">
@@ -301,9 +335,10 @@ function AppContent() {
             </main>
           </div>
 
-          {/* ── Chat IA ── */}
-          {section === 'chat' && (
-            <div className="section section-full section-active">
+          {/* ── Chat IA — montado en primer acceso, persiste con CSS ── */}
+          {mounted.chat && (
+            <div className={`section section-full ${section === 'chat' ? 'section-active' : ''}`} aria-hidden={section !== 'chat'}>
+              <SectionBar section="chat" telegramBadge={0} />
               <ErrorBoundary>
                 <Suspense fallback={<Skeleton lines={6} style={{ padding: '24px' }} />}>
                   <WebChatPanel onClose={toTerminal} embedded />
@@ -312,9 +347,10 @@ function AppContent() {
             </div>
           )}
 
-          {/* ── Telegram ── */}
-          {section === 'telegram' && (
-            <div className="section section-full section-active">
+          {/* ── Telegram — montado en primer acceso, persiste con CSS ── */}
+          {mounted.telegram && (
+            <div className={`section section-full ${section === 'telegram' ? 'section-active' : ''}`} aria-hidden={section !== 'telegram'}>
+              <SectionBar section="telegram" telegramBadge={telegramChatsCount} />
               <ErrorBoundary>
                 <Suspense fallback={<Skeleton lines={6} style={{ padding: '24px' }} />}>
                   <TelegramPanel onClose={toTerminal} onOpenSession={handleOpenSession} embedded />
@@ -323,9 +359,10 @@ function AppContent() {
             </div>
           )}
 
-          {/* ── Contactos ── */}
-          {section === 'contacts' && (
-            <div className="section section-full section-active">
+          {/* ── Contactos — montado en primer acceso, persiste con CSS ── */}
+          {mounted.contacts && (
+            <div className={`section section-full ${section === 'contacts' ? 'section-active' : ''}`} aria-hidden={section !== 'contacts'}>
+              <SectionBar section="contacts" telegramBadge={0} />
               <ErrorBoundary>
                 <Suspense fallback={<Skeleton lines={6} style={{ padding: '24px' }} />}>
                   <ContactsPanel onClose={toTerminal} embedded />
@@ -334,9 +371,9 @@ function AppContent() {
             </div>
           )}
 
-          {/* ── Config ── */}
-          {section === 'config' && (
-            <div className="section section-full section-active">
+          {/* ── Config — montado en primer acceso, persiste con CSS ── */}
+          {mounted.config && (
+            <div className={`section section-full ${section === 'config' ? 'section-active' : ''}`} aria-hidden={section !== 'config'}>
               <ErrorBoundary>
                 <Suspense fallback={<Skeleton lines={6} style={{ padding: '24px' }} />}>
                   <ConfigSection />
@@ -351,16 +388,16 @@ function AppContent() {
       {/* ── Mobile bottom nav ── */}
       <nav className="mobile-bottom-nav" aria-label="Navegación móvil">
         {[
-          { key: 'terminal',  Icon: Terminal,      label: 'Terminal' },
-          { key: 'chat',      Icon: MessageCircle, label: 'Chat' },
-          { key: 'telegram',  Icon: Send,          label: 'TG' },
-          { key: 'contacts',  Icon: BookUser,      label: 'Contactos' },
-          { key: 'config',    Icon: Settings,      label: 'Config' },
+          { key: 'terminal', Icon: Terminal,      label: 'Terminal' },
+          { key: 'chat',     Icon: MessageCircle, label: 'Chat'     },
+          { key: 'telegram', Icon: Send,          label: 'TG'       },
+          { key: 'contacts', Icon: BookUser,      label: 'Contactos' },
+          { key: 'config',   Icon: Settings,      label: 'Config'   },
         ].map(({ key, Icon, label }) => (
           <button
             key={key}
             className={section === key ? 'active' : ''}
-            onClick={() => setSection(key)}
+            onClick={() => handleSection(key)}
             aria-label={label}
           >
             <Icon size={20} aria-hidden="true" />

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,5 +1,8 @@
-import { useState, useCallback, useRef, useEffect, useReducer, lazy, Suspense } from 'react';
-import { MessageCircle, Settings, Plug, Users, Bot, Sun, Moon, Terminal, BookUser } from 'lucide-react';
+import { useState, useCallback, useRef, useEffect, lazy, Suspense } from 'react';
+import {
+  Terminal, MessageCircle, Send, Users, BookUser, Settings,
+  Plug, Bot, Sun, Moon,
+} from 'lucide-react';
 import TabBar from './components/TabBar.jsx';
 import CommandBar from './components/CommandBar.jsx';
 import ErrorBoundary from './components/ErrorBoundary.jsx';
@@ -8,95 +11,154 @@ import ReconnectBanner from './components/ReconnectBanner.jsx';
 import { AuthProvider } from './contexts/AuthContext.jsx';
 import { ThemeProvider, useTheme } from './contexts/ThemeContext.jsx';
 import { ToastProvider } from './contexts/ToastContext.jsx';
+import { useAuth } from './contexts/AuthContext.jsx';
 import { API_BASE, WS_URL } from './config';
 import { apiFetch } from './authUtils';
 import './App.css';
-import './components/AgentsPanel.css';
-import './components/TelegramPanel.css';
-import './components/ContactsPanel.css';
-import './components/WebChatPanel.css';
-import './components/ProvidersPanel.css';
 
-// Lazy-load paneles que se abren bajo demanda
-const TerminalPanel = lazy(() => import('./components/TerminalPanel.jsx'));
-const TelegramPanel = lazy(() => import('./components/TelegramPanel.jsx'));
-const AgentsPanel = lazy(() => import('./components/AgentsPanel.jsx'));
+const TerminalPanel  = lazy(() => import('./components/TerminalPanel.jsx'));
+const TelegramPanel  = lazy(() => import('./components/TelegramPanel.jsx'));
+const AgentsPanel    = lazy(() => import('./components/AgentsPanel.jsx'));
 const ProvidersPanel = lazy(() => import('./components/ProvidersPanel.jsx'));
-const McpsPanel = lazy(() => import('./components/McpsPanel.jsx'));
-const WebChatPanel = lazy(() => import('./components/WebChatPanel.jsx'));
-const ContactsPanel = lazy(() => import('./components/ContactsPanel.jsx'));
+const McpsPanel      = lazy(() => import('./components/McpsPanel.jsx'));
+const WebChatPanel   = lazy(() => import('./components/WebChatPanel.jsx'));
+const ContactsPanel  = lazy(() => import('./components/ContactsPanel.jsx'));
 
 let nextId = 0;
 
 function createSession(command = null, type = 'pty', httpSessionId = null, provider = null) {
   const id = ++nextId;
   let title;
-  if (provider === 'gemini') {
-    title = `Gemini ${id}`;
-  } else if (provider === 'openai') {
-    title = `GPT ${id}`;
-  } else if (provider === 'anthropic' || type === 'claude') {
-    title = `Claude ${id}`;
-  } else if (command && command.startsWith('claude')) {
-    title = `CC ${id}`;
-  } else {
-    title = command ? command.split(' ')[0] : `bash ${id}`;
-  }
+  if (provider === 'gemini')          title = `Gemini ${id}`;
+  else if (provider === 'openai')     title = `GPT ${id}`;
+  else if (provider === 'anthropic' || type === 'claude') title = `Claude ${id}`;
+  else if (command && command.startsWith('claude')) title = `CC ${id}`;
+  else title = command ? command.split(' ')[0] : `bash ${id}`;
   return { id, title, command, type, httpSessionId, provider };
 }
 
-// ── Panel reducer: reemplaza 5 booleans por un estado único ──────────────────
+// ── Secciones de navegación ───────────────────────────────────────────────────
 
-function panelReducer(state, action) {
-  switch (action.type) {
-    case 'toggle':
-      return state === action.panel ? null : action.panel;
-    case 'close':
-      return null;
-    default:
-      return state;
-  }
+const NAV_TOP = [
+  { key: 'terminal',  Icon: Terminal,        label: 'Terminal' },
+  { key: 'chat',      Icon: MessageCircle,   label: 'Chat' },
+];
+const NAV_MID = [
+  { key: 'telegram',  Icon: Send,            label: 'Telegram' },
+  { key: 'contacts',  Icon: BookUser,        label: 'Contactos' },
+];
+const CONFIG_TABS = [
+  { key: 'agents',    Icon: Bot,             label: 'Agentes' },
+  { key: 'providers', Icon: Settings,        label: 'Providers' },
+  { key: 'mcps',      Icon: Plug,            label: 'MCPs' },
+];
+
+// ── Sidebar ───────────────────────────────────────────────────────────────────
+
+function Sidebar({ section, onSection, telegramBadge }) {
+  return (
+    <aside className="app-sidebar" aria-label="Navegación principal">
+      <nav className="sidebar-nav">
+        {NAV_TOP.map(({ key, Icon, label }) => (
+          <button
+            key={key}
+            className={`sidebar-item ${section === key ? 'active' : ''}`}
+            onClick={() => onSection(key)}
+            aria-label={label}
+            aria-current={section === key ? 'page' : undefined}
+          >
+            <Icon size={18} aria-hidden="true" />
+            <span className="sidebar-label">{label}</span>
+          </button>
+        ))}
+
+        <div className="sidebar-divider" aria-hidden="true" />
+
+        {NAV_MID.map(({ key, Icon, label }) => (
+          <button
+            key={key}
+            className={`sidebar-item ${section === key ? 'active' : ''}`}
+            onClick={() => onSection(key)}
+            aria-label={label}
+            aria-current={section === key ? 'page' : undefined}
+          >
+            <Icon size={18} aria-hidden="true" />
+            <span className="sidebar-label">{label}</span>
+            {key === 'telegram' && telegramBadge > 0 && (
+              <span className="sidebar-badge" aria-label={`${telegramBadge} chats`}>{telegramBadge}</span>
+            )}
+          </button>
+        ))}
+      </nav>
+
+      <div className="sidebar-bottom">
+        <div className="sidebar-divider" aria-hidden="true" />
+        <button
+          className={`sidebar-item ${section === 'config' ? 'active' : ''}`}
+          onClick={() => onSection('config')}
+          aria-label="Configuración"
+          aria-current={section === 'config' ? 'page' : undefined}
+        >
+          <Settings size={18} aria-hidden="true" />
+          <span className="sidebar-label">Config</span>
+        </button>
+      </div>
+    </aside>
+  );
 }
 
-const PANELS = [
-  { key: 'chat', icon: MessageCircle, label: 'Chat con IA' },
-  { key: 'providers', icon: Settings, label: 'Providers de IA' },
-  { key: 'mcps', icon: Plug, label: 'MCPs' },
-  { key: 'agents', icon: Users, label: 'Agentes personalizados' },
-  { key: 'telegram', icon: Bot, label: 'Panel de Telegram' },
-  { key: 'contacts', icon: BookUser, label: 'Contactos' },
-];
+// ── Config section — tabs internos ────────────────────────────────────────────
+
+function ConfigSection() {
+  const [tab, setTab] = useState('agents');
+  return (
+    <div className="section-config">
+      <div className="config-tab-bar">
+        {CONFIG_TABS.map(({ key, Icon, label }) => (
+          <button
+            key={key}
+            className={`config-tab ${tab === key ? 'active' : ''}`}
+            onClick={() => setTab(key)}
+          >
+            <Icon size={14} aria-hidden="true" />
+            {label}
+          </button>
+        ))}
+      </div>
+      <div className="config-tab-body">
+        <ErrorBoundary>
+          <Suspense fallback={<Skeleton lines={4} style={{ padding: '24px' }} />}>
+            {tab === 'agents'    && <AgentsPanel    onClose={null} embedded />}
+            {tab === 'providers' && <ProvidersPanel onClose={null} embedded />}
+            {tab === 'mcps'      && <McpsPanel      onClose={null} embedded />}
+          </Suspense>
+        </ErrorBoundary>
+      </div>
+    </div>
+  );
+}
+
+// ── App principal ─────────────────────────────────────────────────────────────
 
 function AppContent() {
   const { theme, toggleTheme } = useTheme();
+  const { user } = useAuth();
 
-  const [sessions, setSessions] = useState(() => {
-    const initial = createSession();
-    return [initial];
-  });
+  const [section, setSection]   = useState('terminal');
+  const [sessions, setSessions] = useState(() => { const s = createSession(); return [s]; });
   const [activeId, setActiveId] = useState(() => nextId);
-  const [activePanel, dispatchPanel] = useReducer(panelReducer, null);
   const [telegramChatsCount, setTelegramChatsCount] = useState(0);
   const [wsConnected, setWsConnected] = useState(true);
 
-  // Mapa: httpSessionId → frontendTabId
   const httpIdToTabId = useRef(new Map());
 
-  // WebSocket listener para eventos de Telegram (abre pestañas automáticamente)
+  // Listener WebSocket global (eventos de Telegram → nuevas tabs)
   useEffect(() => {
-    let ws;
-    let reconnectTimer;
-
+    let ws, reconnectTimer;
     function connect() {
       ws = new WebSocket(WS_URL);
-      ws.onopen = () => {
-        setWsConnected(true);
-        ws.send(JSON.stringify({ type: 'init', sessionType: 'listener' }));
-      };
-      ws.onclose = () => {
-        setWsConnected(false);
-        reconnectTimer = setTimeout(connect, 3000);
-      };
+      ws.onopen  = () => { setWsConnected(true);  ws.send(JSON.stringify({ type: 'init', sessionType: 'listener' })); };
+      ws.onclose = () => { setWsConnected(false); reconnectTimer = setTimeout(connect, 3000); };
       ws.onerror = () => {};
       ws.onmessage = (event) => {
         try {
@@ -117,35 +179,30 @@ function AppContent() {
         } catch { /* silenciar */ }
       };
     }
-
     connect();
-    return () => {
-      clearTimeout(reconnectTimer);
-      ws?.close();
-    };
+    return () => { clearTimeout(reconnectTimer); ws?.close(); };
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Obtener cantidad de chats activos del bot para el badge
+  // Polling badge Telegram (solo cuando no está en la sección telegram)
   useEffect(() => {
-    if (activePanel === 'telegram') return;
+    if (section === 'telegram') return;
     const interval = setInterval(async () => {
       try {
         const res = await apiFetch(`${API_BASE}/api/telegram/bots`);
         const bots = await res.json();
-        const chats = Array.isArray(bots)
-          ? bots.reduce((n, b) => n + (b.chats?.length || 0), 0)
-          : 0;
-        setTelegramChatsCount(chats);
-      } catch { /* silenciar — polling en background */ }
+        const count = Array.isArray(bots) ? bots.reduce((n, b) => n + (b.chats?.length || 0), 0) : 0;
+        setTelegramChatsCount(count);
+      } catch { /* silenciar */ }
     }, 5000);
     return () => clearInterval(interval);
-  }, [activePanel]);
+  }, [section]);
 
   const openNew = useCallback((command = null, type = 'pty', httpSessionId = null, provider = null) => {
-    const session = createSession(command, type, httpSessionId, provider);
-    setSessions((prev) => [...prev, session]);
-    setActiveId(session.id);
-    return session;
+    const s = createSession(command, type, httpSessionId, provider);
+    setSessions((prev) => [...prev, s]);
+    setActiveId(s.id);
+    setSection('terminal');
+    return s;
   }, []);
 
   const closeSession = useCallback((id) => {
@@ -159,146 +216,155 @@ function AppContent() {
         setActiveId(s.id);
         return [s];
       }
-      if (activeId === id) {
-        setActiveId(next[next.length - 1].id);
-      }
+      if (activeId === id) setActiveId(next[next.length - 1].id);
       return next;
     });
   }, [activeId]);
 
-  const handleSessionId = useCallback((frontendTabId, httpId) => {
-    httpIdToTabId.current.set(httpId, frontendTabId);
-  }, []);
-
+  const handleSessionId  = useCallback((frontendTabId, httpId) => { httpIdToTabId.current.set(httpId, frontendTabId); }, []);
   const handleOpenSession = useCallback((httpSessionId) => {
     const tabId = httpIdToTabId.current.get(httpSessionId);
-    if (tabId) {
-      setActiveId(tabId);
-      dispatchPanel({ type: 'close' });
-    } else {
-      openNew(null, 'pty', httpSessionId);
-      dispatchPanel({ type: 'close' });
-    }
+    if (tabId) { setActiveId(tabId); } else { openNew(null, 'pty', httpSessionId); }
+    setSection('terminal');
   }, [openNew]);
+
+  const toTerminal = useCallback(() => setSection('terminal'), []);
 
   return (
     <div className="app">
-      <a href="#terminal-main" className="skip-link">Ir al contenido principal</a>
-
+      <a href="#app-main" className="skip-link">Ir al contenido principal</a>
       <ReconnectBanner connected={wsConnected} />
 
+      {/* ── Header ── */}
       <header className="app-header">
-        <span className="dot red" aria-hidden="true" />
+        <span className="dot red"    aria-hidden="true" />
         <span className="dot yellow" aria-hidden="true" />
-        <span className="dot green" aria-hidden="true" />
-        <h1 className="title">Terminal Live</h1>
+        <span className="dot green"  aria-hidden="true" />
+        <h1 className="title">Clawmint</h1>
 
-        <nav className="header-right" aria-label="Paneles">
+        <div className="header-right">
+          {user && (
+            <div className="header-user" aria-label={`Usuario: ${user.name}`}>
+              <span className="header-user-avatar">{(user.name || 'U')[0].toUpperCase()}</span>
+              <span className="header-user-name">{user.name}</span>
+            </div>
+          )}
           <button
-            className="telegram-btn theme-toggle"
+            className="header-icon-btn theme-toggle"
             onClick={toggleTheme}
             aria-label={theme === 'dark' ? 'Cambiar a tema claro' : 'Cambiar a tema oscuro'}
           >
-            {theme === 'dark' ? <Sun size={16} aria-hidden="true" /> : <Moon size={16} aria-hidden="true" />}
+            {theme === 'dark'
+              ? <Sun  size={16} aria-hidden="true" />
+              : <Moon size={16} aria-hidden="true" />}
           </button>
-
-          {PANELS.map(({ key, icon: Icon, label }) => (
-            <button
-              key={key}
-              className={`telegram-btn ${activePanel === key ? 'active' : ''}`}
-              onClick={() => dispatchPanel({ type: 'toggle', panel: key })}
-              aria-label={label}
-              aria-pressed={activePanel === key}
-            >
-              <Icon size={16} aria-hidden="true" />
-              {key === 'telegram' && telegramChatsCount > 0 && activePanel !== 'telegram' && (
-                <span className="telegram-badge">{telegramChatsCount}</span>
-              )}
-            </button>
-          ))}
-        </nav>
+        </div>
       </header>
 
-      <TabBar
-        sessions={sessions}
-        activeId={activeId}
-        onSelect={setActiveId}
-        onClose={closeSession}
-        onNew={() => openNew()}
-      />
+      {/* ── Layout principal ── */}
+      <div className="app-layout">
+        <Sidebar
+          section={section}
+          onSection={setSection}
+          telegramBadge={telegramChatsCount}
+        />
 
-      <CommandBar
-        onCommand={openNew}
-        onClaude={(sys) => openNew(sys || null, 'ai', null, 'anthropic')}
-        onAI={(provider, sys) => openNew(sys || null, 'ai', null, provider)}
-      />
+        <div id="app-main" className="app-content">
 
-      <div className="app-body-wrap">
-        <main id="terminal-main" className="app-body">
-          <Suspense fallback={<Skeleton lines={5} style={{ padding: '24px' }} />}>
-            {sessions.map((session) => (
-              <TerminalPanel
-                key={session.id}
-                session={session}
-                wsUrl={WS_URL}
-                active={session.id === activeId}
-                onClose={() => closeSession(session.id)}
-                onSessionId={(httpId) => handleSessionId(session.id, httpId)}
-              />
-            ))}
-          </Suspense>
-        </main>
+          {/* ── Terminal ── */}
+          <div className={`section section-terminal ${section === 'terminal' ? 'section-active' : ''}`} aria-hidden={section !== 'terminal'}>
+            <TabBar
+              sessions={sessions}
+              activeId={activeId}
+              onSelect={setActiveId}
+              onClose={closeSession}
+              onNew={() => openNew()}
+            />
+            <CommandBar
+              onCommand={openNew}
+              onClaude={(sys) => openNew(sys || null, 'ai', null, 'anthropic')}
+              onAI={(provider, sys) => openNew(sys || null, 'ai', null, provider)}
+            />
+            <main className="terminal-body">
+              <Suspense fallback={<Skeleton lines={5} style={{ padding: '24px' }} />}>
+                {sessions.map((s) => (
+                  <TerminalPanel
+                    key={s.id}
+                    session={s}
+                    wsUrl={WS_URL}
+                    active={s.id === activeId}
+                    onClose={() => closeSession(s.id)}
+                    onSessionId={(httpId) => handleSessionId(s.id, httpId)}
+                  />
+                ))}
+              </Suspense>
+            </main>
+          </div>
 
-        <Suspense fallback={<Skeleton lines={4} style={{ width: 380, padding: '16px' }} />}>
-          <ErrorBoundary>
-            {activePanel === 'telegram' && (
-              <TelegramPanel
-                onClose={() => dispatchPanel({ type: 'close' })}
-                onOpenSession={handleOpenSession}
-              />
-            )}
+          {/* ── Chat IA ── */}
+          {section === 'chat' && (
+            <div className="section section-full section-active">
+              <ErrorBoundary>
+                <Suspense fallback={<Skeleton lines={6} style={{ padding: '24px' }} />}>
+                  <WebChatPanel onClose={toTerminal} embedded />
+                </Suspense>
+              </ErrorBoundary>
+            </div>
+          )}
 
-            {activePanel === 'agents' && (
-              <AgentsPanel onClose={() => dispatchPanel({ type: 'close' })} />
-            )}
+          {/* ── Telegram ── */}
+          {section === 'telegram' && (
+            <div className="section section-full section-active">
+              <ErrorBoundary>
+                <Suspense fallback={<Skeleton lines={6} style={{ padding: '24px' }} />}>
+                  <TelegramPanel onClose={toTerminal} onOpenSession={handleOpenSession} embedded />
+                </Suspense>
+              </ErrorBoundary>
+            </div>
+          )}
 
-            {activePanel === 'providers' && (
-              <ProvidersPanel onClose={() => dispatchPanel({ type: 'close' })} />
-            )}
+          {/* ── Contactos ── */}
+          {section === 'contacts' && (
+            <div className="section section-full section-active">
+              <ErrorBoundary>
+                <Suspense fallback={<Skeleton lines={6} style={{ padding: '24px' }} />}>
+                  <ContactsPanel onClose={toTerminal} embedded />
+                </Suspense>
+              </ErrorBoundary>
+            </div>
+          )}
 
-            {activePanel === 'mcps' && (
-              <McpsPanel onClose={() => dispatchPanel({ type: 'close' })} />
-            )}
+          {/* ── Config ── */}
+          {section === 'config' && (
+            <div className="section section-full section-active">
+              <ErrorBoundary>
+                <Suspense fallback={<Skeleton lines={6} style={{ padding: '24px' }} />}>
+                  <ConfigSection />
+                </Suspense>
+              </ErrorBoundary>
+            </div>
+          )}
 
-            {activePanel === 'chat' && (
-              <WebChatPanel onClose={() => dispatchPanel({ type: 'close' })} />
-            )}
-
-            {activePanel === 'contacts' && (
-              <ContactsPanel onClose={() => dispatchPanel({ type: 'close' })} />
-            )}
-          </ErrorBoundary>
-        </Suspense>
+        </div>
       </div>
 
-      {/* Mobile bottom nav — visible solo en <640px */}
+      {/* ── Mobile bottom nav ── */}
       <nav className="mobile-bottom-nav" aria-label="Navegación móvil">
-        <button
-          className={activePanel === null ? 'active' : ''}
-          onClick={() => dispatchPanel({ type: 'close' })}
-        >
-          <Terminal size={20} aria-hidden="true" />
-          <span>Terminal</span>
-        </button>
-        {PANELS.map(({ key, icon: Icon, label }) => (
+        {[
+          { key: 'terminal',  Icon: Terminal,      label: 'Terminal' },
+          { key: 'chat',      Icon: MessageCircle, label: 'Chat' },
+          { key: 'telegram',  Icon: Send,          label: 'TG' },
+          { key: 'contacts',  Icon: BookUser,      label: 'Contactos' },
+          { key: 'config',    Icon: Settings,      label: 'Config' },
+        ].map(({ key, Icon, label }) => (
           <button
             key={key}
-            className={activePanel === key ? 'active' : ''}
-            onClick={() => dispatchPanel({ type: 'toggle', panel: key })}
+            className={section === key ? 'active' : ''}
+            onClick={() => setSection(key)}
             aria-label={label}
           >
             <Icon size={20} aria-hidden="true" />
-            <span>{key === 'chat' ? 'Chat' : key === 'telegram' ? 'TG' : key.slice(0, 4)}</span>
+            <span>{label}</span>
           </button>
         ))}
       </nav>

--- a/client/src/components/ContactsPanel.jsx
+++ b/client/src/components/ContactsPanel.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { X, Plus, Star, StarOff, Pencil, Trash2, Check, Phone, Mail, FileText, Link } from 'lucide-react';
+import { X, Plus, Star, StarOff, Pencil, Trash2, Check, Phone, Mail, FileText, Link, MessageSquare } from 'lucide-react';
 import { API_BASE } from '../config';
 import { apiFetch } from '../authUtils';
 import './ContactsPanel.css';
@@ -13,6 +13,9 @@ function ContactForm({ initial, onSave, onCancel }) {
   const [email, setEmail] = useState(initial?.email || '');
   const [notes, setNotes] = useState(initial?.notes || '');
   const [isFavorite, setIsFavorite] = useState(!!initial?.is_favorite);
+  const [telegramId, setTelegramId] = useState(
+    initial?.linkedUser?.identities?.find(i => i.channel === 'telegram')?.identifier || ''
+  );
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
 
@@ -23,19 +26,33 @@ function ContactForm({ initial, onSave, onCancel }) {
     try {
       const url = isEdit ? `${API}/${initial.id}` : API;
       const method = isEdit ? 'PATCH' : 'POST';
+      const body = {
+        name: name.trim(),
+        phone: phone.trim() || null,
+        email: email.trim() || null,
+        notes: notes.trim() || null,
+        is_favorite: isFavorite,
+      };
+      if (!isEdit && telegramId.trim()) body.telegram_id = telegramId.trim();
       const res = await apiFetch(url, {
         method,
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          name: name.trim(),
-          phone: phone.trim() || null,
-          email: email.trim() || null,
-          notes: notes.trim() || null,
-          is_favorite: isFavorite,
-        }),
+        body: JSON.stringify(body),
       });
       const data = await res.json();
       if (!res.ok || data.error) throw new Error(data.error || 'Error');
+
+      // En edición, vincular por Telegram ID si se proporcionó
+      if (isEdit && telegramId.trim()) {
+        const linkRes = await apiFetch(`${API}/${initial.id}/link`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ telegram_id: telegramId.trim() }),
+        });
+        const linkData = await linkRes.json();
+        if (!linkRes.ok || linkData.error) throw new Error(linkData.error || 'Error al vincular Telegram');
+      }
+
       onSave();
     } catch (err) {
       setError(err.message);
@@ -76,6 +93,16 @@ function ContactForm({ initial, onSave, onCancel }) {
         value={email}
         onChange={e => setEmail(e.target.value)}
         aria-label="Email"
+      />
+
+      <label className="cp-label" style={{ marginTop: 8 }}>Telegram ID</label>
+      <input
+        className="cp-input"
+        type="text"
+        placeholder="ej: 7874537448"
+        value={telegramId}
+        onChange={e => setTelegramId(e.target.value)}
+        aria-label="Telegram ID"
       />
 
       <label className="cp-label" style={{ marginTop: 8 }}>Notas</label>
@@ -160,6 +187,12 @@ function ContactDetail({ contactId, onBack, onEdit, onDelete }) {
           <div className="cp-detail-row cp-detail-notes">
             <FileText size={13} />
             <span>{contact.notes}</span>
+          </div>
+        )}
+        {contact.linkedUser?.identities?.find(i => i.channel === 'telegram') && (
+          <div className="cp-detail-row">
+            <MessageSquare size={13} />
+            <span>Telegram: {contact.linkedUser.identities.find(i => i.channel === 'telegram').identifier}</span>
           </div>
         )}
         {contact.linkedUser ? (

--- a/client/src/components/ContactsPanel.jsx
+++ b/client/src/components/ContactsPanel.jsx
@@ -264,7 +264,7 @@ function ContactRow({ contact, onSelect, onToggleFav, onDelete }) {
   );
 }
 
-export default function ContactsPanel({ onClose }) {
+export default function ContactsPanel({ onClose, embedded }) {
   const [contacts, setContacts] = useState([]);
   const [loading, setLoading] = useState(true);
   const [query, setQuery] = useState('');
@@ -316,9 +316,11 @@ export default function ContactsPanel({ onClose }) {
     <div className="cp-panel" role="dialog" aria-label="Contactos">
       <div className="cp-header">
         <span className="cp-title">Contactos</span>
-        <button className="cp-close-btn" onClick={onClose} aria-label="Cerrar">
-          <X size={16} />
-        </button>
+        {!embedded && (
+          <button className="cp-close-btn" onClick={onClose} aria-label="Cerrar">
+            <X size={16} />
+          </button>
+        )}
       </div>
 
       {view === 'list' && (

--- a/client/src/components/ContactsPanel.jsx
+++ b/client/src/components/ContactsPanel.jsx
@@ -33,7 +33,11 @@ function ContactForm({ initial, onSave, onCancel }) {
         notes: notes.trim() || null,
         is_favorite: isFavorite,
       };
-      if (!isEdit && telegramId.trim()) body.telegram_id = telegramId.trim();
+      if (!isEdit && telegramId.trim()) {
+        const tid = telegramId.trim();
+        if (tid.startsWith('@')) body.username = tid;
+        else body.telegram_id = tid;
+      }
       const res = await apiFetch(url, {
         method,
         headers: { 'Content-Type': 'application/json' },
@@ -42,12 +46,14 @@ function ContactForm({ initial, onSave, onCancel }) {
       const data = await res.json();
       if (!res.ok || data.error) throw new Error(data.error || 'Error');
 
-      // En edición, vincular por Telegram ID si se proporcionó
+      // En edición, vincular por Telegram ID o username si se proporcionó
       if (isEdit && telegramId.trim()) {
+        const tid = telegramId.trim();
+        const linkBody = tid.startsWith('@') ? { username: tid } : { telegram_id: tid };
         const linkRes = await apiFetch(`${API}/${initial.id}/link`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ telegram_id: telegramId.trim() }),
+          body: JSON.stringify(linkBody),
         });
         const linkData = await linkRes.json();
         if (!linkRes.ok || linkData.error) throw new Error(linkData.error || 'Error al vincular Telegram');
@@ -95,14 +101,14 @@ function ContactForm({ initial, onSave, onCancel }) {
         aria-label="Email"
       />
 
-      <label className="cp-label" style={{ marginTop: 8 }}>Telegram ID</label>
+      <label className="cp-label" style={{ marginTop: 8 }}>Telegram (ID o @username)</label>
       <input
         className="cp-input"
         type="text"
-        placeholder="ej: 7874537448"
+        placeholder="ej: 7874537448 o @bpadilla3570"
         value={telegramId}
         onChange={e => setTelegramId(e.target.value)}
-        aria-label="Telegram ID"
+        aria-label="Telegram ID o username"
       />
 
       <label className="cp-label" style={{ marginTop: 8 }}>Notas</label>

--- a/client/src/components/TelegramPanel.jsx
+++ b/client/src/components/TelegramPanel.jsx
@@ -342,7 +342,7 @@ const AddBotForm = memo(function AddBotForm({ onAdd, onCancel }) {
   );
 });
 
-export default function TelegramPanel({ onClose, onOpenSession }) {
+export default function TelegramPanel({ onClose, onOpenSession, embedded }) {
   const [bots, setBots] = useState([]);
   const [allAgents, setAllAgents] = useState([]);
   const [showAdd, setShowAdd] = useState(false);
@@ -380,14 +380,16 @@ export default function TelegramPanel({ onClose, onOpenSession }) {
 
   return (
     <div className="tg-panel" role="region" aria-label="Panel de Telegram">
-      <div className="tg-header">
-        <span className="tg-header-title">
-          <span className="tg-icon"><Bot size={16} /></span>
-          Bots de Telegram
-          {activeBots > 0 && <span className="tg-header-badge">{activeBots} activo{activeBots > 1 ? 's' : ''}</span>}
-        </span>
-        <button className="tg-close" onClick={onClose} aria-label="Cerrar panel de Telegram"><X size={16} /></button>
-      </div>
+      {!embedded && (
+        <div className="tg-header">
+          <span className="tg-header-title">
+            <span className="tg-icon"><Bot size={16} /></span>
+            Bots de Telegram
+            {activeBots > 0 && <span className="tg-header-badge">{activeBots} activo{activeBots > 1 ? 's' : ''}</span>}
+          </span>
+          <button className="tg-close" onClick={onClose} aria-label="Cerrar panel de Telegram"><X size={16} /></button>
+        </div>
+      )}
 
       <div className="tg-body">
         {/* Resumen */}

--- a/client/src/components/WebChatPanel.jsx
+++ b/client/src/components/WebChatPanel.jsx
@@ -13,7 +13,7 @@ import ChatInput from './chat/ChatInput.jsx';
 import AuthPanel from './AuthPanel.jsx';
 import './WebChatPanel.css';
 
-export default function WebChatPanel({ onClose }) {
+export default function WebChatPanel({ onClose, embedded }) {
   const [providers, setProviders] = useState([]);
   const [agentsList, setAgentsList] = useState([]);
 
@@ -168,6 +168,7 @@ export default function WebChatPanel({ onClose }) {
         onClear={clearChat}
         onClose={onClose}
         onSettingsChange={handleSettingsChange}
+        embedded={embedded}
       />
 
       <StatusBar

--- a/client/src/components/chat/ChatHeader.jsx
+++ b/client/src/components/chat/ChatHeader.jsx
@@ -2,11 +2,11 @@ import { Trash2, X, LogIn, LogOut, User } from 'lucide-react';
 
 export default function ChatHeader({
   providers, provider, setProvider, agentsList, agent, setAgent,
-  authUser, onLogout, onShowAuth, onClear, onClose, onSettingsChange,
+  authUser, onLogout, onShowAuth, onClear, onClose, onSettingsChange, embedded,
 }) {
   return (
     <div className="wc-header">
-      <span className="wc-header-title">Chat</span>
+      {!embedded && <span className="wc-header-title">Chat</span>}
       <div className="wc-header-controls">
         <select
           className="wc-select"
@@ -52,7 +52,7 @@ export default function ChatHeader({
           </button>
         )}
         <button className="wc-btn-icon" onClick={onClear} title="Nueva conversación" aria-label="Nueva conversación"><Trash2 size={14} /></button>
-        <button className="wc-close" onClick={onClose} aria-label="Cerrar panel de chat"><X size={16} /></button>
+        {!embedded && <button className="wc-close" onClick={onClose} aria-label="Cerrar panel de chat"><X size={16} /></button>}
       </div>
     </div>
   );

--- a/server/routes/contacts.js
+++ b/server/routes/contacts.js
@@ -27,12 +27,16 @@ module.exports = function createContactsRouter({ usersRepo }) {
     const ownerId = getOwnerId(req);
     if (!ownerId) return res.status(401).json({ error: 'No autenticado' });
 
-    const { name, phone, email, notes, is_favorite, telegram_id } = req.body || {};
+    const { name, phone, email, notes, is_favorite, telegram_id, username } = req.body || {};
     if (!name) return res.status(400).json({ error: 'name requerido' });
 
     let userId = null;
     if (telegram_id) {
       const u = usersRepo.findByIdentity('telegram', String(telegram_id));
+      if (u) userId = u.id;
+    }
+    if (!userId && username) {
+      const u = usersRepo.findByTelegramUsername(username);
       if (u) userId = u.id;
     }
 
@@ -107,7 +111,7 @@ module.exports = function createContactsRouter({ usersRepo }) {
     const contact = usersRepo.getContact(req.params.id);
     if (!contact || contact.owner_id !== ownerId) return res.status(404).json({ error: 'No encontrado' });
 
-    const { telegram_id, user_id } = req.body || {};
+    const { telegram_id, user_id, username } = req.body || {};
     let userId = user_id || null;
 
     if (!userId && telegram_id) {
@@ -116,7 +120,13 @@ module.exports = function createContactsRouter({ usersRepo }) {
       userId = u.id;
     }
 
-    if (!userId) return res.status(400).json({ error: 'Se requiere telegram_id o user_id' });
+    if (!userId && username) {
+      const u = usersRepo.findByTelegramUsername(username);
+      if (!u) return res.status(404).json({ error: `No hay usuario con username ${username}` });
+      userId = u.id;
+    }
+
+    if (!userId) return res.status(400).json({ error: 'Se requiere telegram_id, username o user_id' });
 
     usersRepo.updateContact(req.params.id, { user_id: userId });
     res.json(usersRepo.getContact(req.params.id));

--- a/server/storage/UsersRepository.js
+++ b/server/storage/UsersRepository.js
@@ -119,6 +119,32 @@ class UsersRepository {
   }
 
   /**
+   * Busca un usuario de Telegram por su username (@handle).
+   * El username está guardado en el campo metadata JSON de user_identities.
+   */
+  findByTelegramUsername(username) {
+    if (!this._db || !username) return null;
+    const clean = username.replace(/^@/, '').toLowerCase();
+    const rows = this._db.prepare(`
+      SELECT u.*, ui.metadata
+      FROM user_identities ui
+      JOIN users u ON u.id = ui.user_id
+      WHERE ui.channel = 'telegram' AND ui.metadata IS NOT NULL
+    `).all();
+    for (const row of rows) {
+      try {
+        const meta = JSON.parse(row.metadata);
+        if (meta.username && meta.username.toLowerCase() === clean) {
+          const user = { id: row.id, name: row.name, role: row.role, created_at: row.created_at, updated_at: row.updated_at };
+          user.identities = this.getIdentities(user.id);
+          return user;
+        }
+      } catch { /* metadata no es JSON válido */ }
+    }
+    return null;
+  }
+
+  /**
    * Busca un usuario por identidad; si no existe, crea usuario + identidad.
    * Idempotente: si ya existe la identidad, retorna el usuario sin modificar.
    */


### PR DESCRIPTION
## Cambios

Fase 1 del rediseño completo del WebClient.

### Layout
- **Sidebar izquierdo** (60px) reemplaza los 6 botones del header
- **Secciones full-width**: Terminal, Chat IA, Telegram, Contactos, Config
- **Header limpio**: dots + título + usuario + theme toggle (sin botones de panel)

### Navegación
- `terminal` — TabBar + CommandBar + PTY (comportamiento actual preservado)
- `chat` — WebChatPanel a pantalla completa
- `telegram` — TelegramPanel a pantalla completa
- `contacts` — ContactsPanel a pantalla completa
- `config` — Agentes / Providers / MCPs agrupados con tabs internos

### Responsive
- `≥769px`: sidebar visible, bottom nav oculto
- `<768px`: sidebar oculto, bottom nav fijo (5 secciones)

### Lo que NO cambió
- Todos los componentes internos (WebChatPanel, TelegramPanel, etc.) intactos
- Lógica de sesiones PTY / WebSocket sin cambios
- Sistema de auth sin cambios