### PR TITLE
feat(client): rediseño Fase 4 — cleanups + DirPicker + Providers

### DIFF
--- a/client/src/components/DirPicker.css
+++ b/client/src/components/DirPicker.css
@@ -11,12 +11,12 @@
 .dirpicker {
   background: var(--bg-secondary);
   border: 1px solid var(--border-primary);
-  border-radius: 8px;
+  border-radius: 12px;
   width: 480px;
   max-height: 70vh;
   display: flex;
   flex-direction: column;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.6), 0 0 0 1px rgba(79,195,247,0.08);
 }
 
 .dirpicker-header {
@@ -77,14 +77,15 @@
   border: 1px solid var(--border-primary);
   border-radius: 4px;
   color: var(--text-primary);
-  font-family: 'Cascadia Code', 'Fira Code', monospace;
+  font-family: var(--font-mono);
   font-size: 12px;
   padding: 5px 8px;
   outline: none;
 }
 
 .dirpicker-input:focus {
-  border-color: var(--focus-ring);
+  border-color: rgba(45,212,191,0.5);
+  box-shadow: 0 0 0 3px rgba(45,212,191,0.08);
 }
 
 .dirpicker-bookmarks {
@@ -96,18 +97,21 @@
 }
 
 .dirpicker-bookmark {
-  background: var(--bg-header);
-  border: 1px solid #3a3a3a;
+  background: var(--bg-card);
+  border: 1px solid var(--border-primary);
   color: var(--text-muted);
   font-size: 11px;
-  padding: 2px 8px;
-  border-radius: 3px;
+  font-family: var(--font-ui);
+  padding: 3px 9px;
+  border-radius: 6px;
   cursor: pointer;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
 }
 
 .dirpicker-bookmark:hover {
-  background: var(--bg-active);
-  color: var(--text-primary);
+  background: var(--bg-hover);
+  color: var(--accent-teal);
+  border-color: rgba(45,212,191,0.3);
 }
 
 .dirpicker-list {
@@ -130,12 +134,12 @@
   color: var(--text-secondary);
   font-size: 13px;
   cursor: pointer;
-  font-family: 'Cascadia Code', 'Fira Code', monospace;
+  font-family: var(--font-mono);
 }
 
 .dirpicker-item:hover {
-  background: var(--border-subtle);
-  color: #fff;
+  background: var(--bg-hover);
+  color: var(--accent-teal);
 }
 
 .dirpicker-folder-icon {
@@ -163,15 +167,20 @@
 }
 
 .dirpicker-select {
-  background: var(--btn-primary-bg);
+  background: linear-gradient(135deg, var(--accent-teal) 0%, var(--accent-cyan) 100%);
   border: none;
-  color: #fff;
+  color: #000;
   font-size: 13px;
-  padding: 6px 16px;
-  border-radius: 4px;
+  font-weight: 600;
+  font-family: var(--font-ui);
+  padding: 7px 18px;
+  border-radius: 8px;
   cursor: pointer;
+  transition: opacity 0.15s, box-shadow 0.15s;
+  box-shadow: 0 2px 8px rgba(45,212,191,0.25);
 }
 
 .dirpicker-select:hover {
-  background: var(--btn-primary-hover);
+  opacity: 0.88;
+  box-shadow: 0 2px 14px rgba(45,212,191,0.4);
 }

--- a/client/src/components/ProvidersPanel.css
+++ b/client/src/components/ProvidersPanel.css
@@ -10,26 +10,32 @@
 }
 
 .pp-section-title {
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--text-secondary);
-  margin-bottom: 6px;
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--accent-yellow);
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+  font-family: var(--font-ui);
 }
 
 .pp-default-select {
   width: 100%;
-  padding: 6px 8px;
-  background: var(--bg-secondary);
-  color: var(--text-secondary);
+  padding: 7px 10px;
+  background: var(--bg-card);
+  color: var(--text-primary);
   border: 1px solid var(--border-primary);
-  border-radius: 4px;
-  font-size: 12px;
+  border-radius: 6px;
+  font-size: 12.5px;
+  font-family: var(--font-ui);
   cursor: pointer;
+  outline: none;
+  transition: border-color 0.18s, box-shadow 0.18s;
 }
 
 .pp-default-select:focus {
-  border-color: var(--focus-ring);
-  outline: none;
+  border-color: rgba(251,191,36,0.45);
+  box-shadow: 0 0 0 3px rgba(251,191,36,0.07);
 }
 
 .pp-provider-title {
@@ -68,33 +74,39 @@
 .pp-input {
   width: 100%;
   margin-bottom: 6px;
-  padding: 5px 8px;
-  background: var(--bg-secondary);
-  color: var(--text-secondary);
+  padding: 6px 10px;
+  background: var(--bg-card);
+  color: var(--text-primary);
   border: 1px solid var(--border-primary);
-  border-radius: 4px;
-  font-size: 12px;
+  border-radius: 6px;
+  font-size: 12.5px;
+  font-family: var(--font-ui);
   box-sizing: border-box;
+  outline: none;
+  transition: border-color 0.18s, box-shadow 0.18s;
 }
 
 .pp-input:focus {
-  border-color: var(--focus-ring);
-  outline: none;
+  border-color: rgba(251,191,36,0.45);
+  box-shadow: 0 0 0 3px rgba(251,191,36,0.07);
 }
 
 .pp-select {
   width: 100%;
   margin-bottom: 8px;
-  padding: 5px 8px;
-  background: var(--bg-secondary);
-  color: var(--text-secondary);
+  padding: 6px 10px;
+  background: var(--bg-card);
+  color: var(--text-primary);
   border: 1px solid var(--border-primary);
-  border-radius: 4px;
-  font-size: 12px;
+  border-radius: 6px;
+  font-size: 12.5px;
+  font-family: var(--font-ui);
   box-sizing: border-box;
+  outline: none;
+  transition: border-color 0.18s, box-shadow 0.18s;
 }
 
 .pp-select:focus {
-  border-color: var(--focus-ring);
-  outline: none;
+  border-color: rgba(251,191,36,0.45);
+  box-shadow: 0 0 0 3px rgba(251,191,36,0.07);
 }

--- a/client/src/components/TelegramPanel.css
+++ b/client/src/components/TelegramPanel.css
@@ -346,15 +346,19 @@
 .tg-btn-add {
   background: var(--bg-card);
   color: var(--text-muted);
-  border: 1px dashed #3a3a3a;
+  border: 1px dashed var(--border-primary);
   width: 100%;
   text-align: center;
   padding: 9px;
   border-radius: 7px;
   font-size: 12px;
+  font-family: var(--font-ui);
   transition: color 0.15s, border-color 0.15s;
 }
-.tg-btn-add:hover { color: #29b6f6; border-color: #29b6f655; }
+.tg-btn-add:hover {
+  color: var(--accent-blue);
+  border-color: rgba(91,141,240,0.4);
+}
 
 /* ─── Status dot ──────────────────────────────────────────────────────────── */
 

--- a/client/src/components/WebChatPanel.css
+++ b/client/src/components/WebChatPanel.css
@@ -533,18 +533,19 @@
   margin-top: 6px;
 }
 .wc-inline-btn {
-  background: var(--bg-hover);
-  color: #58a6ff;
-  border: 1px solid #3a3a3a;
-  border-radius: 6px;
-  padding: 4px 12px;
+  background: rgba(167,139,250,0.08);
+  color: var(--accent-purple);
+  border: 1px solid rgba(167,139,250,0.25);
+  border-radius: 8px;
+  padding: 5px 14px;
   font-size: 12px;
+  font-family: var(--font-ui);
   cursor: pointer;
   transition: background 0.15s, border-color 0.15s;
 }
 .wc-inline-btn:hover {
-  background: var(--border-secondary);
-  border-color: #58a6ff;
+  background: rgba(167,139,250,0.16);
+  border-color: rgba(167,139,250,0.45);
 }
 
 /* ─── TTS audio message ────────────────────────────────────────────────────── */
@@ -594,7 +595,7 @@
 
 /* Status text en barra */
 .wc-status-text {
-  color: #58a6ff;
+  color: var(--accent-cyan);
   font-style: italic;
 }
 
@@ -616,7 +617,8 @@
   width: 7px;
   height: 7px;
   border-radius: 50%;
-  background: #888;
+  background: var(--accent-cyan);
+  opacity: 0.6;
   animation: wc-typing-bounce 1.4s infinite ease-in-out both;
 }
 .wc-typing-dot:nth-child(1) { animation-delay: 0s; }
@@ -669,13 +671,13 @@
   align-items: center;
   gap: 8px;
   padding: 10px 12px;
-  color: #58a6ff;
+  color: var(--accent-blue);
   text-decoration: none;
   border-radius: 8px;
   transition: background 0.15s;
 }
 .wc-media-doc:hover {
-  background: var(--border-secondary);
+  background: var(--bg-hover);
 }
 .wc-media-doc-name {
   flex: 1;


### PR DESCRIPTION
## Cambios

### WebChatPanel — últimos hardcoded
- Inline buttons: `#58a6ff/#3a3a3a` → **purple theme** con `rgba(167,139,250)`
- Status text (pensando/tool): `#58a6ff` → `accent-cyan`
- Typing dots: `#888` → `accent-cyan`
- Media doc link: `#58a6ff` → `accent-blue`, hover → `bg-hover`

### TelegramPanel
- `tg-btn-add` border: `#3a3a3a` → `var(--border-primary)`, hover → `accent-blue`
- Añadido `font-family: var(--font-ui)`

### DirPicker — overhaul completo
- `'Cascadia Code', 'Fira Code', monospace` → `var(--font-mono)` en todas partes
- `border-radius 8→12px` + `box-shadow` mejorado con glow sutil
- Input focus: teal glow `rgba(45,212,191,0.08)`
- Bookmarks: `border-primary` + hover teal
- Items hover: `bg-hover + accent-teal` (sin `#fff` hardcoded)
- Select button: gradiente `teal→cyan` + sombra (igual que el send del chat)

### ProvidersPanel — yellow config theme
- Section title: `accent-yellow` + uppercase (identidad de la sección Config)
- Inputs y selects: `bg-card` + `border-radius 6px` + focus glow **yellow**
- `font-family: var(--font-ui)` en todos los inputs

## Test
- [ ] Build limpio ✓
- [ ] Chat: inline buttons purple, typing dots cyan
- [ ] DirPicker: select button gradiente, bookmarks hover teal
- [ ] ProvidersPanel: title amarillo, inputs con focus glow amarillo