### PR TITLE
feat(telegram): soporte para documentos recibidos

### DIFF
--- a/server/channels/telegram/MediaHandler.js
+++ b/server/channels/telegram/MediaHandler.js
@@ -7,8 +7,21 @@ const os   = require('os');
 
 const { tdbg } = require('./utils');
 
+const TEXT_EXTENSIONS = new Set([
+  'txt', 'md', 'csv', 'json', 'xml', 'yaml', 'yml', 'toml', 'ini', 'cfg', 'conf', 'log',
+  'js', 'ts', 'jsx', 'tsx', 'mjs', 'cjs', 'py', 'rb', 'go', 'rs', 'java', 'kt', 'c',
+  'cpp', 'h', 'hpp', 'cs', 'swift', 'php', 'pl', 'sh', 'bash', 'zsh', 'fish', 'ps1',
+  'bat', 'cmd', 'sql', 'r', 'lua', 'vim', 'el', 'clj', 'ex', 'exs', 'erl', 'hs',
+  'scala', 'dart', 'v', 'zig', 'nim', 'cr', 'ml', 'mli', 'f90', 'jl',
+  'html', 'htm', 'css', 'scss', 'sass', 'less', 'svg',
+  'dockerfile', 'makefile', 'cmake', 'gradle', 'env', 'gitignore', 'editorconfig',
+]);
+
+const MAX_DOC_SIZE = 20 * 1024 * 1024; // 20MB (límite Telegram Bot API)
+const MAX_TEXT_READ = 100 * 1024;       // 100KB de texto leído
+
 /**
- * MediaHandler — procesa mensajes de voz/audio y fotos de Telegram.
+ * MediaHandler — procesa mensajes de voz/audio, fotos y documentos de Telegram.
  *
  * Patrón: recibe `bot` como primer parámetro (igual que CommandHandler).
  * Después de procesar el media, delega a bot._handleMessage(msg).
@@ -102,6 +115,74 @@ class MediaHandler {
       console.error(`[Telegram:${bot.key}] Error procesando foto:`, errDetail);
       if (err?.stack) console.error(`[Telegram:${bot.key}] Stack:`, err.stack);
       await bot.sendText(chatId, `❌ Error al procesar la foto: ${errDetail.slice(0, 200)}`);
+    }
+  }
+  async handleDocument(bot, msg) {
+    const chatId = msg.chat.id;
+    if (!bot._isAllowed(chatId, msg.chat.type)) {
+      await bot.sendText(chatId, '⛔ No tenés acceso a este bot.', msg.message_id);
+      return;
+    }
+    const doc = msg.document;
+    if (!doc) return;
+
+    if (doc.file_size > MAX_DOC_SIZE) {
+      await bot.sendText(chatId, '⚠️ El archivo es demasiado grande (máx 20MB).');
+      return;
+    }
+
+    const fileName = doc.file_name || 'archivo';
+    const ext = path.extname(fileName).replace('.', '').toLowerCase();
+    const isImage = ['jpg', 'jpeg', 'png', 'gif', 'webp', 'bmp'].includes(ext);
+    const isText = TEXT_EXTENSIONS.has(ext) || (doc.mime_type || '').startsWith('text/');
+
+    try {
+      const fileInfo = await bot._apiCall('getFile', { file_id: doc.file_id });
+      const fileUrl  = `https://api.telegram.org/file/bot${bot.token}/${fileInfo.file_path}`;
+
+      const buffer = await new Promise((resolve, reject) => {
+        https.get(fileUrl, (res) => {
+          if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+            https.get(res.headers.location, (r2) => {
+              const chunks = []; r2.on('data', c => chunks.push(c)); r2.on('end', () => resolve(Buffer.concat(chunks))); r2.on('error', reject);
+            }).on('error', reject);
+            return;
+          }
+          const chunks = []; res.on('data', c => chunks.push(c)); res.on('end', () => resolve(Buffer.concat(chunks))); res.on('error', reject);
+        }).on('error', reject);
+      });
+
+      console.log(`[Telegram:${bot.key}] Documento recibido de ${chatId}: ${fileName} (${Math.round(buffer.length / 1024)}KB)`);
+
+      if (isImage) {
+        const mediaType = ext === 'png' ? 'image/png' : ext === 'gif' ? 'image/gif' : ext === 'webp' ? 'image/webp' : 'image/jpeg';
+        msg.text = msg.caption || 'Describe esta imagen';
+        msg._images = [{ base64: buffer.toString('base64'), mediaType }];
+        await bot._handleMessage(msg);
+        return;
+      }
+
+      if (isText) {
+        let content = buffer.toString('utf-8');
+        const truncated = content.length > MAX_TEXT_READ;
+        if (truncated) content = content.slice(0, MAX_TEXT_READ);
+
+        const caption = msg.caption || '';
+        const truncNote = truncated ? `\n(archivo truncado a ${Math.round(MAX_TEXT_READ / 1024)}KB)` : '';
+        msg.text = `${caption}\n\n📄 Archivo: ${fileName}${truncNote}\n\`\`\`\n${content}\n\`\`\``.trim();
+        await bot._handleMessage(msg);
+        return;
+      }
+
+      // Archivo binario no soportado para lectura directa
+      const tmpFile = path.join(os.tmpdir(), `clawmint_doc_${Date.now()}_${fileName}`);
+      fs.writeFileSync(tmpFile, buffer);
+      msg.text = msg.caption || `Recibí el archivo "${fileName}" (${Math.round(buffer.length / 1024)}KB, tipo: ${doc.mime_type || ext || 'desconocido'}).`;
+      msg._files = [{ path: tmpFile, name: fileName, mime: doc.mime_type || 'application/octet-stream', size: buffer.length }];
+      await bot._handleMessage(msg);
+    } catch (err) {
+      console.error(`[Telegram:${bot.key}] Error procesando documento:`, err.message);
+      await bot.sendText(chatId, `❌ Error al procesar documento: ${err.message}`);
     }
   }
 }

--- a/server/channels/telegram/TelegramBot.js
+++ b/server/channels/telegram/TelegramBot.js
@@ -416,6 +416,12 @@ class TelegramBot {
       }
       return;
     }
+    if (msg.document) {
+      if (this._mediaHandler) {
+        await this._mediaHandler.handleDocument(this, msg);
+      }
+      return;
+    }
     if (!msg.text) return;
     await this._handleMessage(msg);
   }


### PR DESCRIPTION
## Summary
- Agrega `handleDocument()` en `MediaHandler` para procesar archivos enviados por el usuario
- Archivos de texto/código (~50 extensiones): lee el contenido y lo inyecta como contexto a la IA
- Imágenes enviadas como documento (no comprimidas): las procesa igual que fotos (base64 + visión)
- Archivos binarios: guarda en `/tmp`, pasa metadata a la IA via `msg._files`
- Límites: 20MB máximo (API Telegram), texto truncado a 100KB

## Test plan
- [ ] Enviar un `.txt` o `.py` → la IA debe ver el contenido del archivo
- [ ] Enviar una imagen como documento → la IA debe describirla
- [ ] Enviar un archivo binario (.zip, .pdf) → la IA debe recibir metadata
- [ ] Enviar archivo >20MB → debe mostrar mensaje de error
- [ ] Verificar que el caption del documento se usa como prompt