### PR TITLE
fix(client): mover botón Login al header principal

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -139,6 +139,29 @@
   white-space: nowrap;
 }
 
+/* Login button en header */
+.header-login-btn {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  background: rgba(79,195,247,0.08);
+  border: 1px solid rgba(79,195,247,0.22) !important;
+  border-radius: 20px !important;
+  padding: 3px 10px !important;
+  font-size: 12px;
+  color: var(--accent-cyan);
+  font-family: var(--font-ui);
+  cursor: pointer;
+  transition: background 0.2s, border-color 0.2s;
+}
+.header-login-btn:hover {
+  background: rgba(79,195,247,0.14);
+  border-color: rgba(79,195,247,0.4) !important;
+}
+.header-login-label {
+  font-size: 12px;
+}
+
 /* Icon buttons */
 .header-icon-btn {
   background: none;

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2,7 +2,7 @@ import { useState, useCallback, useRef, useEffect, lazy, Suspense } from 'react'
 import {
   Terminal, MessageCircle, Send, BookUser, Settings,
   Plug, Bot, Sun, Moon, ChevronLeft, ChevronRight,
-  PanelsLeftRight,
+  PanelsLeftRight, LogIn,
 } from 'lucide-react';
 import TabBar from './components/TabBar.jsx';
 import CommandBar from './components/CommandBar.jsx';
@@ -179,7 +179,7 @@ function ConfigSection() {
 
 function AppContent() {
   const { theme, toggleTheme } = useTheme();
-  const { user } = useAuth();
+  const { user, setShowAuthPanel } = useAuth();
 
   const [section, setSection]   = useState('terminal');
   const [mounted, setMounted]   = useState({ terminal: true });
@@ -349,11 +349,20 @@ function AppContent() {
         />
 
         <div className="header-right">
-          {user && (
+          {user ? (
             <div className="header-user" aria-label={`Usuario: ${user.name}`}>
               <span className="header-user-avatar">{(user.name || 'U')[0].toUpperCase()}</span>
               <span className="header-user-name">{user.name}</span>
             </div>
+          ) : (
+            <button
+              className="header-icon-btn header-login-btn"
+              onClick={() => setShowAuthPanel(true)}
+              aria-label="Iniciar sesión"
+            >
+              <LogIn size={14} aria-hidden="true" />
+              <span className="header-login-label">Entrar</span>
+            </button>
           )}
           <button
             className="header-icon-btn theme-toggle"

--- a/client/src/components/chat/ChatHeader.jsx
+++ b/client/src/components/chat/ChatHeader.jsx
@@ -46,7 +46,7 @@ export default function ChatHeader({
             {authUser.name || authUser.email}
             <LogOut size={10} />
           </button>
-        ) : (
+        ) : !embedded && (
           <button className="wc-login-btn" onClick={onShowAuth} title="Iniciar sesión">
             <LogIn size={12} /> Login
           </button>


### PR DESCRIPTION
## Problema
El botón "→ Login" aparecía dentro del panel Chat IA sin contexto, confundiendo al usuario que ya estaba usando la app.

## Cambios
- **App.jsx**: header muestra `→ Entrar` cuando `user === null`, y el chip de usuario cuando está autenticado
- **ChatHeader.jsx**: Login button oculto cuando `embedded=true` (se maneja desde el header del app)
- **App.css**: estilos del nuevo `.header-login-btn`