### PR TITLE
feat(client): rediseño Fase 2

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -128,6 +128,12 @@
   flex-direction: column;
   flex-shrink: 0;
   padding: 8px 0;
+  transition: width 0.2s ease;
+  overflow: hidden;
+}
+
+.app-sidebar.sidebar-expanded {
+  width: 180px;
 }
 
 .sidebar-nav {
@@ -137,6 +143,7 @@
   gap: 2px;
   padding: 0 8px;
   flex: 1;
+  overflow: hidden;
 }
 
 .sidebar-bottom {
@@ -144,6 +151,13 @@
   flex-direction: column;
   align-items: center;
   padding: 0 8px 4px;
+  overflow: hidden;
+}
+
+/* Expanded: items stretch full width */
+.app-sidebar.sidebar-expanded .sidebar-nav,
+.app-sidebar.sidebar-expanded .sidebar-bottom {
+  align-items: stretch;
 }
 
 .sidebar-item {
@@ -162,6 +176,18 @@
   position: relative;
   transition: color 0.15s, background 0.15s, border-color 0.15s;
   padding: 6px 2px;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+/* Expanded: items are rows */
+.app-sidebar.sidebar-expanded .sidebar-item {
+  width: auto;
+  flex-direction: row;
+  justify-content: flex-start;
+  padding: 9px 12px;
+  gap: 10px;
+  border-radius: 8px;
 }
 
 .sidebar-item:hover {
@@ -187,6 +213,12 @@
   line-height: 1;
 }
 
+.app-sidebar.sidebar-expanded .sidebar-label {
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0;
+}
+
 .sidebar-badge {
   position: absolute;
   top: 4px;
@@ -205,12 +237,27 @@
   line-height: 1;
 }
 
+.app-sidebar.sidebar-expanded .sidebar-badge {
+  position: static;
+  margin-left: auto;
+}
+
 .sidebar-divider {
   width: 28px;
   height: 1px;
   background: var(--border-primary);
   margin: 6px 0;
+  flex-shrink: 0;
 }
+
+.app-sidebar.sidebar-expanded .sidebar-divider {
+  width: 100%;
+}
+
+.sidebar-toggle-btn {
+  opacity: 0.6;
+}
+.sidebar-toggle-btn:hover { opacity: 1; }
 
 /* ── Content area ─────────────────────────────────────────────────────────── */
 .app-content {
@@ -248,6 +295,38 @@
 /* Full-width sections (chat, telegram, contacts, config) */
 .section-full {
   flex-direction: column;
+}
+
+/* ── Barra de sección ─────────────────────────────────────────────────────── */
+.section-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  height: 36px;
+  padding: 0 16px;
+  background: var(--bg-header);
+  border-bottom: 1px solid var(--border-primary);
+  flex-shrink: 0;
+}
+
+.section-bar-icon {
+  color: var(--accent-cyan);
+}
+
+.section-bar-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.section-bar-badge {
+  font-size: 11px;
+  color: var(--text-muted);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-primary);
+  border-radius: 10px;
+  padding: 1px 7px;
+  margin-left: 2px;
 }
 
 /* ── Config section ───────────────────────────────────────────────────────── */
@@ -297,9 +376,13 @@
   display: flex;
 }
 
-/* Los paneles embebidos (sin el header/close propio) llenan el espacio */
+/* Paneles embebidos llenan el espacio — section-bar queda excluida */
+.section-full > .section-bar {
+  flex: none;
+}
+
 .config-tab-body > *,
-.section-full > * {
+.section-full > :not(.section-bar) {
   flex: 1;
   width: 100% !important;
   min-width: 0 !important;

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useRef, useEffect, lazy, Suspense } from 'react';
 import {
-  Terminal, MessageCircle, Send, Users, BookUser, Settings,
-  Plug, Bot, Sun, Moon,
+  Terminal, MessageCircle, Send, BookUser, Settings,
+  Plug, Bot, Sun, Moon, ChevronLeft, ChevronRight,
 } from 'lucide-react';
 import TabBar from './components/TabBar.jsx';
 import CommandBar from './components/CommandBar.jsx';
@@ -37,73 +37,87 @@ function createSession(command = null, type = 'pty', httpSessionId = null, provi
   return { id, title, command, type, httpSessionId, provider };
 }
 
-// ── Secciones de navegación ───────────────────────────────────────────────────
+// ── Metadatos de secciones ────────────────────────────────────────────────────
 
-const NAV_TOP = [
-  { key: 'terminal',  Icon: Terminal,        label: 'Terminal' },
-  { key: 'chat',      Icon: MessageCircle,   label: 'Chat' },
-];
-const NAV_MID = [
-  { key: 'telegram',  Icon: Send,            label: 'Telegram' },
-  { key: 'contacts',  Icon: BookUser,        label: 'Contactos' },
-];
+const SECTION_META = {
+  terminal: { Icon: Terminal,      label: 'Terminal'       },
+  chat:     { Icon: MessageCircle, label: 'Chat IA'        },
+  telegram: { Icon: Send,          label: 'Telegram'       },
+  contacts: { Icon: BookUser,      label: 'Contactos'      },
+  config:   { Icon: Settings,      label: 'Configuración'  },
+};
+
+const NAV_TOP = ['terminal', 'chat'];
+const NAV_MID = ['telegram', 'contacts'];
+
 const CONFIG_TABS = [
-  { key: 'agents',    Icon: Bot,             label: 'Agentes' },
-  { key: 'providers', Icon: Settings,        label: 'Providers' },
-  { key: 'mcps',      Icon: Plug,            label: 'MCPs' },
+  { key: 'agents',    Icon: Bot,      label: 'Agentes'  },
+  { key: 'providers', Icon: Settings, label: 'Providers' },
+  { key: 'mcps',      Icon: Plug,     label: 'MCPs'     },
 ];
 
 // ── Sidebar ───────────────────────────────────────────────────────────────────
 
-function Sidebar({ section, onSection, telegramBadge }) {
+function Sidebar({ section, onSection, telegramBadge, expanded, onToggle }) {
+  const renderItem = (key) => {
+    const { Icon, label } = SECTION_META[key];
+    return (
+      <button
+        key={key}
+        className={`sidebar-item ${section === key ? 'active' : ''}`}
+        onClick={() => onSection(key)}
+        title={!expanded ? label : undefined}
+        aria-label={label}
+        aria-current={section === key ? 'page' : undefined}
+      >
+        <Icon size={18} aria-hidden="true" />
+        <span className="sidebar-label">{label}</span>
+        {key === 'telegram' && telegramBadge > 0 && (
+          <span className="sidebar-badge" aria-label={`${telegramBadge} chats`}>{telegramBadge}</span>
+        )}
+      </button>
+    );
+  };
+
   return (
-    <aside className="app-sidebar" aria-label="Navegación principal">
+    <aside className={`app-sidebar${expanded ? ' sidebar-expanded' : ''}`} aria-label="Navegación principal">
       <nav className="sidebar-nav">
-        {NAV_TOP.map(({ key, Icon, label }) => (
-          <button
-            key={key}
-            className={`sidebar-item ${section === key ? 'active' : ''}`}
-            onClick={() => onSection(key)}
-            aria-label={label}
-            aria-current={section === key ? 'page' : undefined}
-          >
-            <Icon size={18} aria-hidden="true" />
-            <span className="sidebar-label">{label}</span>
-          </button>
-        ))}
-
+        {NAV_TOP.map(renderItem)}
         <div className="sidebar-divider" aria-hidden="true" />
-
-        {NAV_MID.map(({ key, Icon, label }) => (
-          <button
-            key={key}
-            className={`sidebar-item ${section === key ? 'active' : ''}`}
-            onClick={() => onSection(key)}
-            aria-label={label}
-            aria-current={section === key ? 'page' : undefined}
-          >
-            <Icon size={18} aria-hidden="true" />
-            <span className="sidebar-label">{label}</span>
-            {key === 'telegram' && telegramBadge > 0 && (
-              <span className="sidebar-badge" aria-label={`${telegramBadge} chats`}>{telegramBadge}</span>
-            )}
-          </button>
-        ))}
+        {NAV_MID.map(renderItem)}
       </nav>
 
       <div className="sidebar-bottom">
         <div className="sidebar-divider" aria-hidden="true" />
+        {renderItem('config')}
         <button
-          className={`sidebar-item ${section === 'config' ? 'active' : ''}`}
-          onClick={() => onSection('config')}
-          aria-label="Configuración"
-          aria-current={section === 'config' ? 'page' : undefined}
+          className="sidebar-item sidebar-toggle-btn"
+          onClick={onToggle}
+          title={expanded ? 'Colapsar sidebar' : 'Expandir sidebar'}
+          aria-label={expanded ? 'Colapsar sidebar' : 'Expandir sidebar'}
         >
-          <Settings size={18} aria-hidden="true" />
-          <span className="sidebar-label">Config</span>
+          {expanded
+            ? <ChevronLeft  size={16} aria-hidden="true" />
+            : <ChevronRight size={16} aria-hidden="true" />}
         </button>
       </div>
     </aside>
+  );
+}
+
+// ── Barra de sección ──────────────────────────────────────────────────────────
+
+function SectionBar({ section, telegramBadge }) {
+  if (!['chat', 'telegram', 'contacts'].includes(section)) return null;
+  const { Icon, label } = SECTION_META[section];
+  return (
+    <div className="section-bar">
+      <Icon size={14} className="section-bar-icon" aria-hidden="true" />
+      <span className="section-bar-title">{label}</span>
+      {section === 'telegram' && telegramBadge > 0 && (
+        <span className="section-bar-badge">{telegramBadge} chats</span>
+      )}
+    </div>
   );
 }
 
@@ -145,12 +159,30 @@ function AppContent() {
   const { user } = useAuth();
 
   const [section, setSection]   = useState('terminal');
+  const [mounted, setMounted]   = useState({ terminal: true });
   const [sessions, setSessions] = useState(() => { const s = createSession(); return [s]; });
   const [activeId, setActiveId] = useState(() => nextId);
   const [telegramChatsCount, setTelegramChatsCount] = useState(0);
   const [wsConnected, setWsConnected] = useState(true);
+  const [sidebarExpanded, setSidebarExpanded] = useState(() => {
+    try { return localStorage.getItem('sidebar-expanded') === 'true'; } catch { return false; }
+  });
 
   const httpIdToTabId = useRef(new Map());
+
+  // Cambia de sección y monta la sección si es la primera vez
+  const handleSection = useCallback((key) => {
+    setMounted(prev => prev[key] ? prev : { ...prev, [key]: true });
+    setSection(key);
+  }, []);
+
+  const toggleSidebar = useCallback(() => {
+    setSidebarExpanded(v => {
+      const next = !v;
+      try { localStorage.setItem('sidebar-expanded', String(next)); } catch {}
+      return next;
+    });
+  }, []);
 
   // Listener WebSocket global (eventos de Telegram → nuevas tabs)
   useEffect(() => {
@@ -201,9 +233,9 @@ function AppContent() {
     const s = createSession(command, type, httpSessionId, provider);
     setSessions((prev) => [...prev, s]);
     setActiveId(s.id);
-    setSection('terminal');
+    handleSection('terminal');
     return s;
-  }, []);
+  }, [handleSection]);
 
   const closeSession = useCallback((id) => {
     setSessions((prev) => {
@@ -221,14 +253,14 @@ function AppContent() {
     });
   }, [activeId]);
 
-  const handleSessionId  = useCallback((frontendTabId, httpId) => { httpIdToTabId.current.set(httpId, frontendTabId); }, []);
+  const handleSessionId   = useCallback((frontendTabId, httpId) => { httpIdToTabId.current.set(httpId, frontendTabId); }, []);
   const handleOpenSession = useCallback((httpSessionId) => {
     const tabId = httpIdToTabId.current.get(httpSessionId);
     if (tabId) { setActiveId(tabId); } else { openNew(null, 'pty', httpSessionId); }
-    setSection('terminal');
-  }, [openNew]);
+    handleSection('terminal');
+  }, [openNew, handleSection]);
 
-  const toTerminal = useCallback(() => setSection('terminal'), []);
+  const toTerminal = useCallback(() => handleSection('terminal'), [handleSection]);
 
   return (
     <div className="app">
@@ -265,8 +297,10 @@ function AppContent() {
       <div className="app-layout">
         <Sidebar
           section={section}
-          onSection={setSection}
+          onSection={handleSection}
           telegramBadge={telegramChatsCount}
+          expanded={sidebarExpanded}
+          onToggle={toggleSidebar}
         />
 
         <div id="app-main" className="app-content">
@@ -301,9 +335,10 @@ function AppContent() {
             </main>
           </div>
 
-          {/* ── Chat IA ── */}
-          {section === 'chat' && (
-            <div className="section section-full section-active">
+          {/* ── Chat IA — montado en primer acceso, persiste con CSS ── */}
+          {mounted.chat && (
+            <div className={`section section-full ${section === 'chat' ? 'section-active' : ''}`} aria-hidden={section !== 'chat'}>
+              <SectionBar section="chat" telegramBadge={0} />
               <ErrorBoundary>
                 <Suspense fallback={<Skeleton lines={6} style={{ padding: '24px' }} />}>
                   <WebChatPanel onClose={toTerminal} embedded />
@@ -312,9 +347,10 @@ function AppContent() {
             </div>
           )}
 
-          {/* ── Telegram ── */}
-          {section === 'telegram' && (
-            <div className="section section-full section-active">
+          {/* ── Telegram — montado en primer acceso, persiste con CSS ── */}
+          {mounted.telegram && (
+            <div className={`section section-full ${section === 'telegram' ? 'section-active' : ''}`} aria-hidden={section !== 'telegram'}>
+              <SectionBar section="telegram" telegramBadge={telegramChatsCount} />
               <ErrorBoundary>
                 <Suspense fallback={<Skeleton lines={6} style={{ padding: '24px' }} />}>
                   <TelegramPanel onClose={toTerminal} onOpenSession={handleOpenSession} embedded />
@@ -323,9 +359,10 @@ function AppContent() {
             </div>
           )}
 
-          {/* ── Contactos ── */}
-          {section === 'contacts' && (
-            <div className="section section-full section-active">
+          {/* ── Contactos — montado en primer acceso, persiste con CSS ── */}
+          {mounted.contacts && (
+            <div className={`section section-full ${section === 'contacts' ? 'section-active' : ''}`} aria-hidden={section !== 'contacts'}>
+              <SectionBar section="contacts" telegramBadge={0} />
               <ErrorBoundary>
                 <Suspense fallback={<Skeleton lines={6} style={{ padding: '24px' }} />}>
                   <ContactsPanel onClose={toTerminal} embedded />
@@ -334,9 +371,9 @@ function AppContent() {
             </div>
           )}
 
-          {/* ── Config ── */}
-          {section === 'config' && (
-            <div className="section section-full section-active">
+          {/* ── Config — montado en primer acceso, persiste con CSS ── */}
+          {mounted.config && (
+            <div className={`section section-full ${section === 'config' ? 'section-active' : ''}`} aria-hidden={section !== 'config'}>
               <ErrorBoundary>
                 <Suspense fallback={<Skeleton lines={6} style={{ padding: '24px' }} />}>
                   <ConfigSection />
@@ -351,16 +388,16 @@ function AppContent() {
       {/* ── Mobile bottom nav ── */}
       <nav className="mobile-bottom-nav" aria-label="Navegación móvil">
         {[
-          { key: 'terminal',  Icon: Terminal,      label: 'Terminal' },
-          { key: 'chat',      Icon: MessageCircle, label: 'Chat' },
-          { key: 'telegram',  Icon: Send,          label: 'TG' },
-          { key: 'contacts',  Icon: BookUser,      label: 'Contactos' },
-          { key: 'config',    Icon: Settings,      label: 'Config' },
+          { key: 'terminal', Icon: Terminal,      label: 'Terminal' },
+          { key: 'chat',     Icon: MessageCircle, label: 'Chat'     },
+          { key: 'telegram', Icon: Send,          label: 'TG'       },
+          { key: 'contacts', Icon: BookUser,      label: 'Contactos' },
+          { key: 'config',   Icon: Settings,      label: 'Config'   },
         ].map(({ key, Icon, label }) => (
           <button
             key={key}
             className={section === key ? 'active' : ''}
-            onClick={() => setSection(key)}
+            onClick={() => handleSection(key)}
             aria-label={label}
           >
             <Icon size={20} aria-hidden="true" />

--- a/client/src/components/ContactsPanel.jsx
+++ b/client/src/components/ContactsPanel.jsx
@@ -264,7 +264,7 @@ function ContactRow({ contact, onSelect, onToggleFav, onDelete }) {
   );
 }
 
-export default function ContactsPanel({ onClose }) {
+export default function ContactsPanel({ onClose, embedded }) {
   const [contacts, setContacts] = useState([]);
   const [loading, setLoading] = useState(true);
   const [query, setQuery] = useState('');
@@ -316,9 +316,11 @@ export default function ContactsPanel({ onClose }) {
     <div className="cp-panel" role="dialog" aria-label="Contactos">
       <div className="cp-header">
         <span className="cp-title">Contactos</span>
-        <button className="cp-close-btn" onClick={onClose} aria-label="Cerrar">
-          <X size={16} />
-        </button>
+        {!embedded && (
+          <button className="cp-close-btn" onClick={onClose} aria-label="Cerrar">
+            <X size={16} />
+          </button>
+        )}
       </div>
 
       {view === 'list' && (

--- a/client/src/components/TelegramPanel.jsx
+++ b/client/src/components/TelegramPanel.jsx
@@ -342,7 +342,7 @@ const AddBotForm = memo(function AddBotForm({ onAdd, onCancel }) {
   );
 });
 
-export default function TelegramPanel({ onClose, onOpenSession }) {
+export default function TelegramPanel({ onClose, onOpenSession, embedded }) {
   const [bots, setBots] = useState([]);
   const [allAgents, setAllAgents] = useState([]);
   const [showAdd, setShowAdd] = useState(false);
@@ -380,14 +380,16 @@ export default function TelegramPanel({ onClose, onOpenSession }) {
 
   return (
     <div className="tg-panel" role="region" aria-label="Panel de Telegram">
-      <div className="tg-header">
-        <span className="tg-header-title">
-          <span className="tg-icon"><Bot size={16} /></span>
-          Bots de Telegram
-          {activeBots > 0 && <span className="tg-header-badge">{activeBots} activo{activeBots > 1 ? 's' : ''}</span>}
-        </span>
-        <button className="tg-close" onClick={onClose} aria-label="Cerrar panel de Telegram"><X size={16} /></button>
-      </div>
+      {!embedded && (
+        <div className="tg-header">
+          <span className="tg-header-title">
+            <span className="tg-icon"><Bot size={16} /></span>
+            Bots de Telegram
+            {activeBots > 0 && <span className="tg-header-badge">{activeBots} activo{activeBots > 1 ? 's' : ''}</span>}
+          </span>
+          <button className="tg-close" onClick={onClose} aria-label="Cerrar panel de Telegram"><X size={16} /></button>
+        </div>
+      )}
 
       <div className="tg-body">
         {/* Resumen */}

--- a/client/src/components/WebChatPanel.jsx
+++ b/client/src/components/WebChatPanel.jsx
@@ -13,7 +13,7 @@ import ChatInput from './chat/ChatInput.jsx';
 import AuthPanel from './AuthPanel.jsx';
 import './WebChatPanel.css';
 
-export default function WebChatPanel({ onClose }) {
+export default function WebChatPanel({ onClose, embedded }) {
   const [providers, setProviders] = useState([]);
   const [agentsList, setAgentsList] = useState([]);
 
@@ -168,6 +168,7 @@ export default function WebChatPanel({ onClose }) {
         onClear={clearChat}
         onClose={onClose}
         onSettingsChange={handleSettingsChange}
+        embedded={embedded}
       />
 
       <StatusBar

--- a/client/src/components/chat/ChatHeader.jsx
+++ b/client/src/components/chat/ChatHeader.jsx
@@ -2,11 +2,11 @@ import { Trash2, X, LogIn, LogOut, User } from 'lucide-react';
 
 export default function ChatHeader({
   providers, provider, setProvider, agentsList, agent, setAgent,
-  authUser, onLogout, onShowAuth, onClear, onClose, onSettingsChange,
+  authUser, onLogout, onShowAuth, onClear, onClose, onSettingsChange, embedded,
 }) {
   return (
     <div className="wc-header">
-      <span className="wc-header-title">Chat</span>
+      {!embedded && <span className="wc-header-title">Chat</span>}
       <div className="wc-header-controls">
         <select
           className="wc-select"
@@ -52,7 +52,7 @@ export default function ChatHeader({
           </button>
         )}
         <button className="wc-btn-icon" onClick={onClear} title="Nueva conversación" aria-label="Nueva conversación"><Trash2 size={14} /></button>
-        <button className="wc-close" onClick={onClose} aria-label="Cerrar panel de chat"><X size={16} /></button>
+        {!embedded && <button className="wc-close" onClick={onClose} aria-label="Cerrar panel de chat"><X size={16} /></button>}
       </div>
     </div>
   );


### PR DESCRIPTION
## Cambios

- **Sidebar expandible**: toggle 60px ↔ 180px, persiste en `localStorage`. Botón chevron en la parte inferior.
- **Tooltips**: cuando el sidebar está comprimido, `title` attribute en cada ítem muestra el label al hover.
- **Persistencia de secciones** (bug fix crítico): Chat, Telegram, Contactos y Config ya no se destruyen al cambiar de sección. Se montan en el primer acceso y se muestran/ocultan con CSS `display:none`, preservando el estado del chat, historial, etc.
- **Barra de sección** (`section-bar`): sub-header con ícono + nombre de la sección activa para Chat, Telegram y Contactos.
- **Prop `embedded`** en `WebChatPanel`, `TelegramPanel`, `ContactsPanel` y `ChatHeader`: oculta títulos y botones de cierre redundantes cuando el panel está embebido en la sección full-width.
- **CSS `section-full > :not(.section-bar)`**: fix del selector para que `section-bar` no reciba los `!important` overrides de flex/width.

## Testing
- Build limpio (`vite build` sin errores ni warnings)
- Verificar: cambiar entre secciones preserva el chat y el estado de Telegram
- Verificar: toggle del sidebar expande/colapsa correctamente
- Verificar: botones X desaparecen en paneles embedded