### PR TITLE
feat: migrar bots a SQLite con ownership por usuario

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -83,7 +83,14 @@
       "Bash(python3 -c \"import sys,json; data=json.load\\(sys.stdin\\); [print\\(f{r[''''full_name'''']} | stars:{r[''''stargazers_count'''']} | lang:{r.get\\(''''language'''',''''''''\\)} | {r[''''description'''']} | updated:{r[''''updated_at'''']}\\) for r in data.get\\(''''items'''',[]\\)]\")",
       "Bash(pm2 env:*)",
       "WebFetch(domain:www.bing.com)",
-      "Bash(curl -s \"https://registry.npmjs.org/-/v1/search?text=kheiron&size=20\")"
+      "Bash(curl -s \"https://registry.npmjs.org/-/v1/search?text=kheiron&size=20\")",
+      "Bash(echo \"exit: $?\")",
+      "Bash(pm2 describe:*)",
+      "Bash(curl -s \"https://api.telegram.org/bot8793100760:AAEgNx5nnC_IyNQHq9YPs0UiTFEL8D7E6gw/getUpdates?offset=101123432&limit=5\")",
+      "Bash(curl:*)",
+      "Bash(TOKEN=\"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI1YmY4ZDYzZi1hNmU5LTQxYzItOTRkMS05ODRkMzk2ZDZhOTAiLCJpYXQiOjE3NzQ3MjM5NDYsImV4cCI6MTc3NDcyNDg0Nn0.wJ9sOuIdoqc57Wsf8Y3rqETCbs1w5neuijeko_mA1aE\")",
+      "Bash(xargs kill:*)",
+      "Bash(pm2 flush:*)"
     ]
   }
 }

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -419,6 +419,8 @@
 
 .terminal-body {
   flex: 1;
+  display: flex;
+  flex-direction: column;
   overflow: hidden;
   position: relative;
 }

--- a/server/bootstrap.js
+++ b/server/bootstrap.js
@@ -62,7 +62,8 @@ function createContainer() {
   const messagesRepo = new WebchatMessagesRepository(db);
   messagesRepo.init();
 
-  const botsRepo = new BotsRepository(path.join(__dirname, 'bots.json'));
+  const botsRepo = new BotsRepository(db, path.join(__dirname, 'bots.json'));
+  botsRepo.init();
 
   const usersRepo = new UsersRepository(db);
   usersRepo.init();

--- a/server/channels/telegram/MediaHandler.js
+++ b/server/channels/telegram/MediaHandler.js
@@ -7,8 +7,21 @@ const os   = require('os');
 
 const { tdbg } = require('./utils');
 
+const TEXT_EXTENSIONS = new Set([
+  'txt', 'md', 'csv', 'json', 'xml', 'yaml', 'yml', 'toml', 'ini', 'cfg', 'conf', 'log',
+  'js', 'ts', 'jsx', 'tsx', 'mjs', 'cjs', 'py', 'rb', 'go', 'rs', 'java', 'kt', 'c',
+  'cpp', 'h', 'hpp', 'cs', 'swift', 'php', 'pl', 'sh', 'bash', 'zsh', 'fish', 'ps1',
+  'bat', 'cmd', 'sql', 'r', 'lua', 'vim', 'el', 'clj', 'ex', 'exs', 'erl', 'hs',
+  'scala', 'dart', 'v', 'zig', 'nim', 'cr', 'ml', 'mli', 'f90', 'jl',
+  'html', 'htm', 'css', 'scss', 'sass', 'less', 'svg',
+  'dockerfile', 'makefile', 'cmake', 'gradle', 'env', 'gitignore', 'editorconfig',
+]);
+
+const MAX_DOC_SIZE = 20 * 1024 * 1024; // 20MB (límite Telegram Bot API)
+const MAX_TEXT_READ = 100 * 1024;       // 100KB de texto leído
+
 /**
- * MediaHandler — procesa mensajes de voz/audio y fotos de Telegram.
+ * MediaHandler — procesa mensajes de voz/audio, fotos y documentos de Telegram.
  *
  * Patrón: recibe `bot` como primer parámetro (igual que CommandHandler).
  * Después de procesar el media, delega a bot._handleMessage(msg).
@@ -102,6 +115,74 @@ class MediaHandler {
       console.error(`[Telegram:${bot.key}] Error procesando foto:`, errDetail);
       if (err?.stack) console.error(`[Telegram:${bot.key}] Stack:`, err.stack);
       await bot.sendText(chatId, `❌ Error al procesar la foto: ${errDetail.slice(0, 200)}`);
+    }
+  }
+  async handleDocument(bot, msg) {
+    const chatId = msg.chat.id;
+    if (!bot._isAllowed(chatId, msg.chat.type)) {
+      await bot.sendText(chatId, '⛔ No tenés acceso a este bot.', msg.message_id);
+      return;
+    }
+    const doc = msg.document;
+    if (!doc) return;
+
+    if (doc.file_size > MAX_DOC_SIZE) {
+      await bot.sendText(chatId, '⚠️ El archivo es demasiado grande (máx 20MB).');
+      return;
+    }
+
+    const fileName = doc.file_name || 'archivo';
+    const ext = path.extname(fileName).replace('.', '').toLowerCase();
+    const isImage = ['jpg', 'jpeg', 'png', 'gif', 'webp', 'bmp'].includes(ext);
+    const isText = TEXT_EXTENSIONS.has(ext) || (doc.mime_type || '').startsWith('text/');
+
+    try {
+      const fileInfo = await bot._apiCall('getFile', { file_id: doc.file_id });
+      const fileUrl  = `https://api.telegram.org/file/bot${bot.token}/${fileInfo.file_path}`;
+
+      const buffer = await new Promise((resolve, reject) => {
+        https.get(fileUrl, (res) => {
+          if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+            https.get(res.headers.location, (r2) => {
+              const chunks = []; r2.on('data', c => chunks.push(c)); r2.on('end', () => resolve(Buffer.concat(chunks))); r2.on('error', reject);
+            }).on('error', reject);
+            return;
+          }
+          const chunks = []; res.on('data', c => chunks.push(c)); res.on('end', () => resolve(Buffer.concat(chunks))); res.on('error', reject);
+        }).on('error', reject);
+      });
+
+      console.log(`[Telegram:${bot.key}] Documento recibido de ${chatId}: ${fileName} (${Math.round(buffer.length / 1024)}KB)`);
+
+      if (isImage) {
+        const mediaType = ext === 'png' ? 'image/png' : ext === 'gif' ? 'image/gif' : ext === 'webp' ? 'image/webp' : 'image/jpeg';
+        msg.text = msg.caption || 'Describe esta imagen';
+        msg._images = [{ base64: buffer.toString('base64'), mediaType }];
+        await bot._handleMessage(msg);
+        return;
+      }
+
+      if (isText) {
+        let content = buffer.toString('utf-8');
+        const truncated = content.length > MAX_TEXT_READ;
+        if (truncated) content = content.slice(0, MAX_TEXT_READ);
+
+        const caption = msg.caption || '';
+        const truncNote = truncated ? `\n(archivo truncado a ${Math.round(MAX_TEXT_READ / 1024)}KB)` : '';
+        msg.text = `${caption}\n\n📄 Archivo: ${fileName}${truncNote}\n\`\`\`\n${content}\n\`\`\``.trim();
+        await bot._handleMessage(msg);
+        return;
+      }
+
+      // Archivo binario no soportado para lectura directa
+      const tmpFile = path.join(os.tmpdir(), `clawmint_doc_${Date.now()}_${fileName}`);
+      fs.writeFileSync(tmpFile, buffer);
+      msg.text = msg.caption || `Recibí el archivo "${fileName}" (${Math.round(buffer.length / 1024)}KB, tipo: ${doc.mime_type || ext || 'desconocido'}).`;
+      msg._files = [{ path: tmpFile, name: fileName, mime: doc.mime_type || 'application/octet-stream', size: buffer.length }];
+      await bot._handleMessage(msg);
+    } catch (err) {
+      console.error(`[Telegram:${bot.key}] Error procesando documento:`, err.message);
+      await bot.sendText(chatId, `❌ Error al procesar documento: ${err.message}`);
     }
   }
 }

--- a/server/channels/telegram/TelegramBot.js
+++ b/server/channels/telegram/TelegramBot.js
@@ -356,8 +356,10 @@ class TelegramBot {
         const updates = await this._getUpdates();
 
         if (updates.length > 0) {
-          // Actualizar offset al último update recibido
+          // Actualizar offset al último update recibido (guardar ANTES de procesar
+          // para evitar re-procesar updates si el proceso muere durante el handling)
           this.offset = updates[updates.length - 1].update_id + 1;
+          if (this._onOffsetSave) this._onOffsetSave();
 
           // Agrupar updates por chatId: paralelo entre chats, serial dentro del mismo chat
           const byChat = new Map();
@@ -738,6 +740,7 @@ class TelegramBot {
   toJSON() {
     return {
       key:              this.key,
+      ownerId:          this.ownerId || null,
       running:          this.running,
       botInfo:          this.botInfo,
       defaultAgent:     this.defaultAgent,

--- a/server/channels/telegram/TelegramBot.js
+++ b/server/channels/telegram/TelegramBot.js
@@ -416,6 +416,12 @@ class TelegramBot {
       }
       return;
     }
+    if (msg.document) {
+      if (this._mediaHandler) {
+        await this._mediaHandler.handleDocument(this, msg);
+      }
+      return;
+    }
     if (!msg.text) return;
     await this._handleMessage(msg);
   }

--- a/server/channels/telegram/TelegramChannel.js
+++ b/server/channels/telegram/TelegramChannel.js
@@ -170,8 +170,9 @@ class TelegramChannel extends BaseChannel {
   async loadAndStart() {
     const saved = this._readFile();
     for (const entry of saved) {
-      const { key, token, defaultAgent, whitelist, groupWhitelist, rateLimit, rateLimitKeyword, offset, startGreeting, lastGreetingAt } = entry;
+      const { key, token, defaultAgent, whitelist, groupWhitelist, rateLimit, rateLimitKeyword, offset, startGreeting, lastGreetingAt, ownerId } = entry;
       const bot = this._buildBot(key, token, { initialOffset: offset || 0 });
+      bot.ownerId = ownerId || null;
       if (defaultAgent) bot.defaultAgent = defaultAgent;
 
       const envWhitelist = (process.env.BOT_WHITELIST || '')
@@ -202,9 +203,10 @@ class TelegramChannel extends BaseChannel {
     // Nota: recordatorios ahora gestionados por Scheduler (server/scheduler.js)
   }
 
-  async addBot(key, token) {
+  async addBot(key, token, { ownerId = null } = {}) {
     if (this.bots.has(key)) await this.bots.get(key).stop();
     const bot  = this._buildBot(key, token);
+    bot.ownerId = ownerId || null;
     const info = this._telegramMode === 'webhook'
       ? await bot.startWebhook(this._webhookBaseUrl)
       : await bot.start();
@@ -238,6 +240,11 @@ class TelegramChannel extends BaseChannel {
 
   getBot(key)   { return this.bots.get(key); }
   listBots()    { return [...this.bots.values()].map(b => b.toJSON()); }
+  listBotsByOwner(ownerId) {
+    return [...this.bots.values()]
+      .filter(b => !b.ownerId || b.ownerId === ownerId)
+      .map(b => b.toJSON());
+  }
 
   linkSession(key, chatId, sessionId) {
     const bot = this.bots.get(key);
@@ -315,6 +322,7 @@ class TelegramChannel extends BaseChannel {
   _saveFile() {
     const data = [...this.bots.entries()].map(([key, bot]) => ({
       key,
+      ownerId:          bot.ownerId || null,
       token:            bot.token,
       defaultAgent:     bot.defaultAgent,
       whitelist:        bot.whitelist,

--- a/server/mcp/tools/contacts.js
+++ b/server/mcp/tools/contacts.js
@@ -3,9 +3,49 @@
 /**
  * mcp/tools/contacts.js — Tools MCP para agenda de contactos.
  *
- * Expone: contact_add, contact_list, contact_info, contact_update, contact_delete, contact_link
+ * Expone: contact_add, contact_list, contact_info, contact_update, contact_delete, contact_link, contact_send_message
  * Usa ctx.usersRepo (server/storage/UsersRepository.js).
  */
+
+const http = require('http');
+
+const API_BASE = `http://localhost:${process.env.PORT || 3002}`;
+
+let _internalToken = null;
+function _getInternalToken() {
+  if (!_internalToken) {
+    _internalToken = require('../../middleware/authMiddleware').INTERNAL_TOKEN;
+  }
+  return _internalToken;
+}
+
+function _apiPost(path, body) {
+  return new Promise((resolve, reject) => {
+    const url = new URL(`${API_BASE}${path}`);
+    const data = JSON.stringify(body);
+    const options = {
+      hostname: url.hostname,
+      port: url.port,
+      path: url.pathname + url.search,
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(data),
+        'X-Internal-Token': _getInternalToken(),
+      },
+    };
+    const req = http.request(options, (res) => {
+      let raw = '';
+      res.on('data', c => { raw += c; });
+      res.on('end', () => {
+        try { resolve(JSON.parse(raw)); } catch { resolve(raw); }
+      });
+    });
+    req.on('error', reject);
+    req.write(data);
+    req.end();
+  });
+}
 
 function _requireUsers(ctx) {
   if (!ctx.usersRepo) throw new Error('Módulo de usuarios no disponible');
@@ -237,4 +277,51 @@ const CONTACT_LINK = {
   },
 };
 
-module.exports = [CONTACT_ADD, CONTACT_LIST, CONTACT_INFO, CONTACT_UPDATE, CONTACT_DELETE, CONTACT_LINK];
+const CONTACT_SEND_MESSAGE = {
+  name: 'contact_send_message',
+  description: 'Enviar un mensaje de Telegram a un contacto vinculado. El contacto debe tener un usuario del sistema con identidad de Telegram.',
+  params: {
+    id:   '?string — UUID del contacto',
+    name: '?string — buscar contacto por nombre',
+    text: 'string — texto del mensaje a enviar',
+    bot:  '?string — key del bot a usar (default: el bot del contexto actual)',
+  },
+
+  async execute(args = {}, ctx = {}) {
+    _requireUsers(ctx);
+    if (!args.text) return 'Error: parámetro text requerido.';
+
+    const ownerId = _getOwnerId(ctx);
+    if (!ownerId) return 'Error: no se pudo identificar al usuario.';
+
+    // Resolver contacto
+    let contact = null;
+    if (args.id) {
+      contact = ctx.usersRepo.getContact(args.id);
+    } else if (args.name) {
+      const results = ctx.usersRepo.searchContacts(ownerId, args.name);
+      contact = results[0] || null;
+    }
+    if (!contact || contact.owner_id !== ownerId) return 'Error: contacto no encontrado.';
+    if (!contact.user_id) return `Error: el contacto "${contact.name}" no está vinculado a un usuario del sistema. Usá contact_link primero.`;
+
+    // Obtener identidad de Telegram del usuario vinculado
+    const user = ctx.usersRepo.getById(contact.user_id);
+    if (!user) return 'Error: usuario vinculado no encontrado.';
+
+    const tgIdentity = (user.identities || []).find(i => i.channel === 'telegram');
+    if (!tgIdentity) return `Error: el usuario vinculado "${user.name}" no tiene identidad de Telegram.`;
+
+    const chatId = tgIdentity.identifier;
+    const botKey = args.bot || ctx.botKey || 'chibi2026_bot';
+
+    const result = await _apiPost(`/api/telegram/bots/${botKey}/chats/${chatId}/message`, {
+      text: args.text,
+    });
+
+    if (result.error) return `Error enviando mensaje: ${result.error}`;
+    return `✅ Mensaje enviado a ${contact.name} (message_id: ${result.message_id})`;
+  },
+};
+
+module.exports = [CONTACT_ADD, CONTACT_LIST, CONTACT_INFO, CONTACT_UPDATE, CONTACT_DELETE, CONTACT_LINK, CONTACT_SEND_MESSAGE];

--- a/server/routes/telegram.js
+++ b/server/routes/telegram.js
@@ -4,6 +4,19 @@ const express = require('express');
 module.exports = function createTelegramRouter({ telegram, sessionManager }) {
   const router = express.Router();
 
+  // Helper: verificar que el bot pertenece al usuario (o es interno/sin owner)
+  function _ownedBot(req, res) {
+    const bot = telegram.getBot(req.params.key);
+    if (!bot) { res.status(404).json({ error: 'Bot no encontrado' }); return null; }
+    if (req.user.internal) return bot;
+    if (!bot.ownerId) return bot; // bots sin owner → acceso libre
+    if (bot.ownerId !== req.user.id) {
+      res.status(403).json({ error: 'No tenés acceso a este bot' });
+      return null;
+    }
+    return bot;
+  }
+
   // GET /telegram/mode — modo actual (polling|webhook) y URL de webhook
   router.get('/mode', (_req, res) => {
     res.json({
@@ -12,34 +25,50 @@ module.exports = function createTelegramRouter({ telegram, sessionManager }) {
     });
   });
 
-  // GET /telegram/bots — lista todos los bots con su estado
-  router.get('/bots', (_req, res) => {
-    res.json(telegram.listBots());
+  // GET /telegram/bots — lista bots del usuario autenticado
+  router.get('/bots', (req, res) => {
+    if (req.user.internal) return res.json(telegram.listBots());
+    res.json(telegram.listBotsByOwner(req.user.id));
   });
 
-  // POST /telegram/bots — agregar/actualizar bot
+  // POST /telegram/bots — agregar bot (asignado al usuario)
   // Body: { key, token }
   router.post('/bots', async (req, res) => {
     const { key, token } = req.body || {};
     if (!key || !token) return res.status(400).json({ error: 'key y token requeridos' });
     if (!/^[a-zA-Z0-9_-]+$/.test(key)) return res.status(400).json({ error: 'key inválida (solo letras, números, _ y -)' });
     try {
-      const result = await telegram.addBot(key, token);
+      const result = await telegram.addBot(key, token, { ownerId: req.user.id });
       res.json({ ok: true, username: result.username });
     } catch (err) {
       res.status(400).json({ error: err.message });
     }
   });
 
-  // DELETE /telegram/bots/:key — eliminar bot
+  // POST /telegram/bots/:key/claim — reclamar bot sin owner
+  router.post('/bots/:key/claim', (req, res) => {
+    const bot = telegram.getBot(req.params.key);
+    if (!bot) return res.status(404).json({ error: 'Bot no encontrado' });
+    if (bot.ownerId && bot.ownerId !== req.user.id) {
+      return res.status(403).json({ error: 'Este bot ya tiene dueño' });
+    }
+    bot.ownerId = req.user.id;
+    telegram.saveBots();
+    res.json({ ok: true, ownerId: req.user.id });
+  });
+
+  // DELETE /telegram/bots/:key — eliminar bot (solo owner)
   router.delete('/bots/:key', async (req, res) => {
-    const ok = await telegram.removeBot(req.params.key);
-    if (!ok) return res.status(404).json({ error: 'Bot no encontrado' });
+    const bot = _ownedBot(req, res);
+    if (!bot) return;
+    await telegram.removeBot(req.params.key);
     res.json({ ok: true });
   });
 
-  // POST /telegram/bots/:key/start — iniciar bot
+  // POST /telegram/bots/:key/start — iniciar bot (solo owner)
   router.post('/bots/:key/start', async (req, res) => {
+    const bot = _ownedBot(req, res);
+    if (!bot) return;
     try {
       const result = await telegram.startBot(req.params.key);
       res.json({ ok: true, username: result.username });
@@ -48,11 +77,11 @@ module.exports = function createTelegramRouter({ telegram, sessionManager }) {
     }
   });
 
-  // PATCH /telegram/bots/:key — actualizar config del bot
+  // PATCH /telegram/bots/:key — actualizar config del bot (solo owner)
   // Body: { defaultAgent?, whitelist?, groupWhitelist?, rateLimit?, rateLimitKeyword? }
   router.patch('/bots/:key', (req, res) => {
-    const bot = telegram.getBot(req.params.key);
-    if (!bot) return res.status(404).json({ error: 'Bot no encontrado' });
+    const bot = _ownedBot(req, res);
+    if (!bot) return;
     const { defaultAgent, whitelist, groupWhitelist, rateLimit, rateLimitKeyword } = req.body || {};
     if (defaultAgent !== undefined) bot.setDefaultAgent(defaultAgent);
     if (whitelist !== undefined) bot.setWhitelist(whitelist);
@@ -63,26 +92,30 @@ module.exports = function createTelegramRouter({ telegram, sessionManager }) {
     res.json(bot.toJSON());
   });
 
-  // POST /telegram/bots/:key/stop — detener bot
+  // POST /telegram/bots/:key/stop — detener bot (solo owner)
   router.post('/bots/:key/stop', async (req, res) => {
+    const bot = _ownedBot(req, res);
+    if (!bot) return;
     try {
       await telegram.stopBot(req.params.key);
       res.json({ ok: true });
     } catch (err) {
-      res.status(404).json({ error: err.message });
+      res.status(400).json({ error: err.message });
     }
   });
 
-  // GET /telegram/bots/:key/chats — chats del bot
+  // GET /telegram/bots/:key/chats — chats del bot (solo owner)
   router.get('/bots/:key/chats', (req, res) => {
-    const bot = telegram.getBot(req.params.key);
-    if (!bot) return res.status(404).json({ error: 'Bot no encontrado' });
+    const bot = _ownedBot(req, res);
+    if (!bot) return;
     res.json([...bot.chats.values()]);
   });
 
-  // POST /telegram/bots/:key/chats/:chatId/session — vincular sesión
+  // POST /telegram/bots/:key/chats/:chatId/session — vincular sesión (solo owner)
   // Body: { sessionId? } — omitir → crear nueva claude
   router.post('/bots/:key/chats/:chatId/session', async (req, res) => {
+    const bot = _ownedBot(req, res);
+    if (!bot) return;
     const { key } = req.params;
     const chatId = Number(req.params.chatId);
     const { sessionId } = req.body || {};
@@ -98,17 +131,19 @@ module.exports = function createTelegramRouter({ telegram, sessionManager }) {
     res.json({ ok: true, sessionId: session.id });
   });
 
-  // DELETE /telegram/bots/:key/chats/:chatId — desconectar chat
+  // DELETE /telegram/bots/:key/chats/:chatId — desconectar chat (solo owner)
   router.delete('/bots/:key/chats/:chatId', (req, res) => {
+    const bot = _ownedBot(req, res);
+    if (!bot) return;
     const ok = telegram.disconnectChat(req.params.key, Number(req.params.chatId));
     res.json({ ok });
   });
 
-  // POST /telegram/bots/:key/chats/:chatId/message — enviar texto a un chat
+  // POST /telegram/bots/:key/chats/:chatId/message — enviar texto a un chat (solo owner o interno)
   router.post('/bots/:key/chats/:chatId/message', async (req, res) => {
+    const bot = _ownedBot(req, res);
+    if (!bot) return;
     try {
-      const bot = telegram.getBot(req.params.key);
-      if (!bot) return res.status(404).json({ error: 'Bot no encontrado' });
       const chatId = Number(req.params.chatId);
       const { text, parse_mode, reply_markup, callbacks } = req.body || {};
       if (!text) return res.status(400).json({ error: 'Se requiere text' });
@@ -129,16 +164,15 @@ module.exports = function createTelegramRouter({ telegram, sessionManager }) {
     }
   });
 
-  // POST /telegram/bots/:key/chats/:chatId/photo — enviar imagen a un chat
+  // POST /telegram/bots/:key/chats/:chatId/photo — enviar imagen a un chat (solo owner o interno)
   router.post('/bots/:key/chats/:chatId/photo', express.raw({ type: '*/*', limit: '20mb' }), async (req, res) => {
+    const bot = _ownedBot(req, res);
+    if (!bot) return;
     try {
-      const bot = telegram.getBot(req.params.key);
-      if (!bot) return res.status(404).json({ error: 'Bot no encontrado' });
       const chatId = Number(req.params.chatId);
       const caption = req.query.caption || '';
       const filename = req.query.filename || 'photo.png';
 
-      // Aceptar body raw (Buffer) o base64 en JSON
       let photoBuffer;
       if (Buffer.isBuffer(req.body) && req.body.length > 0) {
         photoBuffer = req.body;
@@ -155,11 +189,11 @@ module.exports = function createTelegramRouter({ telegram, sessionManager }) {
     }
   });
 
-  // POST /telegram/bots/:key/chats/:chatId/document — enviar archivo a un chat
+  // POST /telegram/bots/:key/chats/:chatId/document — enviar archivo a un chat (solo owner o interno)
   router.post('/bots/:key/chats/:chatId/document', express.raw({ type: '*/*', limit: '50mb' }), async (req, res) => {
+    const bot = _ownedBot(req, res);
+    if (!bot) return;
     try {
-      const bot = telegram.getBot(req.params.key);
-      if (!bot) return res.status(404).json({ error: 'Bot no encontrado' });
       const chatId = Number(req.params.chatId);
       const caption = req.query.caption || '';
       const filename = req.query.filename || 'file.bin';
@@ -181,11 +215,11 @@ module.exports = function createTelegramRouter({ telegram, sessionManager }) {
     }
   });
 
-  // POST /telegram/bots/:key/chats/:chatId/voice — enviar audio/voz a un chat
+  // POST /telegram/bots/:key/chats/:chatId/voice — enviar audio/voz a un chat (solo owner o interno)
   router.post('/bots/:key/chats/:chatId/voice', express.raw({ type: '*/*', limit: '20mb' }), async (req, res) => {
+    const bot = _ownedBot(req, res);
+    if (!bot) return;
     try {
-      const bot = telegram.getBot(req.params.key);
-      if (!bot) return res.status(404).json({ error: 'Bot no encontrado' });
       const chatId = Number(req.params.chatId);
 
       let audioBuffer;
@@ -204,11 +238,11 @@ module.exports = function createTelegramRouter({ telegram, sessionManager }) {
     }
   });
 
-  // POST /telegram/bots/:key/chats/:chatId/video — enviar video a un chat
+  // POST /telegram/bots/:key/chats/:chatId/video — enviar video a un chat (solo owner o interno)
   router.post('/bots/:key/chats/:chatId/video', express.raw({ type: '*/*', limit: '50mb' }), async (req, res) => {
+    const bot = _ownedBot(req, res);
+    if (!bot) return;
     try {
-      const bot = telegram.getBot(req.params.key);
-      if (!bot) return res.status(404).json({ error: 'Bot no encontrado' });
       const chatId = Number(req.params.chatId);
       const caption = req.query.caption || '';
       const filename = req.query.filename || 'video.mp4';
@@ -229,11 +263,11 @@ module.exports = function createTelegramRouter({ telegram, sessionManager }) {
     }
   });
 
-  // POST /telegram/bots/:key/chats/:chatId/edit — editar mensaje de texto
+  // POST /telegram/bots/:key/chats/:chatId/edit — editar mensaje de texto (solo owner o interno)
   router.post('/bots/:key/chats/:chatId/edit', async (req, res) => {
+    const bot = _ownedBot(req, res);
+    if (!bot) return;
     try {
-      const bot = telegram.getBot(req.params.key);
-      if (!bot) return res.status(404).json({ error: 'Bot no encontrado' });
       const chatId = Number(req.params.chatId);
       const { message_id, text, parse_mode } = req.body || {};
       if (!message_id || !text) return res.status(400).json({ error: 'Se requieren message_id y text' });
@@ -247,11 +281,11 @@ module.exports = function createTelegramRouter({ telegram, sessionManager }) {
     }
   });
 
-  // POST /telegram/bots/:key/chats/:chatId/delete — borrar mensaje
+  // POST /telegram/bots/:key/chats/:chatId/delete — borrar mensaje (solo owner o interno)
   router.post('/bots/:key/chats/:chatId/delete', async (req, res) => {
+    const bot = _ownedBot(req, res);
+    if (!bot) return;
     try {
-      const bot = telegram.getBot(req.params.key);
-      if (!bot) return res.status(404).json({ error: 'Bot no encontrado' });
       const chatId = Number(req.params.chatId);
       const { message_id } = req.body || {};
       if (!message_id) return res.status(400).json({ error: 'Se requiere message_id' });

--- a/server/storage/BotsRepository.js
+++ b/server/storage/BotsRepository.js
@@ -4,25 +4,105 @@ const fs   = require('fs');
 const path = require('path');
 
 /**
- * BotsRepository — persistencia de bots en bots.json.
- * Extraído de BotManager._readFile() / _saveFile().
+ * BotsRepository — persistencia de bots de Telegram en SQLite.
+ *
+ * Tabla: bots (key PK, owner_id, token, config, offset).
+ * Ownership: cada bot pertenece a un usuario; las queries filtran por owner_id.
+ * En init() migra automáticamente desde bots.json si existe.
  */
 class BotsRepository {
-  constructor(botsFilePath) {
-    this._filePath = botsFilePath || path.join(__dirname, '..', 'bots.json');
+  static SCHEMA = `
+    CREATE TABLE IF NOT EXISTS bots (
+      key              TEXT PRIMARY KEY,
+      owner_id         TEXT,
+      token            TEXT NOT NULL,
+      default_agent    TEXT DEFAULT 'claude',
+      whitelist        TEXT DEFAULT '[]',
+      group_whitelist  TEXT DEFAULT '[]',
+      rate_limit       INTEGER DEFAULT 30,
+      rate_limit_keyword TEXT DEFAULT '',
+      start_greeting   INTEGER DEFAULT 0,
+      last_greeting_at INTEGER DEFAULT 0,
+      "offset"         INTEGER DEFAULT 0
+    )
+  `;
+
+  static MIGRATIONS = [
+    'ALTER TABLE bots ADD COLUMN owner_id TEXT',
+  ];
+
+  constructor(db, jsonPath) {
+    this._db = db;
+    this._jsonPath = jsonPath || path.join(__dirname, '..', 'bots.json');
   }
 
+  init() {
+    if (!this._db) return;
+    this._db.exec(BotsRepository.SCHEMA);
+    for (const sql of BotsRepository.MIGRATIONS) {
+      try { this._db.exec(sql); } catch {}
+    }
+    this._migrateFromJson();
+  }
+
+  // ── Migración desde bots.json ─────────────────────────────────────────────
+
+  _migrateFromJson() {
+    if (!fs.existsSync(this._jsonPath)) return;
+    try {
+      const data = JSON.parse(fs.readFileSync(this._jsonPath, 'utf8')) || [];
+      if (!data.length) return;
+
+      const existing = this._db.prepare('SELECT COUNT(*) as c FROM bots').get();
+      if (existing.c > 0) {
+        const backupPath = this._jsonPath + '.migrated';
+        fs.renameSync(this._jsonPath, backupPath);
+        console.log(`[BotsRepo] bots.json renombrado a bots.json.migrated (SQLite ya tiene ${existing.c} bots)`);
+        return;
+      }
+
+      const stmt = this._db.prepare(`
+        INSERT OR IGNORE INTO bots (key, owner_id, token, default_agent, whitelist, group_whitelist,
+          rate_limit, rate_limit_keyword, start_greeting, last_greeting_at, "offset")
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `);
+
+      for (const bot of data) {
+        stmt.run(
+          bot.key,
+          bot.ownerId || null,
+          bot.token,
+          bot.defaultAgent || 'claude',
+          JSON.stringify(bot.whitelist || []),
+          JSON.stringify(bot.groupWhitelist || []),
+          bot.rateLimit || 30,
+          bot.rateLimitKeyword || '',
+          bot.startGreeting ? 1 : 0,
+          bot.lastGreetingAt || 0,
+          bot.offset || 0,
+        );
+      }
+
+      const backupPath = this._jsonPath + '.migrated';
+      fs.renameSync(this._jsonPath, backupPath);
+      console.log(`[BotsRepo] Migrados ${data.length} bots de bots.json → SQLite (backup: bots.json.migrated)`);
+    } catch (err) {
+      console.error('[BotsRepo] Error migrando bots.json:', err.message);
+    }
+  }
+
+  // ── CRUD ──────────────────────────────────────────────────────────────────
+
   /**
-   * Lee los bots desde el archivo.
-   * Si no existe, intenta crear uno desde env vars (primera ejecución).
+   * Lee todos los bots (sin filtrar por owner — usado en loadAndStart).
+   * Si no hay datos y hay BOT_TOKEN en env, crea el bot inicial.
    * @returns {object[]}
    */
   read() {
-    try {
-      if (fs.existsSync(this._filePath)) {
-        return JSON.parse(fs.readFileSync(this._filePath, 'utf8')) || [];
-      }
+    if (!this._db) return [];
+    const rows = this._db.prepare('SELECT * FROM bots').all();
 
+    if (rows.length === 0) {
       const token = process.env.BOT_TOKEN;
       if (!token) return [];
 
@@ -40,23 +120,127 @@ class BotsRepository {
         rateLimit:        parseInt(process.env.BOT_RATE_LIMIT) || 30,
         rateLimitKeyword: process.env.BOT_RATE_LIMIT_KEYWORD  || '',
         offset:           0,
+        ownerId:          null,
       };
-      fs.writeFileSync(this._filePath, JSON.stringify([entry], null, 2), 'utf8');
-      console.log(`[Telegram] bots.json creado desde variables de entorno (key: ${entry.key})`);
+      this._upsertBot(entry);
+      console.log(`[BotsRepo] Bot creado desde variables de entorno (key: ${entry.key})`);
       return [entry];
-    } catch { return []; }
+    }
+
+    return rows.map(r => this._rowToBot(r));
   }
 
   /**
-   * Guarda la lista de bots en el archivo.
+   * Lee bots de un usuario específico.
+   * @param {string} ownerId
+   * @returns {object[]}
+   */
+  readByOwner(ownerId) {
+    if (!this._db) return [];
+    const rows = this._db.prepare('SELECT * FROM bots WHERE owner_id = ?').all(ownerId);
+    return rows.map(r => this._rowToBot(r));
+  }
+
+  /**
+   * Guarda la lista completa de bots (sync con memoria).
+   * Upsert cada bot y elimina los que ya no existen.
    * @param {object[]} bots
    */
   save(bots) {
-    try {
-      fs.writeFileSync(this._filePath, JSON.stringify(bots, null, 2), 'utf8');
-    } catch (err) {
-      console.error('[Telegram] No se pudo guardar bots.json:', err.message);
+    if (!this._db) return;
+
+    const keys = bots.map(b => b.key);
+    for (const bot of bots) {
+      this._upsertBot(bot);
     }
+    // Eliminar bots que ya no están en memoria
+    if (keys.length) {
+      const placeholders = keys.map(() => '?').join(',');
+      this._db.prepare(`DELETE FROM bots WHERE key NOT IN (${placeholders})`).run(...keys);
+    } else {
+      this._db.exec('DELETE FROM bots');
+    }
+  }
+
+  /**
+   * Inserta o actualiza un bot individual.
+   * Preserva owner_id existente si el nuevo dato no lo trae.
+   * @param {object} bot
+   */
+  _upsertBot(bot) {
+    const ownerId = bot.ownerId || null;
+    // Si no viene ownerId, preservar el existente en la DB
+    const existing = this._db.prepare('SELECT owner_id FROM bots WHERE key = ?').get(bot.key);
+    const finalOwnerId = ownerId || existing?.owner_id || null;
+
+    this._db.prepare(`
+      INSERT OR REPLACE INTO bots (key, owner_id, token, default_agent, whitelist, group_whitelist,
+        rate_limit, rate_limit_keyword, start_greeting, last_greeting_at, "offset")
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      bot.key,
+      finalOwnerId,
+      bot.token,
+      bot.defaultAgent || 'claude',
+      JSON.stringify(bot.whitelist || []),
+      JSON.stringify(bot.groupWhitelist || []),
+      bot.rateLimit || 30,
+      bot.rateLimitKeyword || '',
+      bot.startGreeting ? 1 : 0,
+      bot.lastGreetingAt || 0,
+      bot.offset || 0,
+    );
+  }
+
+  /**
+   * Obtiene un bot por key.
+   * @param {string} key
+   * @returns {object|null}
+   */
+  getByKey(key) {
+    if (!this._db) return null;
+    const row = this._db.prepare('SELECT * FROM bots WHERE key = ?').get(key);
+    return row ? this._rowToBot(row) : null;
+  }
+
+  /**
+   * Obtiene un bot por key verificando ownership.
+   * @param {string} key
+   * @param {string} ownerId
+   * @returns {object|null}
+   */
+  getByKeyAndOwner(key, ownerId) {
+    if (!this._db) return null;
+    const row = this._db.prepare('SELECT * FROM bots WHERE key = ? AND owner_id = ?').get(key, ownerId);
+    return row ? this._rowToBot(row) : null;
+  }
+
+  /**
+   * Actualiza el offset de un bot (llamada frecuente desde polling).
+   * @param {string} key
+   * @param {number} offset
+   */
+  updateOffset(key, offset) {
+    if (!this._db) return;
+    this._db.prepare('UPDATE bots SET "offset" = ? WHERE key = ?').run(offset, key);
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────────────
+
+  _rowToBot(r) {
+    return {
+      key:              r.key,
+      ownerId:          r.owner_id || null,
+      token:            r.token,
+      defaultAgent:     r.default_agent,
+      whitelist:        JSON.parse(r.whitelist || '[]'),
+      groupWhitelist:   JSON.parse(r.group_whitelist || '[]'),
+      rateLimit:        r.rate_limit,
+      rateLimitKeyword: r.rate_limit_keyword || '',
+      startGreeting:    !!r.start_greeting,
+      lastGreetingAt:   r.last_greeting_at || 0,
+      offset:           r.offset || 0,
+    };
   }
 }
 

--- a/server/storage/sqlite-wrapper.js
+++ b/server/storage/sqlite-wrapper.js
@@ -102,6 +102,7 @@ class StatementWrapper {
 // ── Database wrapper ─────────────────────────────────────────────────────────
 
 const SAVE_DELAY_MS = 500; // debounce de auto-save
+const _instances = new Set(); // registro global para flush en shutdown
 
 class DatabaseWrapper {
   /**
@@ -122,6 +123,8 @@ class DatabaseWrapper {
     } else {
       this._db = new _SQL.Database();
     }
+
+    if (!this._inMemory) _instances.add(this);
   }
 
   /**
@@ -175,12 +178,13 @@ class DatabaseWrapper {
    */
   close() {
     if (this._closed) return;
-    this._closed = true;
+    _instances.delete(this);
     if (this._saveTimer) {
       clearTimeout(this._saveTimer);
       this._saveTimer = null;
     }
     this._saveToDisk();
+    this._closed = true;
     this._db.close();
   }
 
@@ -236,6 +240,17 @@ async function initialize() {
 function isInitialized() {
   return _SQL !== null;
 }
+
+// ── Flush en shutdown ────────────────────────────────────────────────────────
+
+function _flushAll() {
+  for (const db of _instances) {
+    try { db._saveToDisk(); } catch {}
+  }
+}
+
+process.once('SIGTERM', _flushAll);
+process.once('SIGINT', _flushAll);
 
 // Re-exportar la clase como default (drop-in de better-sqlite3)
 // Uso: const Database = require('./sqlite-wrapper');

--- a/server/telegram.js
+++ b/server/telegram.js
@@ -35,9 +35,12 @@ try { consolidator = require('./memory-consolidator'); } catch {}
 
 // ── Repos de storage ─────────────────────────────────────────────────────────
 
-const botsRepo = new BotsRepository(path.join(__dirname, 'bots.json'));
+const db = memoryModule.getDB();
 
-const chatSettingsRepo = new ChatSettingsRepository(memoryModule.getDB());
+const botsRepo = new BotsRepository(db, path.join(__dirname, 'bots.json'));
+botsRepo.init();
+
+const chatSettingsRepo = new ChatSettingsRepository(db);
 chatSettingsRepo.init();
 
 // ── Singleton ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- **fix(sqlite):** `close()` no persistía datos — `_closed` se seteaba antes de `_saveToDisk()`. Agrega flush en SIGTERM/SIGINT para PM2
- **feat(bots):** `BotsRepository` migrado de JSON a SQLite con columna `owner_id`. Migración automática desde `bots.json`
- **feat(telegram):** Ownership en todas las rutas — solo el owner puede gestionar su bot. Ruta `/claim` para reclamar bots sin owner
- **feat(mcp):** Nueva tool `contact_send_message` para enviar mensajes de Telegram a contactos vinculados

## Test plan
- [ ] Login → panel Telegram → verificar que aparecen bots propios
- [ ] Crear nuevo bot → verificar que se asigna al usuario logueado
- [ ] Restart PM2 → verificar que owner persiste
- [ ] Otro usuario no ve bots ajenos