### PR TITLE
fix: save() de bots ya no borra registros de la DB

### DIFF
--- a/server/channels/telegram/TelegramChannel.js
+++ b/server/channels/telegram/TelegramChannel.js
@@ -220,7 +220,8 @@ class TelegramChannel extends BaseChannel {
     if (!bot) return false;
     await bot.stop();
     this.bots.delete(key);
-    this._saveFile();
+    if (this._botsRepo) this._botsRepo.remove(key);
+    else this._saveFile();
     return true;
   }
 

--- a/server/storage/BotsRepository.js
+++ b/server/storage/BotsRepository.js
@@ -148,17 +148,8 @@ class BotsRepository {
    */
   save(bots) {
     if (!this._db) return;
-
-    const keys = bots.map(b => b.key);
     for (const bot of bots) {
       this._upsertBot(bot);
-    }
-    // Eliminar bots que ya no están en memoria
-    if (keys.length) {
-      const placeholders = keys.map(() => '?').join(',');
-      this._db.prepare(`DELETE FROM bots WHERE key NOT IN (${placeholders})`).run(...keys);
-    } else {
-      this._db.exec('DELETE FROM bots');
     }
   }
 
@@ -223,6 +214,17 @@ class BotsRepository {
   updateOffset(key, offset) {
     if (!this._db) return;
     this._db.prepare('UPDATE bots SET "offset" = ? WHERE key = ?').run(offset, key);
+  }
+
+  /**
+   * Elimina un bot por key.
+   * @param {string} key
+   * @returns {boolean}
+   */
+  remove(key) {
+    if (!this._db) return false;
+    const result = this._db.prepare('DELETE FROM bots WHERE key = ?').run(key);
+    return result.changes > 0;
   }
 
   // ── Helpers ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `save()` hacía `DELETE FROM bots WHERE key NOT IN (...)` — borraba bots que no estaban en el Map en memoria
- Esto causaba que bots recién registrados se perdieran en el siguiente offset save del polling
- Ahora `save()` solo hace upsert (INSERT OR REPLACE)
- `removeBot()` usa un nuevo método `remove(key)` para borrar explícitamente

## Test plan
- [ ] Registrar bot nuevo → restart → verificar que persiste
- [ ] Eliminar bot desde panel → verificar que se borra de la DB