### PR TITLE
feat(client): rediseño Fase 3 — paneles temáticos por sección

### DIFF
--- a/client/src/components/AgentsPanel.css
+++ b/client/src/components/AgentsPanel.css
@@ -25,8 +25,8 @@
   align-items: center;
   justify-content: space-between;
   padding: 10px 14px;
-  border-bottom: 1px solid var(--border-secondary);
-  background: var(--bg-input);
+  border-bottom: 1px solid var(--border-primary);
+  background: linear-gradient(90deg, rgba(79,195,247,0.07) 0%, var(--bg-secondary) 50%);
 }
 
 .ap-header-title {
@@ -66,10 +66,17 @@
 /* ─── Agent rows ─── */
 
 .ap-agent-row {
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-secondary);
+  background: var(--bg-card);
+  border: 1px solid var(--border-primary);
+  border-left: 3px solid var(--accent-cyan);
   border-radius: 6px;
   padding: 10px 12px;
+  transition: border-color 0.15s, background 0.15s;
+}
+.ap-agent-row:hover {
+  background: var(--bg-hover);
+  border-color: rgba(79,195,247,0.30);
+  border-left-color: var(--accent-cyan);
 }
 
 .ap-agent-top {
@@ -82,8 +89,8 @@
 .ap-agent-key {
   font-size: 13px;
   font-weight: 600;
-  color: var(--text-secondary);
-  font-family: monospace;
+  color: var(--accent-cyan);
+  font-family: var(--font-mono);
   display: flex;
   align-items: center;
   gap: 4px;
@@ -101,7 +108,7 @@
 
 .ap-agent-prompt {
   font-size: 11px;
-  color: #6a9fb5;
+  color: var(--text-muted);
   font-style: italic;
   margin: 4px 0 0;
   line-height: 1.4;
@@ -192,7 +199,7 @@
 
 .ap-error {
   font-size: 11px;
-  color: #f87171;
+  color: var(--accent-red);
   margin: 6px 0 0;
 }
 

--- a/client/src/components/ContactsPanel.css
+++ b/client/src/components/ContactsPanel.css
@@ -25,8 +25,8 @@
   align-items: center;
   justify-content: space-between;
   padding: 10px 14px;
-  border-bottom: 1px solid var(--border-secondary);
-  background: var(--bg-input);
+  border-bottom: 1px solid var(--border-primary);
+  background: linear-gradient(90deg, rgba(167,139,250,0.07) 0%, var(--bg-secondary) 50%);
 }
 
 .cp-title {
@@ -58,15 +58,20 @@
 
 .cp-search {
   flex: 1;
-  background: var(--bg-input);
-  border: 1px solid var(--border-secondary);
-  border-radius: 5px;
-  padding: 5px 8px;
-  font-size: 12px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-primary);
+  border-radius: 10px;
+  padding: 6px 10px;
+  font-size: 12.5px;
+  font-family: var(--font-ui);
   color: var(--text-primary);
   outline: none;
+  transition: border-color 0.18s, box-shadow 0.18s;
 }
-.cp-search:focus { border-color: var(--accent-primary, #7c6af7); }
+.cp-search:focus {
+  border-color: rgba(167,139,250,0.45);
+  box-shadow: 0 0 0 3px rgba(167,139,250,0.08);
+}
 
 /* ─── List ─── */
 
@@ -92,28 +97,36 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 8px 10px;
-  border-radius: 6px;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-secondary);
+  padding: 9px 10px;
+  border-radius: 8px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-primary);
   cursor: pointer;
-  transition: background 0.15s;
+  transition: background 0.15s, border-color 0.15s;
 }
-.cp-contact-row:hover { background: var(--bg-input); }
-.cp-contact-row:focus { outline: 2px solid var(--accent-primary, #7c6af7); }
+.cp-contact-row:hover {
+  background: var(--bg-hover);
+  border-color: rgba(167,139,250,0.25);
+}
+.cp-contact-row:focus {
+  outline: 2px solid var(--accent-purple);
+  outline-offset: 1px;
+}
 
 .cp-contact-avatar {
-  width: 32px;
-  height: 32px;
+  width: 34px;
+  height: 34px;
   border-radius: 50%;
-  background: var(--accent-primary, #7c6af7);
+  background: linear-gradient(135deg, var(--accent-purple), #7c3aed);
   color: #fff;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 14px;
-  font-weight: 600;
+  font-size: 13px;
+  font-weight: 700;
   flex-shrink: 0;
+  font-family: var(--font-ui);
+  box-shadow: 0 2px 6px rgba(167,139,250,0.25);
 }
 
 .cp-contact-info {
@@ -171,9 +184,9 @@
 }
 
 .cp-btn-primary {
-  background: var(--accent-primary, #7c6af7);
+  background: var(--accent-purple);
   color: #fff;
-  border-color: var(--accent-primary, #7c6af7);
+  border-color: var(--accent-purple);
 }
 .cp-btn-primary:hover { opacity: 0.85; }
 .cp-btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
@@ -186,7 +199,7 @@
 .cp-btn-ghost:hover { background: var(--bg-input); color: var(--text-primary); }
 
 .cp-btn-active {
-  background: var(--accent-primary, #7c6af7);
+  background: var(--accent-purple);
   color: #fff;
 }
 
@@ -205,10 +218,10 @@
 
 .cp-icon-btn-danger:hover { color: #e05252; }
 
-.cp-fav-active { color: #f5a623; }
-.cp-fav-active:hover { color: #f5a623; }
+.cp-fav-active { color: var(--accent-yellow); }
+.cp-fav-active:hover { color: var(--accent-yellow); }
 
-.cp-star-icon { color: #f5a623; flex-shrink: 0; }
+.cp-star-icon { color: var(--accent-yellow); flex-shrink: 0; }
 
 /* ─── Form ─── */
 
@@ -246,7 +259,7 @@
   outline: none;
   font-family: inherit;
 }
-.cp-input:focus, .cp-textarea:focus { border-color: var(--accent-primary, #7c6af7); }
+.cp-input:focus, .cp-textarea:focus { border-color: var(--accent-purple); }
 
 .cp-textarea { resize: vertical; }
 
@@ -336,7 +349,7 @@
 
 .cp-detail-notes { align-items: flex-start; }
 
-.cp-linked { color: var(--accent-primary, #7c6af7); }
+.cp-linked { color: var(--accent-purple); }
 .cp-not-linked { color: var(--text-muted); font-style: italic; }
 .cp-linked-ids { font-size: 11px; color: var(--text-muted); }
 

--- a/client/src/components/TelegramPanel.css
+++ b/client/src/components/TelegramPanel.css
@@ -19,8 +19,8 @@
   align-items: center;
   justify-content: space-between;
   padding: 10px 14px;
-  background: var(--bg-card);
-  border-bottom: 1px solid var(--border-secondary);
+  background: linear-gradient(90deg, rgba(91,141,240,0.07) 0%, var(--bg-card) 50%);
+  border-bottom: 1px solid var(--border-primary);
   flex-shrink: 0;
 }
 
@@ -38,11 +38,12 @@
 .tg-header-badge {
   background: rgba(74,222,128,0.10);
   color: var(--accent-green);
-  border: 1px solid #28c84044;
+  border: 1px solid rgba(74,222,128,0.27);
   border-radius: 10px;
   font-size: 10px;
   font-weight: 600;
   padding: 1px 7px;
+  font-family: var(--font-ui);
 }
 
 .tg-close {
@@ -111,7 +112,7 @@
 }
 
 .tg-bot-card.running {
-  border-color: #28c84033;
+  border-color: rgba(74,222,128,0.20);
 }
 
 .tg-bot-header {
@@ -173,12 +174,19 @@
 
 .tg-chat-row {
   background: var(--bg-card);
-  border: 1px solid var(--bg-hover);
+  border: 1px solid var(--border-primary);
+  border-left: 3px solid var(--accent-blue);
   border-radius: 6px;
   padding: 8px 10px;
   display: flex;
   flex-direction: column;
   gap: 4px;
+  transition: border-color 0.15s, background 0.15s;
+}
+.tg-chat-row:hover {
+  background: var(--bg-hover);
+  border-color: rgba(91,141,240,0.35);
+  border-left-color: var(--accent-blue);
 }
 
 .tg-chat-top {


### PR DESCRIPTION
## Cambios

### ContactsPanel — purple
- Header: gradiente con tinte purple
- Avatar: gradiente `accent-purple → #7c3aed` + box-shadow
- Search: `border-radius 10px` + focus glow purple
- Contact rows: `bg-card` + hover border purple
- Todos los `accent-primary` → `var(--accent-purple)` (fix undefined variable)
- Favorito: `#f5a623` → `var(--accent-yellow)`

### TelegramPanel — blue
- Header: gradiente con tinte blue
- Badge "running": `#28c84044` → `rgba(74,222,128,0.27)` (CSS var)
- Bot card running: `#28c84033` → `rgba(74,222,128,0.20)`
- Chat rows: `border-left: 3px solid accent-blue` + hover tintado

### AgentsPanel — cyan
- Header: gradiente con tinte cyan
- Agent key: `color: accent-cyan` + `font-mono`
- Agent rows: `border-left: 3px solid accent-cyan` + hover tintado
- `#6a9fb5` → `text-muted`, `#f87171` → `accent-red`

## Test
- [ ] Build limpio ✓
- [ ] Contacts: avatar purple, search focus glow
- [ ] Telegram: chat rows con borde izquierdo azul
- [ ] Agents: rows con borde izquierdo cyan