### PR TITLE
fix: bugs críticos y performance del webclient (#130-#136)

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -294,7 +294,7 @@ function AppContent() {
               return [...prev, s];
             });
           }
-        } catch { /* silenciar */ }
+        } catch (err) { console.warn('[WS] Error procesando mensaje:', err.message); }
       };
     }
     connect();
@@ -475,7 +475,7 @@ function AppContent() {
               <SectionBar section="telegram" />
               <ErrorBoundary>
                 <Suspense fallback={<Skeleton lines={6} style={{ padding: '24px' }} />}>
-                  <TelegramPanel onClose={toTerminal} onOpenSession={handleOpenSession} embedded />
+                  <TelegramPanel onClose={toTerminal} onOpenSession={handleOpenSession} embedded active={section === 'telegram'} />
                 </Suspense>
               </ErrorBoundary>
             </div>

--- a/client/src/components/TelegramPanel.jsx
+++ b/client/src/components/TelegramPanel.jsx
@@ -37,14 +37,14 @@ const ChatRow = memo(function ChatRow({ botKey, chat, onOpenSession, onRefresh }
         body: JSON.stringify({ sessionId }),
       });
       onRefresh();
-    } catch { /* ignorar */ }
+    } catch (err) { console.warn('[Telegram]', err.message); }
   };
 
   const handleDisconnect = async () => {
     try {
       await apiFetch(`${API}/bots/${botKey}/chats/${chat.chatId}`, { method: 'DELETE' });
       onRefresh();
-    } catch { /* ignorar */ }
+    } catch (err) { console.warn('[Telegram]', err.message); }
   };
 
   return (
@@ -173,7 +173,7 @@ const BotCard = memo(function BotCard({ bot, allAgents, onOpenSession, onRefresh
     try {
       await apiFetch(`${API}/bots/${bot.key}/start`, { method: 'POST' });
       onRefresh();
-    } catch { /* ignorar */ } finally { setLoading(false); }
+    } catch (err) { console.warn('[Telegram]', err.message); } finally { setLoading(false); }
   };
 
   const handleStop = async () => {
@@ -181,7 +181,7 @@ const BotCard = memo(function BotCard({ bot, allAgents, onOpenSession, onRefresh
     try {
       await apiFetch(`${API}/bots/${bot.key}/stop`, { method: 'POST' });
       onRefresh();
-    } catch { /* ignorar */ } finally { setLoading(false); }
+    } catch (err) { console.warn('[Telegram]', err.message); } finally { setLoading(false); }
   };
 
   const handleRemove = async () => {
@@ -190,7 +190,7 @@ const BotCard = memo(function BotCard({ bot, allAgents, onOpenSession, onRefresh
     try {
       await apiFetch(`${API}/bots/${bot.key}`, { method: 'DELETE' });
       onRefresh();
-    } catch { /* ignorar */ } finally { setLoading(false); }
+    } catch (err) { console.warn('[Telegram]', err.message); } finally { setLoading(false); }
   };
 
   const handleChangeAgent = async (e) => {
@@ -202,7 +202,7 @@ const BotCard = memo(function BotCard({ bot, allAgents, onOpenSession, onRefresh
         body: JSON.stringify({ defaultAgent: e.target.value }),
       });
       onRefresh();
-    } catch { /* ignorar */ }
+    } catch (err) { console.warn('[Telegram]', err.message); }
   };
 
   return (
@@ -342,7 +342,7 @@ const AddBotForm = memo(function AddBotForm({ onAdd, onCancel }) {
   );
 });
 
-export default function TelegramPanel({ onClose, onOpenSession, embedded }) {
+export default function TelegramPanel({ onClose, onOpenSession, embedded, active = true }) {
   const [bots, setBots] = useState([]);
   const [allAgents, setAllAgents] = useState([]);
   const [showAdd, setShowAdd] = useState(false);
@@ -353,14 +353,15 @@ export default function TelegramPanel({ onClose, onOpenSession, embedded }) {
       const res = await apiFetch(`${API}/bots`);
       const data = await res.json();
       setBots(Array.isArray(data) ? data : []);
-    } catch { /* ignorar */ }
+    } catch (err) { console.warn('[Telegram]', err.message); }
   }, []);
 
   useEffect(() => {
+    if (!active && !embedded) return;
     fetchBots();
-    intervalRef.current = setInterval(fetchBots, 3000);
+    intervalRef.current = setInterval(fetchBots, 5000);
     return () => clearInterval(intervalRef.current);
-  }, [fetchBots]);
+  }, [fetchBots, active, embedded]);
 
   // Cargar agentes una sola vez (en vez de por cada BotCard)
   useEffect(() => {

--- a/client/src/components/TerminalPanel.css
+++ b/client/src/components/TerminalPanel.css
@@ -1,0 +1,52 @@
+.tp-container {
+  position: absolute;
+  inset: 0;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+}
+.tp-container[aria-hidden="true"] { display: none; }
+
+.tp-xterm {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.tp-input-bar {
+  display: flex;
+  gap: 6px;
+  padding: 6px 8px;
+  background: var(--bg-secondary);
+  border-top: 1px solid var(--border-primary);
+  flex-shrink: 0;
+}
+
+.tp-input {
+  flex: 1;
+  background: var(--bg-input);
+  color: var(--text-primary);
+  border: 1px solid var(--border-primary);
+  border-radius: 4px;
+  padding: 6px 10px;
+  font-family: "Cascadia Code", "Fira Code", "Courier New", monospace;
+  font-size: 13px;
+  outline: none;
+}
+.tp-input:focus {
+  border-color: var(--accent-cyan);
+}
+
+.tp-send-btn {
+  padding: 6px 14px;
+  background: var(--btn-primary-bg);
+  color: var(--btn-primary-text);
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 13px;
+  font-family: inherit;
+}
+.tp-send-btn:hover {
+  opacity: 0.9;
+}

--- a/client/src/components/TerminalPanel.jsx
+++ b/client/src/components/TerminalPanel.jsx
@@ -3,6 +3,7 @@ import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { WebLinksAddon } from '@xterm/addon-web-links';
 import '@xterm/xterm/css/xterm.css';
+import './TerminalPanel.css';
 
 export default function TerminalPanel({ session, wsUrl, active, onSessionId }) {
   const containerRef = useRef(null);
@@ -142,11 +143,11 @@ export default function TerminalPanel({ session, wsUrl, active, onSessionId }) {
     if (containerRef.current) ro.observe(containerRef.current);
 
     return () => {
-      ro.disconnect();
-      clearTimeout(reconnectTimerRef.current);
       manualCloseRef.current = true;
-      wsRef.current?.close();
+      clearTimeout(reconnectTimerRef.current);
       onDataDisposable.dispose();
+      wsRef.current?.close();
+      ro.disconnect();
       term.dispose();
     };
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
@@ -182,35 +183,17 @@ export default function TerminalPanel({ session, wsUrl, active, onSessionId }) {
     if (ws && ws.readyState === WebSocket.OPEN) {
       ws.send(JSON.stringify({ type: 'input', data: text + '\r' }));
       setInputValue('');
+      inputRef.current?.focus();
     }
   };
 
   return (
-    <div
-      style={{
-        position: 'absolute',
-        inset: 0,
-        padding: 8,
-        display: active ? 'flex' : 'none',
-        flexDirection: 'column',
-      }}
-    >
-      <div
-        ref={containerRef}
-        style={{ flex: 1, minHeight: 0, overflow: 'hidden' }}
-      />
-      <div
-        style={{
-          display: 'flex',
-          gap: '6px',
-          padding: '6px 8px',
-          background: 'var(--bg-secondary)',
-          borderTop: '1px solid var(--border-primary)',
-          flexShrink: 0,
-        }}
-      >
+    <div className="tp-container" aria-hidden={!active}>
+      <div ref={containerRef} className="tp-xterm" />
+      <div className="tp-input-bar">
         <input
           ref={inputRef}
+          className="tp-input"
           value={inputValue}
           onChange={(e) => setInputValue(e.target.value)}
           onKeyDown={(e) => {
@@ -223,33 +206,8 @@ export default function TerminalPanel({ session, wsUrl, active, onSessionId }) {
           aria-label="Entrada de comando de terminal"
           autoComplete="off"
           spellCheck={false}
-          style={{
-            flex: 1,
-            background: 'var(--bg-input)',
-            color: 'var(--text-primary)',
-            border: '1px solid var(--border-primary)',
-            borderRadius: '4px',
-            padding: '6px 10px',
-            fontFamily: '"Cascadia Code", "Fira Code", "Courier New", monospace',
-            fontSize: '13px',
-            outline: 'none',
-          }}
-          onFocus={(e) => (e.target.style.borderColor = 'var(--accent-cyan)')}
-          onBlur={(e) => (e.target.style.borderColor = 'var(--border-primary)')}
         />
-        <button
-          onClick={sendText}
-          style={{
-            padding: '6px 14px',
-            background: 'var(--btn-primary-bg)',
-            color: 'var(--btn-primary-text)',
-            border: 'none',
-            borderRadius: '4px',
-            cursor: 'pointer',
-            fontSize: '13px',
-            fontFamily: 'inherit',
-          }}
-        >
+        <button className="tp-send-btn" onClick={sendText}>
           Enviar
         </button>
       </div>

--- a/client/src/components/WebChatPanel.jsx
+++ b/client/src/components/WebChatPanel.jsx
@@ -44,7 +44,7 @@ export default function WebChatPanel({ onClose, embedded, onNewMessage, onStateC
   useEffect(() => { setWsRef(wsRef.current); }, [connected, setWsRef, wsRef]);
 
   // Reportar cwd + provider al padre (para context bar en split mode)
-  useEffect(() => { onStateChange?.({ cwd, provider }); }, [cwd, provider]); // eslint-disable-line
+  useEffect(() => { onStateChange?.({ cwd, provider }); }, [cwd, provider, onStateChange]);
 
   // ── Cargar providers y agentes ─────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
Fixes de la auditoría del webclient (issues #130-#136):

- **#130** fix(terminal): orden de cleanup corregido para evitar memory leak
- **#131** fix(app): errores de WebSocket se loguean en vez de silenciarse
- **#132** fix(telegram): catch vacíos reemplazados con console.warn
- **#133** perf(telegram): polling pausado cuando panel oculto, intervalo 3s→5s
- **#134** perf(webchat): dependencia faltante en useEffect
- **#135** perf(terminal): inline styles movidos a CSS classes
- **#136** ux(terminal): auto-focus del input después de enviar comando

## Test plan
- [ ] Terminal: enviar comando → input mantiene focus
- [ ] Terminal: cambiar tabs → sin memory leak en DevTools
- [ ] Telegram: navegar a otro panel → polling se detiene (verificar Network tab)
- [ ] Consola: sin errores silenciados, warnings visibles