### PR TITLE
feat(client): rediseño visual — paleta dark navy + tipografía Inter

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -4,9 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
     <meta name="description" content="Terminal web interactiva con soporte para múltiples sesiones, IA y Telegram" />
-    <meta name="theme-color" content="#1a1a1a" />
-    <title>Terminal Live</title>
+    <meta name="theme-color" content="#0d1117" />
+    <title>Clawmint</title>
   </head>
   <body>
     <div id="root"></div>

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -3,12 +3,13 @@
   position: absolute;
   top: -40px;
   left: 0;
-  background: var(--accent-green);
+  background: var(--accent-cyan);
   color: #000;
   padding: 8px 16px;
   z-index: 100;
   font-size: 14px;
   text-decoration: none;
+  font-family: var(--font-ui);
 }
 .skip-link:focus { top: 0; }
 
@@ -19,46 +20,68 @@
   height: 100vh;
   height: 100dvh;
   overflow: hidden;
+  background: var(--bg-primary);
 }
 
 /* ── Header ───────────────────────────────────────────────────────────────── */
 .app-header {
   display: flex;
   align-items: center;
-  gap: 8px;
-  background: var(--bg-header);
-  padding: 8px 16px;
+  gap: 10px;
+  background: linear-gradient(90deg, #0f1923 0%, #111927 100%);
+  padding: 0 18px;
   border-bottom: 1px solid var(--border-primary);
   user-select: none;
   flex-shrink: 0;
-  height: 42px;
+  height: 46px;
+  position: relative;
 }
 
-.dot { width: 12px; height: 12px; border-radius: 50%; }
-.dot.red    { background: #ff5f57; }
-.dot.yellow { background: #febc2e; }
-.dot.green  { background: #28c840; }
+/* subtle glow line at the bottom */
+.app-header::after {
+  content: '';
+  position: absolute;
+  bottom: -1px;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(79,195,247,0.2), transparent);
+  pointer-events: none;
+}
 
+/* macOS traffic lights */
+.dot { width: 12px; height: 12px; border-radius: 50%; flex-shrink: 0; }
+.dot.red    { background: #ff5f57; box-shadow: 0 0 6px rgba(255,95,87,0.4); }
+.dot.yellow { background: #febc2e; box-shadow: 0 0 6px rgba(254,188,46,0.4); }
+.dot.green  { background: #28c840; box-shadow: 0 0 6px rgba(40,200,64,0.4); }
+
+/* Brand title */
 .title {
-  margin: 0 0 0 8px;
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--text-muted);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  margin: 0 0 0 6px;
+  font-size: 13px;
+  font-weight: 700;
+  font-family: var(--font-ui);
+  letter-spacing: -0.01em;
+  color: #fff;
+}
+.title em {
+  font-style: normal;
+  color: var(--accent-cyan);
 }
 
-/* ── WS status dot ─────────────────────────────────────────────────────────── */
+/* WS status dot */
 .ws-status-dot {
-  width: 6px;
-  height: 6px;
+  width: 7px;
+  height: 7px;
   border-radius: 50%;
   background: var(--accent-green);
+  box-shadow: 0 0 6px rgba(74,222,128,0.5);
   flex-shrink: 0;
-  transition: background 0.4s;
+  transition: background 0.4s, box-shadow 0.4s;
 }
 .ws-status-dot.disconnected {
-  background: #ff5f57;
+  background: var(--accent-red);
+  box-shadow: 0 0 6px rgba(248,113,113,0.5);
   animation: ws-dot-pulse 1.2s ease-in-out infinite;
 }
 @keyframes ws-dot-pulse {
@@ -73,23 +96,30 @@
   gap: 8px;
 }
 
+/* User chip */
 .header-user {
   display: flex;
   align-items: center;
   gap: 7px;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-primary);
+  background: rgba(79,195,247,0.06);
+  border: 1px solid rgba(79,195,247,0.18);
   border-radius: 20px;
   padding: 3px 10px 3px 4px;
   font-size: 12px;
-  color: var(--text-muted);
+  color: var(--text-secondary);
+  font-family: var(--font-ui);
+  transition: border-color 0.2s, background 0.2s;
+}
+.header-user:hover {
+  border-color: rgba(79,195,247,0.35);
+  background: rgba(79,195,247,0.10);
 }
 
 .header-user-avatar {
   width: 22px;
   height: 22px;
   border-radius: 50%;
-  background: linear-gradient(135deg, var(--accent-green), #16a34a);
+  background: linear-gradient(135deg, var(--accent-cyan), #2980b9);
   color: #000;
   font-size: 11px;
   font-weight: 700;
@@ -97,33 +127,35 @@
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
+  font-family: var(--font-ui);
 }
 
 .header-user-name {
   font-size: 12px;
-  color: var(--text-muted);
+  color: var(--text-secondary);
   max-width: 120px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
+/* Icon buttons */
 .header-icon-btn {
   background: none;
   border: 1px solid transparent;
-  border-radius: 6px;
+  border-radius: 8px;
   color: var(--text-muted);
   cursor: pointer;
-  padding: 5px 8px;
+  padding: 6px 9px;
   line-height: 1;
   display: flex;
   align-items: center;
   transition: color 0.15s, border-color 0.15s, background 0.15s;
 }
 .header-icon-btn:hover {
-  color: var(--accent-yellow);
-  border-color: rgba(254, 188, 46, 0.2);
-  background: rgba(254, 188, 46, 0.07);
+  color: var(--accent-cyan);
+  border-color: rgba(79,195,247,0.20);
+  background: rgba(79,195,247,0.07);
 }
 .header-icon-btn:focus-visible {
   outline: 2px solid var(--accent-cyan);
@@ -140,18 +172,29 @@
 /* ── Sidebar ──────────────────────────────────────────────────────────────── */
 .app-sidebar {
   width: 60px;
-  background: var(--bg-header);
+  background: linear-gradient(180deg, #0f1923 0%, #0d1520 100%);
   border-right: 1px solid var(--border-primary);
   display: flex;
   flex-direction: column;
   flex-shrink: 0;
-  padding: 8px 0;
-  transition: width 0.2s ease;
+  padding: 10px 0;
+  transition: width 0.22s cubic-bezier(0.4, 0, 0.2, 1);
   overflow: hidden;
+  position: relative;
+}
+
+/* subtle glow on the right edge */
+.app-sidebar::after {
+  content: '';
+  position: absolute;
+  top: 0; right: -1px; bottom: 0;
+  width: 1px;
+  background: linear-gradient(180deg, transparent, rgba(79,195,247,0.15), transparent);
+  pointer-events: none;
 }
 
 .app-sidebar.sidebar-expanded {
-  width: 180px;
+  width: 182px;
 }
 
 .sidebar-nav {
@@ -172,12 +215,12 @@
   overflow: hidden;
 }
 
-/* Expanded: items stretch full width */
 .app-sidebar.sidebar-expanded .sidebar-nav,
 .app-sidebar.sidebar-expanded .sidebar-bottom {
   align-items: stretch;
 }
 
+/* Sidebar items */
 .sidebar-item {
   width: 44px;
   min-height: 44px;
@@ -192,13 +235,12 @@
   cursor: pointer;
   color: var(--text-muted);
   position: relative;
-  transition: color 0.15s, background 0.15s, border-color 0.15s;
+  transition: color 0.15s, background 0.15s, border-color 0.15s, box-shadow 0.15s;
   padding: 6px 2px;
   white-space: nowrap;
   flex-shrink: 0;
 }
 
-/* Expanded: items are rows */
 .app-sidebar.sidebar-expanded .sidebar-item {
   width: auto;
   flex-direction: row;
@@ -210,13 +252,15 @@
 
 .sidebar-item:hover {
   color: var(--text-primary);
-  background: var(--bg-secondary);
+  background: rgba(79,195,247,0.07);
+  border-color: rgba(79,195,247,0.12);
 }
 
 .sidebar-item.active {
   color: var(--accent-cyan);
-  background: color-mix(in srgb, var(--accent-cyan) 10%, transparent);
-  border-color: color-mix(in srgb, var(--accent-cyan) 25%, transparent);
+  background: rgba(79,195,247,0.12);
+  border-color: rgba(79,195,247,0.28);
+  box-shadow: var(--glow-item), 0 0 12px rgba(79,195,247,0.08);
 }
 
 .sidebar-item:focus-visible {
@@ -227,8 +271,9 @@
 .sidebar-label {
   font-size: 9px;
   font-weight: 500;
-  letter-spacing: 0.2px;
+  letter-spacing: 0.3px;
   line-height: 1;
+  font-family: var(--font-ui);
 }
 
 .app-sidebar.sidebar-expanded .sidebar-label {
@@ -237,26 +282,29 @@
   letter-spacing: 0;
 }
 
+/* Badge */
 .sidebar-badge {
   position: absolute;
   top: 4px;
   right: 4px;
-  background: var(--accent-green);
+  background: var(--accent-cyan);
   color: #000;
   font-size: 8px;
   font-weight: 700;
   border-radius: 8px;
-  min-width: 14px;
-  height: 14px;
+  min-width: 15px;
+  height: 15px;
   display: flex;
   align-items: center;
   justify-content: center;
   padding: 0 3px;
   line-height: 1;
+  font-family: var(--font-ui);
+  box-shadow: 0 0 8px rgba(79,195,247,0.4);
   animation: badge-pop 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 @keyframes badge-pop {
-  from { transform: scale(0.5); opacity: 0; }
+  from { transform: scale(0.4); opacity: 0; }
   to   { transform: scale(1);   opacity: 1; }
 }
 
@@ -265,6 +313,7 @@
   margin-left: auto;
 }
 
+/* Divider */
 .sidebar-divider {
   width: 28px;
   height: 1px;
@@ -277,9 +326,7 @@
   width: 100%;
 }
 
-.sidebar-toggle-btn {
-  opacity: 0.6;
-}
+.sidebar-toggle-btn { opacity: 0.5; }
 .sidebar-toggle-btn:hover { opacity: 1; }
 
 /* ── Content area ─────────────────────────────────────────────────────────── */
@@ -289,6 +336,7 @@
   display: flex;
   overflow: hidden;
   position: relative;
+  background: var(--bg-primary);
 }
 
 /* ── Secciones ────────────────────────────────────────────────────────────── */
@@ -320,12 +368,13 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  height: 26px;
-  padding: 0 12px;
+  height: 28px;
+  padding: 0 14px;
   background: var(--bg-secondary);
   border-bottom: 1px solid var(--border-primary);
   flex-shrink: 0;
   font-size: 11px;
+  font-family: var(--font-ui);
 }
 
 .context-cwd {
@@ -339,7 +388,7 @@
 
 .context-provider {
   color: var(--accent-cyan);
-  font-weight: 500;
+  font-weight: 600;
   white-space: nowrap;
 }
 
@@ -351,22 +400,23 @@
   gap: 5px;
   background: none;
   border: 1px solid var(--border-primary);
-  border-radius: 4px;
+  border-radius: 5px;
   color: var(--text-muted);
   cursor: pointer;
-  padding: 2px 8px;
+  padding: 2px 9px;
   font-size: 11px;
+  font-family: var(--font-ui);
   transition: color 0.15s, border-color 0.15s, background 0.15s;
   white-space: nowrap;
 }
 .split-toggle-btn:hover {
   color: var(--text-primary);
-  border-color: var(--text-muted);
+  border-color: var(--border-accent);
 }
 .split-toggle-btn.active {
   color: var(--accent-cyan);
-  border-color: var(--accent-cyan);
-  background: color-mix(in srgb, var(--accent-cyan) 10%, transparent);
+  border-color: rgba(79,195,247,0.35);
+  background: rgba(79,195,247,0.08);
 }
 
 /* ── Split layout ─────────────────────────────────────────────────────────── */
@@ -385,9 +435,7 @@
   position: relative;
 }
 
-.split-chat-panel {
-  border-left: none;
-}
+.split-chat-panel { border-left: none; }
 
 .split-divider {
   width: 4px;
@@ -400,44 +448,62 @@
 }
 .split-divider:hover,
 .split-divider:active {
-  background: var(--accent-cyan);
+  background: rgba(79,195,247,0.5);
+  box-shadow: 0 0 8px rgba(79,195,247,0.2);
 }
 
-/* Full-width sections (chat, telegram, contacts, config) */
+/* Full-width sections */
 .section-full {
   flex-direction: column;
 }
 
-/* ── Barra de sección ─────────────────────────────────────────────────────── */
+/* ── Barra de sección — color por panel ──────────────────────────────────── */
 .section-bar {
   display: flex;
   align-items: center;
   gap: 8px;
-  height: 36px;
-  padding: 0 16px;
-  background: var(--bg-header);
+  height: 38px;
+  padding: 0 18px;
+  background: var(--bg-secondary);
   border-bottom: 1px solid var(--border-primary);
   flex-shrink: 0;
+  position: relative;
 }
 
-.section-bar-icon {
-  color: var(--accent-cyan);
+/* colored left accent line per section */
+.section-bar::before {
+  content: '';
+  position: absolute;
+  left: 0; top: 0; bottom: 0;
+  width: 3px;
+  border-radius: 0 2px 2px 0;
 }
+
+.section-chat     .section-bar::before { background: var(--accent-cyan); box-shadow: 0 0 8px rgba(79,195,247,0.5); }
+.section-telegram .section-bar::before { background: var(--accent-blue); box-shadow: 0 0 8px rgba(91,141,240,0.5); }
+.section-contacts .section-bar::before { background: var(--accent-purple); box-shadow: 0 0 8px rgba(167,139,250,0.5); }
+
+.section-bar-icon { flex-shrink: 0; }
+.section-chat     .section-bar-icon { color: var(--accent-cyan); }
+.section-telegram .section-bar-icon { color: var(--accent-blue); }
+.section-contacts .section-bar-icon { color: var(--accent-purple); }
 
 .section-bar-title {
   font-size: 13px;
   font-weight: 600;
   color: var(--text-primary);
+  font-family: var(--font-ui);
 }
 
 .section-bar-badge {
   font-size: 11px;
   color: var(--text-muted);
-  background: var(--bg-secondary);
+  background: var(--bg-card);
   border: 1px solid var(--border-primary);
   border-radius: 10px;
-  padding: 1px 7px;
+  padding: 1px 8px;
   margin-left: 2px;
+  font-family: var(--font-ui);
 }
 
 /* ── Config section ───────────────────────────────────────────────────────── */
@@ -451,7 +517,7 @@
 .config-tab-bar {
   display: flex;
   gap: 0;
-  background: var(--bg-header);
+  background: var(--bg-secondary);
   border-bottom: 1px solid var(--border-primary);
   padding: 0 20px;
   flex-shrink: 0;
@@ -465,6 +531,7 @@
   background: none;
   color: var(--text-muted);
   font-size: 13px;
+  font-family: var(--font-ui);
   cursor: pointer;
   display: flex;
   align-items: center;
@@ -487,10 +554,8 @@
   display: flex;
 }
 
-/* Paneles embebidos llenan el espacio — section-bar queda excluida */
-.section-full > .section-bar {
-  flex: none;
-}
+/* Paneles embebidos llenan el espacio */
+.section-full > .section-bar { flex: none; }
 
 .config-tab-body > *,
 .section-full > :not(.section-bar) {
@@ -528,6 +593,7 @@
   justify-content: center;
   gap: 3px;
   font-size: 9px;
+  font-family: var(--font-ui);
   cursor: pointer;
   transition: color 0.15s;
 }
@@ -544,7 +610,7 @@
   position: absolute;
   top: -5px;
   right: -8px;
-  background: var(--accent-green);
+  background: var(--accent-cyan);
   color: #000;
   font-size: 7px;
   font-weight: 700;
@@ -565,7 +631,7 @@
   .mobile-bottom-nav { display: flex; }
   .app-layout { margin-bottom: 56px; }
   .dot, .title { display: none; }
-  .app-header { padding: 6px 10px; }
+  .app-header { padding: 0 10px; }
 }
 
 @media (max-width: 480px) {

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -341,7 +341,7 @@ function AppContent() {
         <span className="dot red"    aria-hidden="true" />
         <span className="dot yellow" aria-hidden="true" />
         <span className="dot green"  aria-hidden="true" />
-        <h1 className="title">Clawmint</h1>
+        <h1 className="title"><span>Claw</span><em>mint</em></h1>
         <span
           className={`ws-status-dot${wsConnected ? '' : ' disconnected'}`}
           title={wsConnected ? 'Conectado' : 'Sin conexión'}

--- a/client/src/components/AgentsPanel.css
+++ b/client/src/components/AgentsPanel.css
@@ -125,7 +125,7 @@
 
 .ap-icon-btn:hover { opacity: 1; background: var(--border-secondary); }
 
-.ap-icon-btn-danger:hover { background: #3a1515; }
+.ap-icon-btn-danger:hover { background: rgba(248,113,113,0.10); }
 
 /* ─── Form ─── */
 
@@ -241,7 +241,7 @@
   transition: all 0.15s;
   margin-top: 4px;
 }
-.ap-btn-add:hover { background: #1a2235; border-color: var(--accent-blue); }
+.ap-btn-add:hover { background: rgba(79,195,247,0.10); border-color: var(--accent-blue); }
 
 /* ─── Empty state ─── */
 

--- a/client/src/components/CommandBar.css
+++ b/client/src/components/CommandBar.css
@@ -1,19 +1,20 @@
 .command-bar {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 8px;
   background: var(--bg-secondary);
-  border-bottom: 1px solid var(--border-secondary);
-  padding: 5px 12px;
+  border-bottom: 1px solid var(--border-primary);
+  padding: 5px 14px;
   flex-shrink: 0;
 }
 
 .command-prefix {
-  color: var(--accent-green);
+  color: var(--accent-teal);
   font-size: 14px;
-  font-family: monospace;
+  font-family: var(--font-mono);
   font-weight: bold;
   user-select: none;
+  text-shadow: 0 0 8px rgba(45, 212, 191, 0.5);
 }
 
 .command-input {
@@ -22,40 +23,39 @@
   border: none;
   outline: none;
   color: var(--text-primary);
-  font-family: 'Cascadia Code', 'Fira Code', 'Courier New', monospace;
+  font-family: var(--font-mono);
   font-size: 13px;
-  caret-color: var(--accent-green);
+  caret-color: var(--accent-teal);
 }
 
-.command-input::placeholder {
-  color: var(--text-hint);
-}
-
-.command-submit {
-  background: var(--bg-header);
-  border: 1px solid var(--border-primary);
-  color: var(--text-muted);
-  font-size: 12px;
-  padding: 3px 10px;
-  border-radius: 4px;
-  cursor: pointer;
-  transition: background 0.15s, color 0.15s;
-}
-
-.command-submit:hover {
-  background: var(--accent-green);
-  border-color: var(--accent-green);
-  color: #000;
-}
-
-.command-submit:focus-visible {
-  outline: 2px solid var(--accent-green);
-  outline-offset: 2px;
-}
+.command-input::placeholder { color: var(--text-hint); }
 
 .command-input:focus-visible {
   outline: none;
-  box-shadow: 0 1px 0 0 var(--accent-green);
+  box-shadow: 0 1px 0 0 rgba(45, 212, 191, 0.4);
+}
+
+.command-submit {
+  background: var(--bg-card);
+  border: 1px solid var(--border-primary);
+  color: var(--text-muted);
+  font-size: 12px;
+  font-family: var(--font-ui);
+  padding: 3px 10px;
+  border-radius: 5px;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.command-submit:hover {
+  background: rgba(45, 212, 191, 0.12);
+  border-color: rgba(45, 212, 191, 0.35);
+  color: var(--accent-teal);
+}
+
+.command-submit:focus-visible {
+  outline: 2px solid var(--accent-teal);
+  outline-offset: 2px;
 }
 
 .command-error {
@@ -63,4 +63,5 @@
   font-size: 11px;
   margin-left: 6px;
   white-space: nowrap;
+  font-family: var(--font-ui);
 }

--- a/client/src/components/ProvidersPanel.css
+++ b/client/src/components/ProvidersPanel.css
@@ -3,7 +3,7 @@
 .pp-msg {
   padding: 6px 10px;
   margin-bottom: 8px;
-  background: #1a2a1a;
+  background: rgba(74,222,128,0.10);
   border-radius: 4px;
   color: var(--accent-green);
   font-size: 12px;
@@ -49,12 +49,12 @@
 }
 
 .pp-status-badge.configured {
-  background: #1a3a1a;
+  background: rgba(74,222,128,0.14);
   color: var(--accent-green);
 }
 
 .pp-status-badge.unconfigured {
-  background: #3a1a1a;
+  background: rgba(248,113,113,0.10);
   color: var(--accent-red);
 }
 

--- a/client/src/components/TabBar.css
+++ b/client/src/components/TabBar.css
@@ -8,9 +8,7 @@
   scrollbar-width: none;
 }
 
-.tab-bar::-webkit-scrollbar {
-  display: none;
-}
+.tab-bar::-webkit-scrollbar { display: none; }
 
 .tab {
   display: flex;
@@ -19,12 +17,14 @@
   padding: 6px 14px;
   cursor: pointer;
   font-size: 12px;
+  font-family: var(--font-ui);
   color: var(--text-muted);
-  border-right: 1px solid var(--border-secondary);
+  border-right: 1px solid var(--border-subtle);
   white-space: nowrap;
-  transition: background 0.15s;
+  transition: background 0.15s, color 0.15s;
   min-width: 80px;
   max-width: 180px;
+  position: relative;
 }
 
 .tab:hover {
@@ -33,14 +33,15 @@
 }
 
 .tab:focus-visible {
-  outline: 2px solid var(--accent-green);
+  outline: 2px solid var(--accent-teal);
   outline-offset: -2px;
 }
 
 .tab.active {
   background: var(--bg-primary);
   color: var(--text-primary);
-  border-top: 2px solid var(--accent-green);
+  border-top: 2px solid var(--accent-teal);
+  box-shadow: inset 0 0 12px rgba(45, 212, 191, 0.04);
 }
 
 .tab-title {
@@ -58,11 +59,12 @@
   line-height: 1;
   padding: 4px 6px;
   border-radius: 3px;
+  transition: color 0.15s, background 0.15s;
 }
 
 .tab-close:hover {
   color: var(--accent-red);
-  background: var(--bg-active);
+  background: rgba(248, 113, 113, 0.10);
 }
 
 .tab-close:focus-visible {
@@ -81,11 +83,9 @@
   transition: color 0.15s;
 }
 
-.tab-new:hover {
-  color: var(--accent-green);
-}
+.tab-new:hover { color: var(--accent-teal); }
 
 .tab-new:focus-visible {
-  outline: 2px solid var(--accent-green);
+  outline: 2px solid var(--accent-teal);
   outline-offset: 1px;
 }

--- a/client/src/components/TelegramPanel.css
+++ b/client/src/components/TelegramPanel.css
@@ -19,7 +19,7 @@
   align-items: center;
   justify-content: space-between;
   padding: 10px 14px;
-  background: #252525;
+  background: var(--bg-card);
   border-bottom: 1px solid var(--border-secondary);
   flex-shrink: 0;
 }
@@ -36,7 +36,7 @@
 .tg-icon { font-size: 15px; }
 
 .tg-header-badge {
-  background: #28c84022;
+  background: rgba(74,222,128,0.10);
   color: var(--accent-green);
   border: 1px solid #28c84044;
   border-radius: 10px;
@@ -119,7 +119,7 @@
   align-items: center;
   justify-content: space-between;
   padding: 9px 12px;
-  background: #252525;
+  background: var(--bg-card);
   cursor: pointer;
   user-select: none;
   transition: background 0.1s;
@@ -172,7 +172,7 @@
 /* ─── Chat row ────────────────────────────────────────────────────────────── */
 
 .tg-chat-row {
-  background: #252525;
+  background: var(--bg-card);
   border: 1px solid var(--bg-hover);
   border-radius: 6px;
   padding: 8px 10px;
@@ -230,7 +230,7 @@
 /* ─── Formulario agregar ──────────────────────────────────────────────────── */
 
 .tg-add-form {
-  background: #252525;
+  background: var(--bg-card);
   border: 1px solid var(--border-secondary);
   border-radius: 8px;
   padding: 12px;
@@ -323,20 +323,20 @@
 .tg-btn-ghost { background: var(--bg-hover); color: var(--text-secondary); border: 1px solid var(--border-primary); }
 .tg-btn-ghost:hover:not(:disabled) { background: var(--border-secondary); color: var(--text-primary); }
 
-.tg-btn-start { background: #28c84022; color: #28c840; border: 1px solid #28c84044; }
-.tg-btn-start:hover:not(:disabled) { background: #28c84033; }
+.tg-btn-start { background: rgba(74,222,128,0.10); color: #28c840; border: 1px solid #28c84044; }
+.tg-btn-start:hover:not(:disabled) { background: rgba(74,222,128,0.16); }
 
 .tg-btn-stop { background: #febc2e22; color: #febc2e; border: 1px solid #febc2e44; }
 .tg-btn-stop:hover:not(:disabled) { background: #febc2e33; }
 
 .tg-btn-delete { background: transparent; color: #ff6b6b; border: 1px solid #4a2020; }
-.tg-btn-delete:hover:not(:disabled) { background: #3a1a1a; }
+.tg-btn-delete:hover:not(:disabled) { background: rgba(248,113,113,0.10); }
 
 .tg-btn-danger-ghost { background: transparent; color: #ff6b6b; border: 1px solid #4a2020; font-size: 10px; }
-.tg-btn-danger-ghost:hover:not(:disabled) { background: #3a1a1a; }
+.tg-btn-danger-ghost:hover:not(:disabled) { background: rgba(248,113,113,0.10); }
 
 .tg-btn-add {
-  background: #252525;
+  background: var(--bg-card);
   color: var(--text-muted);
   border: 1px dashed #3a3a3a;
   width: 100%;
@@ -408,11 +408,11 @@
 }
 .tg-agent-chip:hover { background: var(--border-secondary); color: var(--text-secondary); border-color: #555; }
 .tg-agent-chip.cc {
-  background: #29b6f622;
+  background: rgba(79,195,247,0.10);
   color: var(--accent-cyan);
   border-color: #29b6f644;
 }
-.tg-agent-chip.cc:hover { background: #29b6f633; }
+.tg-agent-chip.cc:hover { background: rgba(79,195,247,0.16); }
 
 /* ─── Session picker ──────────────────────────────────────────────────────── */
 
@@ -436,7 +436,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  background: #252525;
+  background: var(--bg-card);
   border: 1px solid var(--bg-hover);
   border-radius: 4px;
   padding: 5px 8px;
@@ -467,11 +467,11 @@
 /* ─── Link active button ──────────────────────────────────────────────────── */
 
 .tg-btn-link-active {
-  background: #29b6f622;
+  background: rgba(79,195,247,0.10);
   color: var(--accent-cyan);
   border: 1px solid #29b6f644;
 }
-.tg-btn-link-active:hover:not(:disabled) { background: #29b6f633; }
+.tg-btn-link-active:hover:not(:disabled) { background: rgba(79,195,247,0.16); }
 
 /* ─── Access config ───────────────────────────────────────────────────────── */
 
@@ -513,7 +513,7 @@
 
 .access-config button {
   float: right;
-  background: #2a4a2a;
+  background: rgba(74,222,128,0.12);
   border: 1px solid #3a6a3a;
   border-radius: 4px;
   color: #8fc88f;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,74 +1,110 @@
 :root {
-  /* Backgrounds */
-  --bg-primary: #1a1a1a;
-  --bg-secondary: #1e1e1e;
-  --bg-header: #2d2d2d;
-  --bg-panel: #222;
-  --bg-input: #111;
-  --bg-hover: #2e2e2e;
-  --bg-active: #3d3d3d;
+  /* ── Backgrounds — dark navy palette ──────────────────────────────────── */
+  --bg-primary:   #0d1117;
+  --bg-secondary: #0f1923;
+  --bg-header:    #111927;
+  --bg-panel:     #0f1923;
+  --bg-input:     #0a1018;
+  --bg-hover:     #162232;
+  --bg-active:    #1a2d42;
+  --bg-card:      #111c2a;
 
-  /* Borders */
-  --border-primary: #444;
-  --border-secondary: #333;
-  --border-subtle: #2a2a2a;
+  /* ── Borders — blue-tinted ────────────────────────────────────────────── */
+  --border-primary:   #1e2d3d;
+  --border-secondary: #162030;
+  --border-subtle:    #0f1a26;
+  --border-accent:    rgba(79, 195, 247, 0.25);
 
-  /* Text — WCAG AA compliant on dark backgrounds */
-  --text-primary: #f0f0f0;
-  --text-secondary: #ccc;
-  --text-muted: #b0b0b0;
-  --text-hint: #b0b0b0;
+  /* ── Text — WCAG AA on dark navy ──────────────────────────────────────── */
+  --text-primary:   #e8edf2;
+  --text-secondary: #9aacbc;
+  --text-muted:     #637282;
+  --text-hint:      #4a5a6a;
 
-  /* Accents */
-  --accent-green: #28c840;
-  --accent-blue: #007aff;
-  --accent-red: #ff5f57;
-  --accent-yellow: #febc2e;
-  --accent-cyan: #29b6f6;
+  /* ── Brand Accents ────────────────────────────────────────────────────── */
+  --accent-cyan:   #4fc3f7;    /* primary brand */
+  --accent-blue:   #5b8df0;
+  --accent-green:  #4ade80;
+  --accent-red:    #f87171;
+  --accent-yellow: #fbbf24;
+  --accent-purple: #a78bfa;
+  --accent-teal:   #2dd4bf;
+  --accent-orange: #fb923c;
 
-  /* Interactive */
-  --focus-ring: #007aff;
-  --btn-primary-bg: #007aff;
-  --btn-primary-hover: #0062cc;
+  /* ── Section accent colors ────────────────────────────────────────────── */
+  --section-terminal: var(--accent-teal);
+  --section-chat:     var(--accent-cyan);
+  --section-telegram: var(--accent-blue);
+  --section-contacts: var(--accent-purple);
+  --section-config:   var(--accent-yellow);
 
-  /* Skeleton */
-  --skeleton-bg: #2a2a2a;
-  --skeleton-shine: #3a3a3a;
+  /* ── Glow effects ─────────────────────────────────────────────────────── */
+  --glow-sm:   0 0 8px  rgba(79, 195, 247, 0.15);
+  --glow-md:   0 0 16px rgba(79, 195, 247, 0.20);
+  --glow-lg:   0 0 32px rgba(79, 195, 247, 0.12);
+  --glow-item: inset 0 0 12px rgba(79, 195, 247, 0.04);
+
+  /* ── Interactive ──────────────────────────────────────────────────────── */
+  --focus-ring:        #4fc3f7;
+  --btn-primary-bg:    #4fc3f7;
+  --btn-primary-hover: #38b2f0;
+  --btn-primary-text:  #000;
+
+  /* ── Skeleton ─────────────────────────────────────────────────────────── */
+  --skeleton-bg:    #111f2d;
+  --skeleton-shine: #1a2d40;
+
+  /* ── Typography ───────────────────────────────────────────────────────── */
+  --font-ui:   'Inter', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  --font-mono: 'Courier New', Courier, monospace;
 }
 
 /* ── Light theme ──────────────────────────────────────────────────────────── */
 
 [data-theme="light"] {
-  --bg-primary: #f5f5f5;
-  --bg-secondary: #eaeaea;
-  --bg-header: #e0e0e0;
-  --bg-panel: #f0f0f0;
-  --bg-input: #fff;
-  --bg-hover: #ddd;
-  --bg-active: #d0d0d0;
+  --bg-primary:   #f0f4f8;
+  --bg-secondary: #e4ecf4;
+  --bg-header:    #dae4ef;
+  --bg-panel:     #e8f0f8;
+  --bg-input:     #ffffff;
+  --bg-hover:     #d0dce8;
+  --bg-active:    #c4d6e8;
+  --bg-card:      #eaf2fa;
 
-  --border-primary: #c0c0c0;
-  --border-secondary: #d5d5d5;
-  --border-subtle: #e0e0e0;
+  --border-primary:   #b8ccd8;
+  --border-secondary: #c8d8e4;
+  --border-subtle:    #d8e8f0;
+  --border-accent:    rgba(0, 151, 196, 0.3);
 
-  --text-primary: #1a1a1a;
-  --text-secondary: #444;
-  --text-muted: #666;
-  --text-hint: #888;
+  --text-primary:   #1a2634;
+  --text-secondary: #445566;
+  --text-muted:     #667788;
+  --text-hint:      #889aaa;
 
-  --accent-green: #1a9e32;
-  --accent-blue: #0066dd;
-  --accent-red: #d93025;
-  --accent-yellow: #e8a000;
-  --accent-cyan: #0288d1;
+  --accent-cyan:   #0097c4;
+  --accent-blue:   #2563eb;
+  --accent-green:  #16a34a;
+  --accent-red:    #dc2626;
+  --accent-yellow: #d97706;
+  --accent-purple: #7c3aed;
+  --accent-teal:   #0d9488;
+  --accent-orange: #ea580c;
 
-  --focus-ring: #0066dd;
-  --btn-primary-bg: #0066dd;
-  --btn-primary-hover: #004fa3;
+  --glow-sm:   0 0 8px  rgba(0, 151, 196, 0.10);
+  --glow-md:   0 0 16px rgba(0, 151, 196, 0.15);
+  --glow-lg:   0 0 32px rgba(0, 151, 196, 0.08);
+  --glow-item: none;
 
-  --skeleton-bg: #e0e0e0;
-  --skeleton-shine: #f0f0f0;
+  --focus-ring:        #0097c4;
+  --btn-primary-bg:    #0097c4;
+  --btn-primary-hover: #007aa8;
+  --btn-primary-text:  #fff;
+
+  --skeleton-bg:    #d8e4ee;
+  --skeleton-shine: #e8f0f8;
 }
+
+/* ── Reset ────────────────────────────────────────────────────────────────── */
 
 * {
   margin: 0;
@@ -79,7 +115,7 @@
 body {
   background: var(--bg-primary);
   color: var(--text-primary);
-  font-family: 'Courier New', monospace;
+  font-family: var(--font-ui);
   height: 100vh;
   height: 100dvh;
   overflow: hidden;
@@ -111,19 +147,18 @@ body {
   align-items: center;
   gap: 8px;
   padding: 10px 14px;
-  border-radius: 8px;
+  border-radius: 10px;
   font-size: 13px;
-  font-family: 'Courier New', monospace;
-  color: #fff;
+  font-family: var(--font-ui);
   pointer-events: auto;
-  animation: toast-slide-in 0.25s ease-out;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  animation: toast-slide-in 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(255, 255, 255, 0.04);
 }
 
-.toast-info    { background: #1565c0; }
-.toast-success { background: #2e7d32; }
-.toast-error   { background: #c62828; }
-.toast-warning { background: #e65100; }
+.toast-info    { background: rgba(79, 195, 247, 0.12); border: 1px solid rgba(79, 195, 247, 0.30); color: #7dd3fc; }
+.toast-success { background: rgba(74, 222, 128, 0.12); border: 1px solid rgba(74, 222, 128, 0.30); color: #86efac; }
+.toast-error   { background: rgba(248, 113, 113, 0.12); border: 1px solid rgba(248, 113, 113, 0.30); color: #fca5a5; }
+.toast-warning { background: rgba(251, 191, 36, 0.12);  border: 1px solid rgba(251, 191, 36, 0.30);  color: #fde68a; }
 
 .toast-icon {
   font-size: 15px;
@@ -140,20 +175,20 @@ body {
 .toast-close {
   background: none;
   border: none;
-  color: rgba(255, 255, 255, 0.7);
+  color: currentColor;
+  opacity: 0.5;
   font-size: 18px;
   cursor: pointer;
   padding: 0 4px;
   line-height: 1;
   flex-shrink: 0;
+  transition: opacity 0.15s;
 }
 
-.toast-close:hover {
-  color: #fff;
-}
+.toast-close:hover { opacity: 1; }
 
 @keyframes toast-slide-in {
-  from { transform: translateX(100%); opacity: 0; }
+  from { transform: translateX(110%); opacity: 0; }
   to   { transform: translateX(0); opacity: 1; }
 }
 
@@ -168,7 +203,7 @@ body {
 
 .skeleton-line {
   height: 14px;
-  border-radius: 4px;
+  border-radius: 6px;
   background: linear-gradient(90deg, var(--skeleton-bg) 25%, var(--skeleton-shine) 50%, var(--skeleton-bg) 75%);
   background-size: 200% 100%;
   animation: skeleton-shimmer 1.5s ease-in-out infinite;
@@ -188,26 +223,28 @@ body {
   gap: 8px;
   padding: 6px 12px;
   font-size: 12px;
-  font-family: 'Courier New', monospace;
+  font-family: var(--font-ui);
   animation: reconnect-fade-in 0.3s ease-out;
   flex-shrink: 0;
 }
 
 .reconnect-warning {
-  background: #e65100;
-  color: #fff;
+  background: rgba(251, 191, 36, 0.10);
+  border-bottom: 1px solid rgba(251, 191, 36, 0.20);
+  color: #fbbf24;
 }
 
 .reconnect-success {
-  background: #2e7d32;
-  color: #fff;
+  background: rgba(74, 222, 128, 0.10);
+  border-bottom: 1px solid rgba(74, 222, 128, 0.20);
+  color: #4ade80;
 }
 
 .reconnect-spinner {
   width: 12px;
   height: 12px;
-  border: 2px solid rgba(255, 255, 255, 0.3);
-  border-top-color: #fff;
+  border: 2px solid rgba(255, 255, 255, 0.15);
+  border-top-color: currentColor;
   border-radius: 50%;
   animation: reconnect-spin 0.8s linear infinite;
 }
@@ -249,16 +286,16 @@ body {
     border: none;
     color: var(--text-muted);
     font-size: 10px;
-    font-family: 'Courier New', monospace;
+    font-family: var(--font-ui);
     padding: 4px 8px;
     cursor: pointer;
-    border-radius: 6px;
+    border-radius: 8px;
     transition: color 0.15s, background 0.15s;
   }
 
   .mobile-bottom-nav button.active {
     color: var(--accent-cyan);
-    background: rgba(41, 182, 246, 0.1);
+    background: rgba(79, 195, 247, 0.10);
   }
 
   .mobile-bottom-nav button:hover {
@@ -267,7 +304,5 @@ body {
 }
 
 @media (min-width: 641px) {
-  .mobile-bottom-nav {
-    display: none;
-  }
+  .mobile-bottom-nav { display: none; }
 }


### PR DESCRIPTION
## Cambios

- **Paleta dark navy**: `bg #0d1117`, accent cyan `#4fc3f7`, colores semánticos por sección (terminal=teal, chat=cyan, telegram=blue, contacts=purple, config=yellow)
- **Tipografía**: Inter desde Google Fonts, `--font-ui` y `--font-mono` unificados como variables
- **Header**: gradiente lineal + glow line inferior + traffic lights con box-shadow
- **CommandBar**: prefix teal con `text-shadow`, focus indicator sutil
- **TabBar**: accent teal, hover states mejorados, transiciones suaves
- **Componentes** (TelegramPanel, AgentsPanel, ProvidersPanel): colores actualizados al nuevo tema
- **index.html**: title "Clawmint", `theme-color #0d1117`
- **Light theme**: variables completas para todos los nuevos tokens

## Test

- [ ] Build limpio: `npm run build` ✓
- [ ] Dark theme se ve correcto
- [ ] Light theme funciona con los nuevos tokens