### PR TITLE
fix(client): quitar React.StrictMode para evitar doble mount

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -4,7 +4,5 @@ import App from './App.jsx';
 import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
+  <App />
 );


### PR DESCRIPTION
## Summary
- Quita `React.StrictMode` de `main.jsx` para evitar doble mount de componentes en dev mode
- StrictMode causaba: PTYs huérfanos en el server, conexiones WS duplicadas, label "bash 2" en vez de "bash 1", y prompt desplazado al centro de la terminal

## Test plan
- [x] Verificado con screenshot: tab muestra "bash 1", prompt arriba, 0 warnings en consola
- [ ] Verificar que no se crean PTYs huérfanos al cargar la página