### PR TITLE
feat: sistema de límites configurables (rate + sesión)

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useRef, useEffect, lazy, Suspense } from 'react';
 import {
   Terminal, MessageCircle, Send, BookUser, Settings,
-  Plug, Bot, Sun, Moon, ChevronLeft, ChevronRight,
+  Plug, Bot, Gauge, Sun, Moon, ChevronLeft, ChevronRight,
   PanelsLeftRight, LogIn,
 } from 'lucide-react';
 import TabBar from './components/TabBar.jsx';
@@ -23,6 +23,7 @@ const ProvidersPanel = lazy(() => import('./components/ProvidersPanel.jsx'));
 const McpsPanel      = lazy(() => import('./components/McpsPanel.jsx'));
 const WebChatPanel   = lazy(() => import('./components/WebChatPanel.jsx'));
 const ContactsPanel  = lazy(() => import('./components/ContactsPanel.jsx'));
+const LimitsPanel    = lazy(() => import('./components/LimitsPanel.jsx'));
 
 let nextId = 0;
 
@@ -54,6 +55,7 @@ const CONFIG_TABS = [
   { key: 'agents',    Icon: Bot,      label: 'Agentes'  },
   { key: 'providers', Icon: Settings, label: 'Providers' },
   { key: 'mcps',      Icon: Plug,     label: 'MCPs'     },
+  { key: 'limits',    Icon: Gauge,    label: 'Límites'  },
 ];
 
 // ── Sidebar ───────────────────────────────────────────────────────────────────
@@ -168,6 +170,7 @@ function ConfigSection() {
             {tab === 'agents'    && <AgentsPanel    onClose={null} embedded />}
             {tab === 'providers' && <ProvidersPanel onClose={null} embedded />}
             {tab === 'mcps'      && <McpsPanel      onClose={null} embedded />}
+            {tab === 'limits'    && <LimitsPanel    onClose={null} embedded />}
           </Suspense>
         </ErrorBoundary>
       </div>

--- a/client/src/components/LimitsPanel.css
+++ b/client/src/components/LimitsPanel.css
@@ -1,0 +1,174 @@
+/* ── LimitsPanel ─────────────────────────────────────────────────────────── */
+
+.lp-section-hint {
+  font-size: 11px;
+  color: var(--text-secondary);
+  margin: 0 0 12px;
+  line-height: 1.5;
+}
+
+.lp-section-title {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--accent);
+  margin: 14px 0 6px;
+}
+
+/* ── Row ──────────────────────────────────────────────────────────────────── */
+
+.lp-row {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px 10px;
+  margin-bottom: 6px;
+}
+
+.lp-row-top {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.lp-type-badge {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  padding: 2px 6px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+.lp-type-badge.rate    { background: #1a3a2a; color: #4ade80; }
+.lp-type-badge.session { background: #1a2a3a; color: #60a5fa; }
+
+.lp-scope {
+  font-size: 12px;
+  color: var(--text-primary);
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.lp-row-actions {
+  display: flex;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+.lp-btn-danger:hover { color: #f87171 !important; }
+
+.lp-row-detail {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+  margin-top: 4px;
+}
+
+.lp-value {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.lp-window {
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.lp-disabled-badge {
+  font-size: 10px;
+  background: #3a2a1a;
+  color: #fbbf24;
+  padding: 1px 5px;
+  border-radius: 3px;
+  margin-left: auto;
+}
+
+/* ── Empty ────────────────────────────────────────────────────────────────── */
+
+.lp-empty {
+  text-align: center;
+  padding: 20px 0;
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+
+.lp-empty-hint {
+  font-size: 11px;
+  margin-top: 4px;
+  opacity: 0.7;
+}
+
+/* ── Form ─────────────────────────────────────────────────────────────────── */
+
+.lp-form {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 12px;
+  margin-top: 8px;
+}
+
+.lp-form-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0 0 10px;
+}
+
+.lp-toggle-row {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 8px;
+}
+
+.lp-toggle {
+  flex: 1;
+  padding: 5px 8px;
+  font-size: 11px;
+  font-weight: 500;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.lp-toggle:hover { border-color: var(--accent); }
+.lp-toggle.active {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
+
+.lp-window-row {
+  display: flex;
+  gap: 6px;
+}
+
+.lp-window-input {
+  flex: 1;
+}
+
+.lp-window-unit {
+  width: 110px;
+  flex-shrink: 0;
+}
+
+.lp-form-actions {
+  display: flex;
+  gap: 6px;
+  margin-top: 10px;
+}
+
+.lp-error-msg {
+  background: #3a1a1a;
+  color: #f87171;
+  border: 1px solid #5a2a2a;
+}

--- a/client/src/components/LimitsPanel.jsx
+++ b/client/src/components/LimitsPanel.jsx
@@ -1,0 +1,306 @@
+import { useState, useEffect, useCallback, memo } from 'react';
+import { Gauge, Plus, X, Pencil, Trash2, Save, RotateCcw } from 'lucide-react';
+import { API_BASE } from '../config';
+import { apiFetch } from '../authUtils';
+import './LimitsPanel.css';
+
+const API = `${API_BASE}/api/limits`;
+
+const TYPES  = ['rate', 'session'];
+const SCOPES = ['global', 'channel', 'bot', 'user', 'agent', 'provider'];
+
+const TYPE_LABELS  = { rate: 'Rate limit', session: 'Sesión CLI' };
+const SCOPE_LABELS = { global: 'Global', channel: 'Canal', bot: 'Bot', user: 'Usuario', agent: 'Agente', provider: 'Provider' };
+
+function windowLabel(ms) {
+  if (!ms) return '';
+  if (ms < 60000) return `${ms / 1000}s`;
+  if (ms < 3600000) return `${ms / 60000}min`;
+  return `${ms / 3600000}h`;
+}
+
+// ── Form ──────────────────────────────────────────────────────────────────────
+
+const LimitForm = memo(function LimitForm({ initial, onSave, onCancel }) {
+  const isEdit = !!initial;
+  const [type, setType]       = useState(initial?.type || 'rate');
+  const [scope, setScope]     = useState(initial?.scope || 'global');
+  const [scopeId, setScopeId] = useState(initial?.scope_id || '');
+  const [maxCount, setMaxCount] = useState(initial?.max_count ?? 10);
+  const [windowMs, setWindowMs] = useState(initial?.window_ms ?? 60000);
+  const [windowUnit, setWindowUnit] = useState('min');
+  const [saving, setSaving]   = useState(false);
+  const [error, setError]     = useState('');
+
+  useEffect(() => {
+    if (initial?.window_ms) {
+      if (initial.window_ms >= 3600000) setWindowUnit('h');
+      else if (initial.window_ms >= 60000) setWindowUnit('min');
+      else setWindowUnit('s');
+    }
+  }, [initial]);
+
+  const windowValue = windowUnit === 'h' ? windowMs / 3600000
+    : windowUnit === 'min' ? windowMs / 60000
+    : windowMs / 1000;
+
+  const handleWindowChange = (val) => {
+    const n = Number(val) || 1;
+    if (windowUnit === 'h') setWindowMs(n * 3600000);
+    else if (windowUnit === 'min') setWindowMs(n * 60000);
+    else setWindowMs(n * 1000);
+  };
+
+  const handleUnitChange = (unit) => {
+    setWindowUnit(unit);
+    const current = windowUnit === 'h' ? windowMs / 3600000
+      : windowUnit === 'min' ? windowMs / 60000
+      : windowMs / 1000;
+    if (unit === 'h') setWindowMs(current * 3600000);
+    else if (unit === 'min') setWindowMs(current * 60000);
+    else setWindowMs(current * 1000);
+  };
+
+  const handleSubmit = async () => {
+    setError('');
+    setSaving(true);
+    try {
+      const body = {
+        type, scope,
+        scope_id: scope === 'global' ? null : scopeId || null,
+        max_count: Number(maxCount),
+        window_ms: type === 'rate' ? windowMs : null,
+      };
+
+      if (isEdit) {
+        const res = await apiFetch(`${API}/${initial.id}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ max_count: body.max_count, window_ms: body.window_ms, scope_id: body.scope_id }),
+        });
+        if (!res.ok) throw new Error((await res.json()).error || 'Error');
+      } else {
+        const res = await apiFetch(API, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+        if (!res.ok) throw new Error((await res.json()).error || 'Error');
+      }
+      onSave();
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="lp-form">
+      <p className="lp-form-title">{isEdit ? 'Editar límite' : 'Nuevo límite'}</p>
+
+      {!isEdit && (
+        <>
+          <label className="ap-label">Tipo</label>
+          <div className="lp-toggle-row">
+            {TYPES.map(t => (
+              <button key={t} className={`lp-toggle ${type === t ? 'active' : ''}`} onClick={() => setType(t)}>
+                {TYPE_LABELS[t]}
+              </button>
+            ))}
+          </div>
+
+          <label className="ap-label">Scope</label>
+          <select className="ap-input" value={scope} onChange={e => setScope(e.target.value)}>
+            {SCOPES.map(s => <option key={s} value={s}>{SCOPE_LABELS[s]}</option>)}
+          </select>
+        </>
+      )}
+
+      {scope !== 'global' && (
+        <>
+          <label className="ap-label">ID del scope</label>
+          <input
+            className="ap-input"
+            placeholder={scope === 'channel' ? 'telegram, webchat...' : scope === 'provider' ? 'claude-code, anthropic...' : 'identificador'}
+            value={scopeId}
+            onChange={e => setScopeId(e.target.value)}
+            disabled={isEdit}
+          />
+        </>
+      )}
+
+      <label className="ap-label">Máximo de mensajes</label>
+      <input
+        className="ap-input"
+        type="number"
+        min="1"
+        value={maxCount}
+        onChange={e => setMaxCount(e.target.value)}
+      />
+
+      {type === 'rate' && (
+        <>
+          <label className="ap-label">Ventana de tiempo</label>
+          <div className="lp-window-row">
+            <input
+              className="ap-input lp-window-input"
+              type="number"
+              min="1"
+              value={windowValue}
+              onChange={e => handleWindowChange(e.target.value)}
+            />
+            <select className="ap-input lp-window-unit" value={windowUnit} onChange={e => handleUnitChange(e.target.value)}>
+              <option value="s">segundos</option>
+              <option value="min">minutos</option>
+              <option value="h">horas</option>
+            </select>
+          </div>
+        </>
+      )}
+
+      {error && <p className="ap-error">{error}</p>}
+
+      <div className="lp-form-actions">
+        <button className="ap-btn ap-btn-primary" onClick={handleSubmit} disabled={saving}>
+          <Save size={13} /> {saving ? 'Guardando...' : 'Guardar'}
+        </button>
+        <button className="ap-btn ap-btn-ghost" onClick={onCancel}>Cancelar</button>
+      </div>
+    </div>
+  );
+});
+
+// ── Row ───────────────────────────────────────────────────────────────────────
+
+const LimitRow = memo(function LimitRow({ rule, onEdit, onDelete }) {
+  const scopeLabel = rule.scope === 'global'
+    ? 'Global'
+    : `${SCOPE_LABELS[rule.scope]}: ${rule.scope_id}`;
+
+  return (
+    <div className="lp-row">
+      <div className="lp-row-top">
+        <span className={`lp-type-badge ${rule.type}`}>{TYPE_LABELS[rule.type]}</span>
+        <span className="lp-scope">{scopeLabel}</span>
+        <div className="lp-row-actions">
+          <button className="ap-btn ap-btn-icon" onClick={() => onEdit(rule)} title="Editar"><Pencil size={13} /></button>
+          <button className="ap-btn ap-btn-icon lp-btn-danger" onClick={() => onDelete(rule.id)} title="Eliminar"><Trash2 size={13} /></button>
+        </div>
+      </div>
+      <div className="lp-row-detail">
+        <span className="lp-value">{rule.max_count} msgs</span>
+        {rule.type === 'rate' && rule.window_ms && (
+          <span className="lp-window">/ {windowLabel(rule.window_ms)}</span>
+        )}
+        {!rule.enabled && <span className="lp-disabled-badge">deshabilitado</span>}
+      </div>
+    </div>
+  );
+});
+
+// ── Panel principal ──────────────────────────────────────────────────────────
+
+export default function LimitsPanel({ onClose, embedded }) {
+  const [rules, setRules]       = useState([]);
+  const [showForm, setShowForm] = useState(false);
+  const [editRule, setEditRule] = useState(null);
+  const [error, setError]       = useState('');
+
+  const fetchRules = useCallback(async () => {
+    try {
+      const res = await apiFetch(API);
+      const data = await res.json();
+      setRules(Array.isArray(data) ? data : []);
+      setError('');
+    } catch (err) {
+      setError('Error cargando límites: ' + err.message);
+    }
+  }, []);
+
+  useEffect(() => { fetchRules(); }, [fetchRules]);
+
+  const handleSave = () => {
+    setShowForm(false);
+    setEditRule(null);
+    fetchRules();
+  };
+
+  const handleEdit = (rule) => {
+    setEditRule(rule);
+    setShowForm(true);
+  };
+
+  const handleDelete = async (id) => {
+    if (!confirm('¿Eliminar esta regla de límite?')) return;
+    try {
+      await apiFetch(`${API}/${id}`, { method: 'DELETE' });
+      fetchRules();
+    } catch (err) {
+      setError('Error eliminando: ' + err.message);
+    }
+  };
+
+  const handleCancel = () => {
+    setShowForm(false);
+    setEditRule(null);
+  };
+
+  const rateRules    = rules.filter(r => r.type === 'rate');
+  const sessionRules = rules.filter(r => r.type === 'session');
+
+  return (
+    <div className="ap-panel" role="region" aria-label="Panel de límites">
+      {!embedded && (
+        <div className="ap-header">
+          <span className="ap-header-title"><Gauge size={16} /> Límites</span>
+          <button className="ap-close" onClick={onClose}><X size={16} /></button>
+        </div>
+      )}
+      <div className="ap-body">
+        {error && <div className="pp-msg lp-error-msg">{error}</div>}
+
+        <p className="lp-section-hint">
+          Configura límites de mensajes por tiempo (rate) y duración de sesión CLI.
+          Prioridad: provider {'>'} agent {'>'} user {'>'} bot {'>'} channel {'>'} global.
+        </p>
+
+        {/* Rate limiting */}
+        {rateRules.length > 0 && (
+          <>
+            <p className="lp-section-title">Rate Limiting</p>
+            {rateRules.map(r => (
+              <LimitRow key={r.id} rule={r} onEdit={handleEdit} onDelete={handleDelete} />
+            ))}
+          </>
+        )}
+
+        {/* Session limits */}
+        {sessionRules.length > 0 && (
+          <>
+            <p className="lp-section-title">Sesión CLI</p>
+            {sessionRules.map(r => (
+              <LimitRow key={r.id} rule={r} onEdit={handleEdit} onDelete={handleDelete} />
+            ))}
+          </>
+        )}
+
+        {rules.length === 0 && !showForm && (
+          <div className="lp-empty">
+            <p>Sin límites configurados</p>
+            <p className="lp-empty-hint">Se usan los defaults: 10 msgs/min (rate) y 10 msgs (sesión)</p>
+          </div>
+        )}
+
+        {/* Form */}
+        {showForm ? (
+          <LimitForm initial={editRule} onSave={handleSave} onCancel={handleCancel} />
+        ) : (
+          <button className="ap-btn ap-btn-add" onClick={() => { setEditRule(null); setShowForm(true); }}>
+            <Plus size={14} /> Nuevo límite
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/docs/proposals/004-rate-limiting-configurable.md
+++ b/docs/proposals/004-rate-limiting-configurable.md
@@ -1,0 +1,239 @@
+# 004 — Límites Configurables (Rate Limiting + Sesiones)
+
+> Estado: `propuesta` | Fecha: 2026-03-28
+
+## Problema
+
+Los límites del sistema están hardcodeados en múltiples archivos y no se pueden ajustar sin tocar código. Hay dos tipos de límites independientes:
+
+1. **Rate limiting** — cuántos mensajes puede enviar un usuario en un período
+2. **Duración de sesión CLI** — cada cuántos mensajes se resetea la sesión de Claude/Gemini
+
+Ninguno de los dos es configurable de forma granular por bot, usuario, canal o agente.
+
+---
+
+## Estado actual
+
+### A. Rate Limiting
+
+#### Capa 1: Bot-level (solo Telegram)
+
+| | |
+|---|---|
+| **Archivo** | `server/channels/telegram/TelegramBot.js` → `_checkRateLimit()` |
+| **Scope** | Per-chat, per-bot |
+| **Default** | 30 msgs/hora |
+| **Ventana** | 1 hora (`RATE_WINDOW_MS = 3600000`) |
+| **Configurable** | Sí — `PATCH /api/telegram/bots/:key` con `{ rateLimit, rateLimitKeyword }` |
+| **Persistencia** | SQLite (tabla `bots`, campos `rate_limit`, `rate_limit_keyword`) |
+| **Bypass** | El usuario puede enviar el `rateLimitKeyword` para resetear el contador |
+| **Aplica a** | Solo Telegram |
+
+#### Capa 2: ConversationService (todos los canales)
+
+| | |
+|---|---|
+| **Archivo** | `server/services/ConversationService.js` → `processMessage()` línea 289 |
+| **Scope** | Per-chat, global |
+| **Default** | **10 msgs/min (HARDCODED)** |
+| **Ventana** | 1 minuto |
+| **Configurable** | No |
+| **Persistencia** | Ninguna — Map en memoria |
+| **Excepciones** | No aplica a providers CLI (`claude-code`, `gemini-cli`) |
+| **Aplica a** | Telegram, WebChat, P2P |
+
+```javascript
+// ConversationService.js:289-306
+const MAX_PER_MIN = 10; // ← HARDCODED
+```
+
+#### Capa 3: Outbound Queue (compliance API Telegram)
+
+| | |
+|---|---|
+| **Archivo** | `server/channels/telegram/OutboundQueue.js` |
+| **Default** | 30 calls/seg global, 1 msg/seg per-chat |
+| **Configurable** | No — cumplimiento de la API de Telegram, no tocar |
+
+### B. Duración de sesión CLI
+
+| | |
+|---|---|
+| **Archivo** | `server/services/ConversationService.js` líneas 400 y 553 |
+| **Default** | **10 mensajes (HARDCODED en 2 lugares)** |
+| **Configurable** | No |
+| **Aplica a** | Sesiones `claude-code` y `gemini-cli` |
+| **Efecto** | Al llegar a 10 mensajes, se destruye la sesión CLI y se crea una nueva |
+| **Continuidad** | Guarda un resumen en `last-session-summary.md` del agente vía memoria |
+
+```javascript
+// _processGeminiCli (línea 400)
+const MAX_SESSION_MESSAGES = 10; // ← HARDCODED
+
+// _processClaudeCode (línea 553)
+const MAX_SESSION_MESSAGES = 10; // ← HARDCODED (duplicado)
+```
+
+**Flujo del auto-reset:**
+```
+mensaje #10 llega
+    → guarda resumen en memoria (last-session-summary.md)
+    → destruye sesión CLI
+    → crea nueva sesión
+    → inyecta contexto previo
+    → procesa mensaje
+```
+
+### C. Otros límites hardcodeados relacionados
+
+| Límite | Archivo | Valor | Descripción |
+|--------|---------|-------|-------------|
+| Sliding window historial API | `ConversationService.js` | 30 msgs | Compresión automática del historial cuando supera 30 mensajes |
+| WebChat messages por sesión | `WebchatMessagesRepository.js:10` | 100 msgs | Máximo de mensajes persistidos por sesión webchat |
+| Retry attempts | `ConversationService.js` | 3 | Reintentos en errores transitorios (429, 500, timeout) |
+| Request timeout | `ConversationService.js` | 120s | Timeout global por request al provider |
+
+---
+
+## Flujo completo de un mensaje
+
+```
+Usuario envía mensaje
+    │
+    ▼
+[ Capa 1 ] TelegramBot._checkRateLimit()    ← 30/hora per-chat (configurable per-bot)
+    │ pasa                                      Solo Telegram. WebChat no tiene.
+    ▼
+ConversationService.processMessage()
+    │
+    ▼
+[ Capa 2 ] Rate limit 10 msg/min            ← HARDCODED, no configurable
+    │ pasa                                      Solo providers API (no CLI)
+    ▼
+¿Es provider CLI?
+    │
+    ├─ Sí → [ Session limit ] 10 msgs        ← HARDCODED, no configurable
+    │        Si excede → reset sesión            Aplica a claude-code y gemini-cli
+    │
+    ├─ No → Provider API procesa directo
+    │
+    ▼
+Respuesta generada
+    │
+    ▼
+[ Capa 3 ] OutboundQueue                     ← 30/seg + 1/seg per-chat (Telegram API)
+    │
+    ▼
+Respuesta enviada
+```
+
+---
+
+## Problemas identificados
+
+1. **Capa 2 no configurable** — 10 msgs/min hardcoded para todos los canales y usuarios
+2. **Duración de sesión CLI no configurable** — 10 mensajes para todos, sin importar el contexto
+3. **`MAX_SESSION_MESSAGES` duplicado** — definido 2 veces en el mismo archivo (líneas 400 y 553)
+4. **WebChat no tiene capa 1** — no hay rate limiting a nivel de canal web
+5. **No hay límite por usuario** — un usuario con múltiples chats/bots no tiene tope global
+6. **No hay límite por provider** — un provider caro (Anthropic) tiene el mismo límite que uno barato
+7. **Contadores se pierden al reiniciar** — no hay persistencia de estado de rate limit
+8. **Las capas no se conocen** — el bot permite 30/hora pero ConversationService corta a 10/min
+
+---
+
+## Propuesta
+
+### Nueva tabla `limits`
+
+```sql
+CREATE TABLE IF NOT EXISTS limits (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  type       TEXT NOT NULL,     -- 'rate' | 'session'
+  scope      TEXT NOT NULL,     -- 'global' | 'channel' | 'bot' | 'user' | 'agent' | 'provider'
+  scope_id   TEXT,              -- id del scope (NULL = default para ese scope)
+  max_count  INTEGER NOT NULL,  -- cantidad máxima
+  window_ms  INTEGER,           -- ventana en ms (solo para type='rate', NULL para 'session')
+  enabled    INTEGER NOT NULL DEFAULT 1,
+  created_at INTEGER DEFAULT (strftime('%s','now') * 1000),
+  UNIQUE(type, scope, scope_id)
+);
+```
+
+### Resolución por prioridad
+
+Más específico gana. Si no hay regla específica, sube al siguiente nivel:
+
+```
+provider > agent > user > bot > channel > global
+```
+
+### Ejemplos de registros
+
+#### Rate limiting (`type = 'rate'`)
+
+| scope | scope_id | max_count | window_ms | Efecto |
+|-------|----------|-----------|-----------|--------|
+| global | NULL | 10 | 60000 | Default: 10/min para todos |
+| channel | telegram | 30 | 3600000 | Telegram: 30/hora |
+| channel | webchat | 20 | 60000 | WebChat: 20/min |
+| bot | chibi2026_bot | 60 | 3600000 | Este bot: 60/hora |
+| user | uuid-marcos | 100 | 3600000 | Marcos: 100/hora |
+| provider | anthropic | 5 | 60000 | Anthropic: max 5/min |
+
+#### Duración de sesión (`type = 'session'`)
+
+| scope | scope_id | max_count | window_ms | Efecto |
+|-------|----------|-----------|-----------|--------|
+| global | NULL | 10 | NULL | Default: reset cada 10 msgs |
+| provider | claude-code | 20 | NULL | Claude CLI: 20 msgs antes de reset |
+| provider | gemini-cli | 5 | NULL | Gemini CLI: 5 msgs |
+| agent | mi-agente | 50 | NULL | Este agente: 50 msgs |
+| user | uuid-marcos | 30 | NULL | Marcos: 30 msgs |
+
+### API REST
+
+```
+GET    /api/limits              — listar todas las reglas
+GET    /api/limits?type=rate    — filtrar por tipo
+GET    /api/limits?scope=bot    — filtrar por scope
+POST   /api/limits              — crear regla { type, scope, scope_id, max_count, window_ms }
+PATCH  /api/limits/:id          — editar regla
+DELETE /api/limits/:id          — eliminar regla
+```
+
+### Cambios necesarios
+
+| Archivo | Cambio |
+|---------|--------|
+| `server/storage/LimitsRepository.js` | **Nuevo** — CRUD + `resolve(type, context)` que devuelve el límite más específico |
+| `server/routes/limits.js` | **Nuevo** — Router REST para CRUD de reglas |
+| `server/bootstrap.js` | Instanciar `LimitsRepository`, inyectar en `ConversationService` |
+| `server/services/ConversationService.js` | Reemplazar `MAX_PER_MIN` y `MAX_SESSION_MESSAGES` hardcodeados por lectura del repo |
+| `server/channels/telegram/TelegramBot.js` | Opcional: unificar `_checkRateLimit` con el mismo sistema |
+| `server/channels/web/WebChannel.js` | Agregar rate limiting (hoy no tiene) |
+
+### Método `resolve(type, context)`
+
+```javascript
+// context = { provider, agentKey, userId, botKey, channel }
+// Busca la regla más específica que aplique
+
+resolve('rate', { provider: 'anthropic', userId: 'uuid-marcos', botKey: 'chibi', channel: 'telegram' })
+// → Busca en orden: provider=anthropic → user=uuid-marcos → bot=chibi → channel=telegram → global
+// → Retorna la primera que encuentre: { max_count, window_ms }
+
+resolve('session', { provider: 'claude-code', agentKey: 'claude' })
+// → Busca: provider=claude-code → agent=claude → global
+// → Retorna: { max_count }
+```
+
+### Consideraciones
+
+- **Contadores en memoria** — los contadores de rate limit siguen siendo Maps en RAM (son efímeros, no tiene sentido persistirlos)
+- **Configuración en SQLite** — las reglas sí se persisten
+- **Cache** — cargar reglas en memoria al arrancar, invalidar al modificar vía API (evitar query en cada mensaje)
+- **Capa 3 intacta** — OutboundQueue no se toca (compliance con API Telegram)
+- **Backward compatible** — si no hay reglas en la DB, usar los defaults actuales (10/min rate, 10 msgs session)
+- **Unificar `MAX_SESSION_MESSAGES`** — eliminar la duplicación en líneas 400 y 553

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -15,6 +15,7 @@ Análisis y decisiones de diseño antes de implementar cambios significativos.
 | [001-refactoring-arquitectural.md](./001-refactoring-arquitectural.md) | `implementada` | 2026-03 | Desacoplamiento completo de telegram.js monolito |
 | [002-ia-local.md](./002-ia-local.md) | `propuesta` | 2026-03 | Pool de IA local con Ollama (Llama 8B, DeepSeek) |
 | [003-mcp-shell-persistente.md](./003-mcp-shell-persistente.md) | `implementada` | 2026-03 | MCP Server embebido con ShellSession — estado de shell por conversación |
+| [004-rate-limiting-configurable.md](./004-rate-limiting-configurable.md) | `propuesta` | 2026-03 | Límites configurables: rate limiting + duración de sesión CLI por scope |
 
 ---
 

--- a/server/bootstrap.js
+++ b/server/bootstrap.js
@@ -24,6 +24,7 @@ const BotsRepository                = require('./storage/BotsRepository');
 const UsersRepository               = require('./storage/UsersRepository');
 const ScheduledActionsRepository    = require('./storage/ScheduledActionsRepository');
 const PendingDeliveriesRepository   = require('./storage/PendingDeliveriesRepository');
+const LimitsRepository              = require('./storage/LimitsRepository');
 const ConversationService      = require('./services/ConversationService');
 const AuthService              = require('./services/AuthService');
 const { TelegramChannel }      = require('./channels/telegram/TelegramChannel');
@@ -76,6 +77,9 @@ function createContainer() {
 
   const pendingRepo = new PendingDeliveriesRepository(db);
   pendingRepo.init();
+
+  const limitsRepo = new LimitsRepository(db);
+  limitsRepo.init();
 
   // ── Singletons de dominio ─────────────────────────────────────────────────
 
@@ -149,6 +153,7 @@ function createContainer() {
     skills,
     ClaudePrintSession,
     consolidator,
+    limitsRepo,
     logger,
   });
 
@@ -247,6 +252,7 @@ function createContainer() {
     ttsConfig,
     usersRepo,
     authService,
+    limitsRepo,
     scheduler,
   };
 

--- a/server/index.js
+++ b/server/index.js
@@ -28,7 +28,7 @@ logger.info('HOME:', process.env.HOME);
 
 // ── Carga de módulos (async por sql.js WASM) ─────────────────────────────────
 
-let sessionManager, telegram, webChannel, agents, skills, events, memory, providerConfig, providersModule, consolidator, convSvc, mcps, authService, usersRepo;
+let sessionManager, telegram, webChannel, agents, skills, events, memory, providerConfig, providersModule, consolidator, convSvc, mcps, authService, usersRepo, limitsRepo;
 let mcpRouter = null;
 let nodrizaInstance = null;
 
@@ -59,6 +59,7 @@ const _modulesReady = (async function loadModules() {
     convSvc      = _c.convSvc;
     authService  = _c.authService;
     usersRepo    = _c.usersRepo;
+    limitsRepo   = _c.limitsRepo;
     try {
       const { createMcpRouter } = require('./mcp');
       mcpRouter = createMcpRouter({ sessionManager: _c.sessionManager, memory: _c.memory, scheduler: _c.scheduler, usersRepo: _c.usersRepo });
@@ -150,6 +151,7 @@ _modulesReady.then(() => {
   app.use('/api/voice-providers', requireAuth, require('./routes/voice-providers')({}));
   app.use('/api/nodriza',         requireAuth, require('./routes/nodriza')({ nodrizaInstance, getDataChannelHandler: () => startAISessionForDataChannel }));
   app.use('/api/contacts',        requireAuth, require('./routes/contacts')({ usersRepo }));
+  app.use('/api/limits',          requireAuth, require('./routes/limits')({ limitsRepo }));
 
   // Montar MCP router si está disponible
   if (mcpRouter) app.use('/mcp', mcpRouter);

--- a/server/routes/limits.js
+++ b/server/routes/limits.js
@@ -1,0 +1,40 @@
+'use strict';
+const express = require('express');
+
+module.exports = function createLimitsRouter({ limitsRepo }) {
+  const router = express.Router();
+
+  // GET /limits — listar reglas (filtros opcionales: ?type=rate&scope=bot)
+  router.get('/', (req, res) => {
+    const filters = {};
+    if (req.query.type) filters.type = req.query.type;
+    if (req.query.scope) filters.scope = req.query.scope;
+    res.json(limitsRepo.list(filters));
+  });
+
+  // POST /limits — crear regla
+  router.post('/', (req, res) => {
+    try {
+      const rule = limitsRepo.create(req.body);
+      res.status(201).json(rule);
+    } catch (err) {
+      res.status(400).json({ error: err.message });
+    }
+  });
+
+  // PATCH /limits/:id — editar regla
+  router.patch('/:id', (req, res) => {
+    const rule = limitsRepo.update(Number(req.params.id), req.body);
+    if (!rule) return res.status(404).json({ error: 'Regla no encontrada' });
+    res.json(rule);
+  });
+
+  // DELETE /limits/:id — eliminar regla
+  router.delete('/:id', (req, res) => {
+    const ok = limitsRepo.remove(Number(req.params.id));
+    if (!ok) return res.status(404).json({ error: 'Regla no encontrada' });
+    res.json({ ok: true });
+  });
+
+  return router;
+};

--- a/server/services/ConversationService.js
+++ b/server/services/ConversationService.js
@@ -43,6 +43,7 @@ class ConversationService {
     ClaudePrintSession,
     GeminiCliSession = null,
     consolidator   = null,
+    limitsRepo     = null,
     logger         = console,
   }) {
     this._sessionManager     = sessionManager;
@@ -60,6 +61,7 @@ class ConversationService {
     if (this._rlCleanup.unref) this._rlCleanup.unref();
     this._agents             = agents;
     this._skills             = skills;
+    this._limitsRepo         = limitsRepo;
     this._ClaudePrintSession = ClaudePrintSession;
     this._GeminiCliSession   = GeminiCliSession || (() => {
       try { return require('../core/GeminiCliSession'); } catch { return null; }
@@ -286,21 +288,23 @@ class ConversationService {
     const resolvedShellId = shellId || String(chatId);
     csdbg('msg', `chatId=${chatId} provider=${provider} agent=${agentKey} model=${model} textLen=${text.length} images=${images?.length || 0} histLen=${history.length} hasSession=${!!claudeSession}`);
 
-    // Rate limiting: 10 mensajes/minuto por chat (solo providers API, no CLI)
+    // Rate limiting configurable (solo providers API, no CLI)
     const CLI_PROVIDERS = new Set(['claude-code', 'gemini-cli']);
     if (!CLI_PROVIDERS.has(provider)) {
-      const MAX_PER_MIN = 10;
+      const rateRule = this._limitsRepo
+        ? this._limitsRepo.resolve('rate', { provider, agentKey, userId, botKey, channel })
+        : { max_count: 10, window_ms: 60000 };
       const now = Date.now();
       const key = `${botKey || 'web'}:${chatId}`;
       let rl = this._rateLimits.get(key);
       if (!rl || now > rl.resetAt) {
-        rl = { count: 0, resetAt: now + 60000 };
+        rl = { count: 0, resetAt: now + rateRule.window_ms };
         this._rateLimits.set(key, rl);
       }
       rl.count++;
-      if (rl.count > MAX_PER_MIN) {
+      if (rl.count > rateRule.max_count) {
         const waitSec = Math.ceil((rl.resetAt - now) / 1000);
-        return { text: `⏳ Rate limit: máximo ${MAX_PER_MIN} mensajes por minuto. Esperá ${waitSec}s.`, history };
+        return { text: `⏳ Rate limit: máximo ${rateRule.max_count} mensajes por ${Math.round(rateRule.window_ms / 1000)}s. Esperá ${waitSec}s.`, history };
       }
       this._rateLimits.set(key, rl);
     }
@@ -397,7 +401,9 @@ class ConversationService {
   // ── Proveedor gemini-cli (GeminiCliSession) ───────────────────────────────
 
   async _processGeminiCli({ chatId, agentKey, text, geminiSession, claudeMode, onChunk, onStatus, botKey, channel }) {
-    const MAX_SESSION_MESSAGES = 10;
+    const sessionRule = this._limitsRepo
+      ? this._limitsRepo.resolve('session', { provider: 'gemini-cli', agentKey, botKey, channel })
+      : { max_count: 10 };
     let session = geminiSession;
     let isNewSession = false;
 
@@ -407,7 +413,7 @@ class ConversationService {
       : '';
 
     // Auto-reset de sesión y guardado de resumen en memoria
-    if (session && session.messageCount >= MAX_SESSION_MESSAGES) {
+    if (session && session.messageCount >= sessionRule.max_count) {
       csdbg('gemini', `auto-reset: session tiene ${session.messageCount} msgs`);
       if (agentKey && this._memory) {
         try {
@@ -550,7 +556,9 @@ class ConversationService {
       const imgContext = descriptions.join('\n\n');
       text = `[El usuario envió ${images.length} imagen(es). Análisis:]\n\n${imgContext}\n\n[Mensaje original del usuario: "${text}"]`;
     }
-    const MAX_SESSION_MESSAGES = 10;
+    const sessionRule = this._limitsRepo
+      ? this._limitsRepo.resolve('session', { provider: 'claude-code', agentKey, botKey, channel })
+      : { max_count: 10 };
     let session = claudeSession;
     let isNewSession = false;
     const isWebChannel = channel === 'web' || botKey === 'web';
@@ -597,9 +605,9 @@ class ConversationService {
 
     // Auto-reset: si la sesión tiene demasiados mensajes, crear una nueva
     // Antes de resetear, guardar resumen en memoria para continuidad
-    if (session && session.messageCount >= MAX_SESSION_MESSAGES) {
-      csdbg('claude', `auto-reset: session tiene ${session.messageCount} msgs (max ${MAX_SESSION_MESSAGES}), creando nueva`);
-      console.log(`[ConvSvc] Auto-reset de sesión (${session.messageCount} mensajes)`);
+    if (session && session.messageCount >= sessionRule.max_count) {
+      csdbg('claude', `auto-reset: session tiene ${session.messageCount} msgs (max ${sessionRule.max_count}), creando nueva`);
+      console.log(`[ConvSvc] Auto-reset de sesión (${session.messageCount}/${sessionRule.max_count} mensajes)`);
 
       // Guardar resumen de sesión en memoria para continuidad
       if (agentKey && this._memory) {

--- a/server/storage/LimitsRepository.js
+++ b/server/storage/LimitsRepository.js
@@ -1,0 +1,163 @@
+'use strict';
+
+/**
+ * LimitsRepository — configuración de límites (rate limiting + sesiones) en SQLite.
+ *
+ * Tabla: limits (type, scope, scope_id, max_count, window_ms).
+ * Método resolve() busca la regla más específica aplicable.
+ */
+
+const SCOPE_PRIORITY = ['provider', 'agent', 'user', 'bot', 'channel', 'global'];
+
+class LimitsRepository {
+  static SCHEMA = `
+    CREATE TABLE IF NOT EXISTS limits (
+      id         INTEGER PRIMARY KEY AUTOINCREMENT,
+      type       TEXT NOT NULL,
+      scope      TEXT NOT NULL,
+      scope_id   TEXT,
+      max_count  INTEGER NOT NULL,
+      window_ms  INTEGER,
+      enabled    INTEGER NOT NULL DEFAULT 1,
+      created_at INTEGER DEFAULT (strftime('%s','now') * 1000),
+      UNIQUE(type, scope, scope_id)
+    )
+  `;
+
+  static DEFAULTS = {
+    rate:    { max_count: 10, window_ms: 60000 },
+    session: { max_count: 10, window_ms: null },
+  };
+
+  constructor(db) {
+    this._db = db;
+    this._cache = null;
+  }
+
+  init() {
+    if (!this._db) return;
+    this._db.exec(LimitsRepository.SCHEMA);
+    this._loadCache();
+  }
+
+  // ── Cache ─────────────────────────────────────────────────────────────────
+
+  _loadCache() {
+    if (!this._db) return;
+    const rows = this._db.prepare('SELECT * FROM limits WHERE enabled = 1').all();
+    this._cache = rows;
+  }
+
+  _invalidateCache() {
+    this._loadCache();
+  }
+
+  // ── Resolve ───────────────────────────────────────────────────────────────
+
+  /**
+   * Busca la regla más específica que aplique.
+   * @param {'rate'|'session'} type
+   * @param {object} context - { provider, agentKey, userId, botKey, channel }
+   * @returns {{ max_count: number, window_ms: number|null }}
+   */
+  resolve(type, context = {}) {
+    const rules = (this._cache || []).filter(r => r.type === type);
+    if (!rules.length) return LimitsRepository.DEFAULTS[type] || { max_count: 10, window_ms: 60000 };
+
+    const scopeMap = {
+      provider: context.provider || null,
+      agent:    context.agentKey || null,
+      user:     context.userId   || null,
+      bot:      context.botKey   || null,
+      channel:  context.channel  || null,
+      global:   null,
+    };
+
+    for (const scope of SCOPE_PRIORITY) {
+      const scopeId = scopeMap[scope];
+      if (scope !== 'global' && !scopeId) continue;
+
+      const match = rules.find(r =>
+        r.scope === scope && (scope === 'global' ? !r.scope_id : r.scope_id === scopeId)
+      );
+      if (match) return { max_count: match.max_count, window_ms: match.window_ms };
+    }
+
+    return LimitsRepository.DEFAULTS[type] || { max_count: 10, window_ms: 60000 };
+  }
+
+  // ── CRUD ──────────────────────────────────────────────────────────────────
+
+  list(filters = {}) {
+    if (!this._db) return [];
+    let sql = 'SELECT * FROM limits';
+    const conditions = [];
+    const params = [];
+
+    if (filters.type) { conditions.push('type = ?'); params.push(filters.type); }
+    if (filters.scope) { conditions.push('scope = ?'); params.push(filters.scope); }
+
+    if (conditions.length) sql += ' WHERE ' + conditions.join(' AND ');
+    sql += ' ORDER BY type, scope, scope_id';
+
+    return this._db.prepare(sql).all(...params);
+  }
+
+  getById(id) {
+    if (!this._db) return null;
+    return this._db.prepare('SELECT * FROM limits WHERE id = ?').get(id) || null;
+  }
+
+  create({ type, scope, scope_id, max_count, window_ms, enabled }) {
+    if (!this._db) return null;
+    if (!type || !scope || max_count == null) throw new Error('type, scope y max_count son requeridos');
+    if (!['rate', 'session'].includes(type)) throw new Error('type debe ser "rate" o "session"');
+    if (!SCOPE_PRIORITY.includes(scope)) throw new Error(`scope debe ser uno de: ${SCOPE_PRIORITY.join(', ')}`);
+
+    const result = this._db.prepare(`
+      INSERT INTO limits (type, scope, scope_id, max_count, window_ms, enabled)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `).run(
+      type,
+      scope,
+      scope_id || null,
+      max_count,
+      type === 'rate' ? (window_ms || 60000) : null,
+      enabled != null ? (enabled ? 1 : 0) : 1,
+    );
+
+    this._invalidateCache();
+    return this.getById(result.lastInsertRowid || this._db.prepare('SELECT last_insert_rowid() as id').get().id);
+  }
+
+  update(id, fields) {
+    if (!this._db) return null;
+    const existing = this.getById(id);
+    if (!existing) return null;
+
+    const sets = [];
+    const params = [];
+
+    for (const key of ['max_count', 'window_ms', 'enabled', 'scope_id']) {
+      if (fields[key] !== undefined) {
+        sets.push(`${key} = ?`);
+        params.push(key === 'enabled' ? (fields[key] ? 1 : 0) : fields[key]);
+      }
+    }
+
+    if (!sets.length) return existing;
+    params.push(id);
+    this._db.prepare(`UPDATE limits SET ${sets.join(', ')} WHERE id = ?`).run(...params);
+    this._invalidateCache();
+    return this.getById(id);
+  }
+
+  remove(id) {
+    if (!this._db) return false;
+    const result = this._db.prepare('DELETE FROM limits WHERE id = ?').run(id);
+    this._invalidateCache();
+    return result.changes > 0;
+  }
+}
+
+module.exports = LimitsRepository;


### PR DESCRIPTION
## Summary
- Nueva tabla `limits` en SQLite con resolución jerárquica por scope
- `LimitsRepository` con método `resolve(type, context)` que busca la regla más específica (provider > agent > user > bot > channel > global)
- API REST completa: `GET/POST/PATCH/DELETE /api/limits`
- `ConversationService` usa `limitsRepo` en vez de valores hardcodeados:
  - Rate limit: era `MAX_PER_MIN = 10` fijo → ahora configurable por scope
  - Sesión CLI: era `MAX_SESSION_MESSAGES = 10` en 2 lugares → ahora configurable
- Propuesta técnica documentada en `docs/proposals/004`

## Test plan
- [ ] Sin reglas en DB → usa defaults (10/min rate, 10 msgs sesión)
- [ ] Crear regla rate global → verificar que aplica
- [ ] Crear regla session provider=claude-code → verificar override
- [ ] PATCH/DELETE reglas → cache se invalida