### PR TITLE
fix(client): AgentsPanel — skills crash si API devuelve error

### DIFF
--- a/client/src/components/AgentsPanel.jsx
+++ b/client/src/components/AgentsPanel.jsx
@@ -124,7 +124,7 @@ function SkillsSection() {
   const [error, setError] = useState('');
 
   const loadSkills = useCallback(() => {
-    apiFetch(SKILLS_API).then(r => r.json()).then(setSkillsList).catch(() => setError('Error cargando skills'));
+    apiFetch(SKILLS_API).then(r => r.json()).then(data => setSkillsList(Array.isArray(data) ? data : [])).catch(() => setError('Error cargando skills'));
   }, []);
 
   useEffect(() => { loadSkills(); }, [loadSkills]);


### PR DESCRIPTION
## Problema

El panel de Configuración crasheaba con `skillsList.map is not a function` al cargar.

## Causa

`SkillsSection` hacía `.then(setSkillsList)` sin validar que la respuesta fuera un array. Cuando la API retorna un objeto de error en vez de `[]`, `skillsList` quedaba como objeto y `.map` fallaba.

## Fix

Guard con `Array.isArray()` igual al que ya existe en `fetchAgents`.