### PR TITLE
fix: UX, accesibilidad y polish del webclient (#137-#143)

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -28,7 +28,7 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  background: linear-gradient(90deg, #0f1923 0%, #111927 100%);
+  background: linear-gradient(90deg, var(--bg-secondary) 0%, var(--bg-header) 100%);
   padding: 0 18px;
   border-bottom: 1px solid var(--border-primary);
   user-select: none;
@@ -507,7 +507,7 @@
 .split-chat-panel { border-left: none; }
 
 .split-divider {
-  width: 4px;
+  width: 6px;
   background: var(--border-primary);
   cursor: col-resize;
   flex-shrink: 0;
@@ -515,10 +515,26 @@
   position: relative;
   z-index: 5;
 }
+.split-divider::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 2px;
+  height: 32px;
+  border-radius: 1px;
+  background: rgba(79,195,247,0.3);
+  transition: background 0.15s, height 0.15s;
+}
 .split-divider:hover,
 .split-divider:active {
   background: rgba(79,195,247,0.5);
   box-shadow: 0 0 8px rgba(79,195,247,0.2);
+}
+.split-divider:hover::after {
+  background: rgba(79,195,247,0.7);
+  height: 48px;
 }
 
 /* Full-width sections */
@@ -699,10 +715,10 @@
 }
 
 /* ── Responsive ───────────────────────────────────────────────────────────── */
-@media (max-width: 768px) {
+@media (max-width: 640px) {
   .app-sidebar { display: none; }
   .mobile-bottom-nav { display: flex; }
-  .app-layout { margin-bottom: 56px; }
+  .app-layout { margin-left: 0; margin-bottom: 56px; }
   .dot, .title { display: none; }
   .app-header { padding: 0 10px; }
 }

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -76,7 +76,7 @@ function Sidebar({ section, onSection, chatBadge, telegramBadge, expanded, onTog
         <Icon size={18} aria-hidden="true" />
         <span className="sidebar-label">{label}</span>
         {badge > 0 && (
-          <span className="sidebar-badge" aria-label={`${badge} nuevos`}>{badge > 99 ? '99+' : badge}</span>
+          <span className="sidebar-badge" aria-label={`${badge} mensajes sin leer en ${label}`}>{badge > 99 ? '99+' : badge}</span>
         )}
       </button>
     );

--- a/client/src/components/ContactsPanel.jsx
+++ b/client/src/components/ContactsPanel.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { X, Plus, Star, StarOff, Pencil, Trash2, Check, Phone, Mail, FileText, Link, MessageSquare } from 'lucide-react';
 import { API_BASE } from '../config';
 import { apiFetch } from '../authUtils';
@@ -268,15 +268,23 @@ export default function ContactsPanel({ onClose, embedded }) {
   const [contacts, setContacts] = useState([]);
   const [loading, setLoading] = useState(true);
   const [query, setQuery] = useState('');
+  const [debouncedQuery, setDebouncedQuery] = useState('');
+  const debounceRef = useRef(null);
   const [view, setView] = useState('list'); // 'list' | 'new' | 'edit' | 'detail'
   const [selected, setSelected] = useState(null); // contacto editando o detalle
   const [favOnly, setFavOnly] = useState(false);
+
+  // Debounce del query de búsqueda (300ms)
+  useEffect(() => {
+    debounceRef.current = setTimeout(() => setDebouncedQuery(query), 300);
+    return () => clearTimeout(debounceRef.current);
+  }, [query]);
 
   const load = useCallback(async () => {
     setLoading(true);
     try {
       const params = new URLSearchParams();
-      if (query) params.set('q', query);
+      if (debouncedQuery) params.set('q', debouncedQuery);
       if (favOnly) params.set('favorites', 'true');
       const res = await apiFetch(`${API}?${params}`);
       const data = await res.json();
@@ -286,7 +294,7 @@ export default function ContactsPanel({ onClose, embedded }) {
     } finally {
       setLoading(false);
     }
-  }, [query, favOnly]);
+  }, [debouncedQuery, favOnly]);
 
   useEffect(() => { load(); }, [load]);
 

--- a/client/src/components/TabBar.jsx
+++ b/client/src/components/TabBar.jsx
@@ -12,7 +12,12 @@ export default function TabBar({ sessions, activeId, onSelect, onClose, onNew })
           tabIndex={session.id === activeId ? 0 : -1}
           aria-selected={session.id === activeId}
           onClick={() => onSelect(session.id)}
-          onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onSelect(session.id); } }}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onSelect(session.id); }
+            const idx = sessions.findIndex(s => s.id === session.id);
+            if (e.key === 'ArrowRight' && idx < sessions.length - 1) { e.preventDefault(); onSelect(sessions[idx + 1].id); }
+            if (e.key === 'ArrowLeft' && idx > 0) { e.preventDefault(); onSelect(sessions[idx - 1].id); }
+          }}
         >
           <span className="tab-title">{session.title}</span>
           {sessions.length > 1 && (

--- a/client/src/components/TelegramPanel.jsx
+++ b/client/src/components/TelegramPanel.jsx
@@ -300,8 +300,9 @@ const AddBotForm = memo(function AddBotForm({ onAdd, onCancel }) {
     <div className="tg-add-form">
       <p className="tg-form-title">Agregar bot</p>
 
-      <label className="tg-label">Clave (identificador)</label>
+      <label className="tg-label" htmlFor="tg-bot-key">Clave (identificador)</label>
       <input
+        id="tg-bot-key"
         className="tg-input"
         type="text"
         placeholder="mibot, iglesia, radio..."
@@ -309,9 +310,10 @@ const AddBotForm = memo(function AddBotForm({ onAdd, onCancel }) {
         onChange={e => { setKey(e.target.value); setError(''); }}
       />
 
-      <label className="tg-label" style={{ marginTop: 8 }}>Token de BotFather</label>
+      <label className="tg-label" htmlFor="tg-bot-token" style={{ marginTop: 8 }}>Token de BotFather</label>
       <div className="tg-token-input-row">
         <input
+          id="tg-bot-token"
           className="tg-input"
           type={showToken ? 'text' : 'password'}
           placeholder="123456:ABC-DEF..."


### PR DESCRIPTION
## Summary
Fixes restantes de la auditoría del webclient:

- **#137** Debounce 300ms en búsqueda de contactos
- **#138** Handle visual en divider de split mode
- **#139** Aria-labels descriptivos en badges del sidebar
- **#140** htmlFor en labels del formulario de bots
- **#141** Navegación con flechas izquierda/derecha en tabs
- **#142** Header gradient usa CSS variables
- **#143** Breakpoint mobile estandarizado a 640px

## Test plan
- [ ] Buscar contactos → verificar debounce (no API call por keystroke)
- [ ] Split mode → divider muestra handle visual
- [ ] Tab → flechas izquierda/derecha cambian tab
- [ ] Light theme → header respeta variables