### PR TITLE
feat(client): rediseño Fase 4 — modo split Terminal + Chat IA

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -315,6 +315,94 @@
   position: relative;
 }
 
+/* ── Context bar ──────────────────────────────────────────────────────────── */
+.context-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  height: 26px;
+  padding: 0 12px;
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-primary);
+  flex-shrink: 0;
+  font-size: 11px;
+}
+
+.context-cwd {
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 240px;
+}
+
+.context-provider {
+  color: var(--accent-cyan);
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.context-spacer { flex: 1; }
+
+.split-toggle-btn {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  background: none;
+  border: 1px solid var(--border-primary);
+  border-radius: 4px;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 2px 8px;
+  font-size: 11px;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+  white-space: nowrap;
+}
+.split-toggle-btn:hover {
+  color: var(--text-primary);
+  border-color: var(--text-muted);
+}
+.split-toggle-btn.active {
+  color: var(--accent-cyan);
+  border-color: var(--accent-cyan);
+  background: color-mix(in srgb, var(--accent-cyan) 10%, transparent);
+}
+
+/* ── Split layout ─────────────────────────────────────────────────────────── */
+.split-layout {
+  flex: 1;
+  display: flex;
+  overflow: hidden;
+  min-height: 0;
+}
+
+.split-panel {
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  position: relative;
+}
+
+.split-chat-panel {
+  border-left: none;
+}
+
+.split-divider {
+  width: 4px;
+  background: var(--border-primary);
+  cursor: col-resize;
+  flex-shrink: 0;
+  transition: background 0.15s;
+  position: relative;
+  z-index: 5;
+}
+.split-divider:hover,
+.split-divider:active {
+  background: var(--accent-cyan);
+}
+
 /* Full-width sections (chat, telegram, contacts, config) */
 .section-full {
   flex-direction: column;

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useRef, useEffect, lazy, Suspense } from 'react'
 import {
   Terminal, MessageCircle, Send, BookUser, Settings,
   Plug, Bot, Sun, Moon, ChevronLeft, ChevronRight,
+  PanelsLeftRight,
 } from 'lucide-react';
 import TabBar from './components/TabBar.jsx';
 import CommandBar from './components/CommandBar.jsx';
@@ -118,6 +119,31 @@ function SectionBar({ section }) {
   );
 }
 
+// ── Context bar (terminal section) ───────────────────────────────────────────
+
+function ContextBar({ splitMode, onToggleSplit, chatState }) {
+  return (
+    <div className="context-bar">
+      {splitMode && chatState.cwd && (
+        <span className="context-cwd" title={chatState.cwd}>📁 {chatState.cwd}</span>
+      )}
+      {splitMode && chatState.provider && (
+        <span className="context-provider">⚡ {chatState.provider}</span>
+      )}
+      <span className="context-spacer" />
+      <button
+        className={`split-toggle-btn${splitMode ? ' active' : ''}`}
+        onClick={onToggleSplit}
+        title={splitMode ? 'Cerrar split' : 'Abrir split con Chat IA'}
+        aria-label={splitMode ? 'Cerrar modo split' : 'Abrir modo split'}
+      >
+        <PanelsLeftRight size={13} aria-hidden="true" />
+        <span>{splitMode ? 'Cerrar split' : 'Split'}</span>
+      </button>
+    </div>
+  );
+}
+
 // ── Config section — tabs internos ────────────────────────────────────────────
 
 function ConfigSection() {
@@ -166,10 +192,61 @@ function AppContent() {
     try { return localStorage.getItem('sidebar-expanded') === 'true'; } catch { return false; }
   });
 
+  // ── Split mode ───────────────────────────────────────────────────────────────
+  const [splitMode, setSplitMode] = useState(() => {
+    try { return localStorage.getItem('split-mode') === 'true'; } catch { return false; }
+  });
+  const [splitRatio, setSplitRatioState] = useState(() => {
+    try { return parseFloat(localStorage.getItem('split-ratio')) || 55; } catch { return 55; }
+  });
+  const [splitChatState, setSplitChatState] = useState({ cwd: '~', provider: 'anthropic' });
+
+  const splitRatioRef     = useRef(splitRatio);
+  const splitContainerRef = useRef(null);
+
+  const setSplitRatio = useCallback((v) => {
+    splitRatioRef.current = v;
+    setSplitRatioState(v);
+  }, []);
+
+  const toggleSplit = useCallback(() => {
+    setSplitMode(v => {
+      const next = !v;
+      try { localStorage.setItem('split-mode', String(next)); } catch {}
+      return next;
+    });
+  }, []);
+
+  const onSplitMouseDown = useCallback((e) => {
+    e.preventDefault();
+    const container = splitContainerRef.current;
+    if (!container) return;
+    const onMove = (ev) => {
+      const rect = container.getBoundingClientRect();
+      const ratio = Math.min(80, Math.max(20, ((ev.clientX - rect.left) / rect.width) * 100));
+      setSplitRatio(ratio);
+    };
+    const onUp = () => {
+      document.removeEventListener('mousemove', onMove);
+      document.removeEventListener('mouseup', onUp);
+      try { localStorage.setItem('split-ratio', String(splitRatioRef.current)); } catch {}
+    };
+    document.addEventListener('mousemove', onMove);
+    document.addEventListener('mouseup', onUp);
+  }, [setSplitRatio]);
+
+  const handleSplitChatStateChange = useCallback(({ cwd, provider }) => {
+    setSplitChatState(prev => ({
+      cwd:      cwd      !== undefined ? cwd      : prev.cwd,
+      provider: provider !== undefined ? provider : prev.provider,
+    }));
+  }, []);
+
+  // ── Resto del estado ─────────────────────────────────────────────────────────
+
   const httpIdToTabId = useRef(new Map());
   const sectionRef    = useRef('terminal');
 
-  // Cambia de sección, monta si primera vez, limpia badge
   const handleSection = useCallback((key) => {
     setMounted(prev => prev[key] ? prev : { ...prev, [key]: true });
     setSection(key);
@@ -186,12 +263,10 @@ function AppContent() {
     });
   }, []);
 
-  // Callback para WebChatPanel: nuevo mensaje IA → badge si no estamos en chat
   const handleNewChatMessage = useCallback(() => {
     if (sectionRef.current !== 'chat') setChatBadge(b => b + 1);
   }, []);
 
-  // Listener WebSocket global (eventos de Telegram + badges)
   useEffect(() => {
     let ws, reconnectTimer;
     function connect() {
@@ -204,7 +279,6 @@ function AppContent() {
           const msg = JSON.parse(event.data);
           if (msg.type === 'telegram_session') {
             const { sessionId, from } = msg;
-            // Badge: nuevo mensaje de Telegram mientras no estamos en esa sección
             if (sectionRef.current !== 'telegram') setTelegramBadge(b => b + 1);
             if (httpIdToTabId.current.has(sessionId)) {
               setActiveId(httpIdToTabId.current.get(sessionId));
@@ -320,20 +394,55 @@ function AppContent() {
               onClaude={(sys) => openNew(sys || null, 'ai', null, 'anthropic')}
               onAI={(provider, sys) => openNew(sys || null, 'ai', null, provider)}
             />
-            <main className="terminal-body">
-              <Suspense fallback={<Skeleton lines={5} style={{ padding: '24px' }} />}>
-                {sessions.map((s) => (
-                  <TerminalPanel
-                    key={s.id}
-                    session={s}
-                    wsUrl={WS_URL}
-                    active={s.id === activeId}
-                    onClose={() => closeSession(s.id)}
-                    onSessionId={(httpId) => handleSessionId(s.id, httpId)}
+            <ContextBar
+              splitMode={splitMode}
+              onToggleSplit={toggleSplit}
+              chatState={splitChatState}
+            />
+
+            {/* ── Split layout ── */}
+            <div className={splitMode ? 'split-layout' : 'terminal-body'} ref={splitContainerRef}>
+
+              {/* Panel izquierdo: Terminal */}
+              <main className={splitMode ? 'split-panel' : undefined} style={splitMode ? { width: `${splitRatio}%` } : undefined}>
+                <Suspense fallback={<Skeleton lines={5} style={{ padding: '24px' }} />}>
+                  {sessions.map((s) => (
+                    <TerminalPanel
+                      key={s.id}
+                      session={s}
+                      wsUrl={WS_URL}
+                      active={s.id === activeId}
+                      onClose={() => closeSession(s.id)}
+                      onSessionId={(httpId) => handleSessionId(s.id, httpId)}
+                    />
+                  ))}
+                </Suspense>
+              </main>
+
+              {/* Divisor + panel derecho: Chat IA (solo en split mode) */}
+              {splitMode && (
+                <>
+                  <div
+                    className="split-divider"
+                    onMouseDown={onSplitMouseDown}
+                    role="separator"
+                    aria-label="Divisor redimensionable"
+                    aria-orientation="vertical"
                   />
-                ))}
-              </Suspense>
-            </main>
+                  <div className="split-panel split-chat-panel" style={{ width: `${100 - splitRatio}%` }}>
+                    <ErrorBoundary>
+                      <Suspense fallback={<Skeleton lines={6} style={{ padding: '24px' }} />}>
+                        <WebChatPanel
+                          embedded
+                          onNewMessage={handleNewChatMessage}
+                          onStateChange={handleSplitChatStateChange}
+                        />
+                      </Suspense>
+                    </ErrorBoundary>
+                  </div>
+                </>
+              )}
+            </div>
           </div>
 
           {/* ── Chat IA — montado en primer acceso, persiste con CSS ── */}

--- a/client/src/components/WebChatPanel.jsx
+++ b/client/src/components/WebChatPanel.jsx
@@ -13,7 +13,7 @@ import ChatInput from './chat/ChatInput.jsx';
 import AuthPanel from './AuthPanel.jsx';
 import './WebChatPanel.css';
 
-export default function WebChatPanel({ onClose, embedded, onNewMessage }) {
+export default function WebChatPanel({ onClose, embedded, onNewMessage, onStateChange }) {
   const [providers, setProviders] = useState([]);
   const [agentsList, setAgentsList] = useState([]);
 
@@ -42,6 +42,9 @@ export default function WebChatPanel({ onClose, embedded, onNewMessage }) {
 
   // Pasar wsRef al AuthContext para refresh proactivo
   useEffect(() => { setWsRef(wsRef.current); }, [connected, setWsRef, wsRef]);
+
+  // Reportar cwd + provider al padre (para context bar en split mode)
+  useEffect(() => { onStateChange?.({ cwd, provider }); }, [cwd, provider]); // eslint-disable-line
 
   // ── Cargar providers y agentes ─────────────────────────────────────────────
 


### PR DESCRIPTION
## Cambios

- **Modo split**: botón en context bar debajo del CommandBar para activar/desactivar
- **Layout split**: Terminal en panel izquierdo + Chat IA en panel derecho
- **Divisor arrastrable**: drag para redimensionar (límites 20%–80%), ratio persiste en `localStorage`
- **Context bar**: nueva barra de 26px debajo del CommandBar que muestra:
  - cwd del chat activo (cuando split está on)
  - provider activo del chat (cuando split está on)
  - Botón Split siempre visible
- **Persistencia**: split mode y ratio se guardan en `localStorage`
- **`WebChatPanel`**: prop `onStateChange({ cwd, provider })` — se llama via `useEffect` cuando cambia cwd o provider

## Archivos

- `client/src/App.jsx` — nuevo componente `ContextBar`, estados split, drag handler, split JSX
- `client/src/App.css` — estilos context bar, split-layout, split-panel, split-divider
- `client/src/components/WebChatPanel.jsx` — prop `onStateChange` + useEffect

## Testing
- Build limpio (`vite build`, 0 warnings)
- Click Split → aparece divisor y chat a la derecha
- Drag divisor → paneles se redimensionan en tiempo real
- Recargar → ratio y modo split se restauran
- Context bar muestra cwd/provider al usar el chat en split