### PR TITLE
chore: agregar bots.json.migrated al .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ dist/
 server/agents/*.json
 server/skills/
 server/bots.json
+server/bots.json.migrated
 server/whisper-config.json
 server/logs.json
 server/server.log


### PR DESCRIPTION
Archivo de backup generado por la migración de bots.json a SQLite. Contiene tokens, no debe versionarse.