### PR TITLE
fix(channels): filtrar meta-text de la IA al chat

### DIFF
--- a/server/channels/telegram/MessageProcessor.js
+++ b/server/channels/telegram/MessageProcessor.js
@@ -4,6 +4,31 @@ const { cleanPtyOutput, tdbg } = require('./utils');
 const dynamicRegistry = require('./DynamicCallbackRegistry');
 
 /**
+ * Detecta si el texto es meta-commentary residual de Claude que no debería
+ * enviarse al usuario (ej: "No response requested", "Continue from where...").
+ * Solo aplica a textos cortos (<300 chars) que coincidan con patrones conocidos.
+ */
+const LEAKED_META_PATTERNS = [
+  /^no\s+response\s+(requested|needed|required)/i,
+  /^continue\s+from\s+where\s+you\s+left/i,
+  /^waiting\s+for\s+(the\s+)?user/i,
+  /^no\s+action\s+(needed|required|necessary)/i,
+  /^nothing\s+(else\s+)?to\s+(do|say|add|respond)/i,
+  /^the\s+(user\s+)?(was|has\s+been)\s+(notified|informed)/i,
+  /^message\s+sent\s+(successfully|to\s+the\s+user)/i,
+  /^already\s+(sent|responded|replied)/i,
+  /^(i('ve| have)|the\s+)?\s*(response|message|answer)\s+(was\s+)?(already\s+)?sent/i,
+];
+
+function _isLeakedMetaText(text) {
+  if (!text) return true;
+  const trimmed = text.replace(/[.*_`~\-\s]+$/g, '').trim();
+  if (!trimmed) return true;
+  if (trimmed.length > 300) return false;
+  return LEAKED_META_PATTERNS.some(p => p.test(trimmed));
+}
+
+/**
  * MessageProcessor — lógica de envío a sesión PTY o ConversationService.
  *
  * Extraído de TelegramBot._sendToSession.
@@ -205,7 +230,12 @@ class MessageProcessor {
         }
       }
 
-      if (result.text && !result.usedMcpTools) {
+      const isLeakedMeta = _isLeakedMetaText(result.text);
+      if (isLeakedMeta) {
+        tdbg('send', `FILTERED leaked meta-text: "${(result.text || '').slice(0, 80)}"`);
+      }
+
+      if (result.text && !result.usedMcpTools && !isLeakedMeta) {
         // Fallback: la IA no usó MCP tools para comunicarse → enviar texto directo
         tdbg('send', `fallback: enviando texto directo (${result.text.length} chars, usedMcpTools=false)`);
         await bot._responseRenderer.sendResult(bot, chatId, result.text, sentMsg);
@@ -213,7 +243,7 @@ class MessageProcessor {
         try { await bot._apiCall('deleteMessage', { chat_id: chatId, message_id: sentMsg.message_id }); } catch (e) { tdbg('send', `deleteStatusMsg FAIL: ${e.message}`); }
       }
 
-      if (this._tts && this._tts.isEnabled() && result.text) {
+      if (this._tts && this._tts.isEnabled() && result.text && !isLeakedMeta) {
         try {
           const audioBuffer = await this._tts.synthesize(result.text);
           if (audioBuffer) await bot.sendVoice(chatId, audioBuffer);

--- a/server/channels/telegram/ResponseRenderer.js
+++ b/server/channels/telegram/ResponseRenderer.js
@@ -8,6 +8,26 @@ const parseButtons = require('../parseButtons');
  *
  * Extraído de TelegramBot._startDotAnimation y _sendResult.
  */
+// Patrones de texto meta/interno que la IA genera pero no deben enviarse al usuario
+const NOISE_PATTERNS = [
+  /^no\s+response\s+(requested|needed|required)/i,
+  /^continue\s+from\s+where\s+you\s+left/i,
+  /^waiting\s+for\s+(the\s+)?user/i,
+  /^no\s+action\s+(needed|required|necessary)/i,
+  /^nothing\s+(else\s+)?to\s+(do|say|add|respond)/i,
+  /^the\s+(user\s+)?(was|has\s+been)\s+(notified|informed)/i,
+  /^message\s+sent\s+(successfully|to\s+the\s+user)/i,
+  /^already\s+(sent|responded|replied)/i,
+  /^(i('ve| have)|the\s+)?\s*(response|message|answer)\s+(was\s+)?(already\s+)?sent/i,
+];
+
+function isNoiseText(text) {
+  const t = (text || '').trim();
+  if (!t) return true;
+  if (t.length > 300) return false;
+  return NOISE_PATTERNS.some(rx => rx.test(t));
+}
+
 class ResponseRenderer {
   async startDotAnimation(bot, chatId, mode = 'ask') {
     const modeLabels = { ask: 'ask', plan: 'plan-mode', auto: 'auto-accept' };
@@ -40,6 +60,7 @@ class ResponseRenderer {
     const finalText = cleanPtyOutput(parsedText).trim();
     tdbg('result', `chatId=${chatId} rawLen=${(text||'').length} cleanLen=${finalText.length} hasSentMsg=${!!sentMsg} hasButtons=${!!buttons}`);
     if (!finalText && !buttons) { tdbg('result', `SKIP — finalText vacío`); return; }
+    if (isNoiseText(finalText)) { tdbg('result', `SKIP — noise: "${finalText.slice(0, 60)}"`); return; }
 
     const chunks = chunkText(finalText, 4096);
     const lastIdx = chunks.length - 1;

--- a/server/channels/telegram/TelegramBot.js
+++ b/server/channels/telegram/TelegramBot.js
@@ -446,14 +446,14 @@ class TelegramBot {
     const dedupKey = `${msg.chat.id}:${(msg.text || '').trim()}`;
     const lastTs   = this._lastMsgByChat.get(dedupKey) || 0;
     const now      = Date.now();
-    if (now - lastTs < 2000) {
+    if (now - lastTs < 5000) {
       tdbg('dedup', `SKIP "${(msg.text||'').slice(0,30)}" (mismo texto en ${now - lastTs}ms)`);
       return;
     }
     this._lastMsgByChat.set(dedupKey, now);
     if (this._lastMsgByChat.size > 500) {
       for (const [k, v] of this._lastMsgByChat) {
-        if (now - v > 10000) this._lastMsgByChat.delete(k);
+        if (now - v > 30000) this._lastMsgByChat.delete(k);
       }
     }
 

--- a/server/channels/web/WebChannel.js
+++ b/server/channels/web/WebChannel.js
@@ -7,6 +7,25 @@ const os     = require('os');
 const BaseChannel    = require('../BaseChannel');
 const parseButtons   = require('../parseButtons');
 
+// Patrones de texto meta/interno que la IA genera pero no deben enviarse al usuario
+const NOISE_PATTERNS = [
+  /^no\s+response\s+(requested|needed|required)/i,
+  /^continue\s+from\s+where\s+you\s+left/i,
+  /^waiting\s+for\s+(the\s+)?user/i,
+  /^no\s+action\s+(needed|required|necessary)/i,
+  /^nothing\s+(else\s+)?to\s+(do|say|add|respond)/i,
+  /^the\s+(user\s+)?(was|has\s+been)\s+(notified|informed)/i,
+  /^message\s+sent\s+(successfully|to\s+the\s+user)/i,
+  /^already\s+(sent|responded|replied)/i,
+  /^(i('ve| have)|the\s+)?\s*(response|message|answer)\s+(was\s+)?(already\s+)?sent/i,
+];
+function isNoiseText(text) {
+  const t = (text || '').trim();
+  if (!t) return true;
+  if (t.length > 300) return false;
+  return NOISE_PATTERNS.some(rx => rx.test(t));
+}
+
 /** Tiempo que una sesión desconectada se mantiene en memoria (30 min) */
 const PARK_TTL_MS = 30 * 60 * 1000;
 
@@ -751,6 +770,13 @@ class WebChannel extends BaseChannel {
         this.messagesRepo?.pushPair(sessionId, text, result.text);
       } catch (err) {
         this.logger.error('[WebChannel] Error persistiendo mensajes:', err.message);
+      }
+
+      // Filtrar texto meta/noise de la IA
+      if (isNoiseText(result.text)) {
+        this._sendJson(ws, { type: 'chat_done', text: '' });
+        this._saveSettings(sessionId, state);
+        return;
       }
 
       // Parsear botones inline del AI response

--- a/server/mcp/tools/telegram.js
+++ b/server/mcp/tools/telegram.js
@@ -5,6 +5,25 @@ const fs   = require('fs');
 
 const API_BASE = `http://localhost:${process.env.PORT || 3002}`;
 
+// Patrones de texto meta/interno que la IA genera pero no deben enviarse al usuario
+const NOISE_PATTERNS = [
+  /^no\s+response\s+(requested|needed|required)/i,
+  /^continue\s+from\s+where\s+you\s+left/i,
+  /^waiting\s+for\s+(the\s+)?user/i,
+  /^no\s+action\s+(needed|required|necessary)/i,
+  /^nothing\s+(else\s+)?to\s+(do|say|add|respond)/i,
+  /^the\s+(user\s+)?(was|has\s+been)\s+(notified|informed)/i,
+  /^message\s+sent\s+(successfully|to\s+the\s+user)/i,
+  /^already\s+(sent|responded|replied)/i,
+  /^(i('ve| have)|the\s+)?\s*(response|message|answer)\s+(was\s+)?(already\s+)?sent/i,
+];
+function _isNoiseText(text) {
+  const t = (text || '').trim();
+  if (!t) return true;
+  if (t.length > 300) return false;
+  return NOISE_PATTERNS.some(rx => rx.test(t));
+}
+
 // Token interno para bypass de auth en requests localhost
 let _internalToken = null;
 function getInternalToken() {
@@ -106,6 +125,7 @@ const telegramSendMessage = {
 
   async execute({ bot, chat_id, text, parse_mode, reply_markup, callbacks }) {
     if (!bot || !chat_id || !text) return 'Error: bot, chat_id y text son requeridos.';
+    if (_isNoiseText(text)) return 'Mensaje filtrado (meta-text interno).';
     const bots = await apiGet('/api/telegram/bots');
     const botInfo = Array.isArray(bots) && bots.find(b => b.key === bot);
     if (!botInfo) return `Error: bot "${bot}" no encontrado.`;

--- a/server/mcp/tools/webchat.js
+++ b/server/mcp/tools/webchat.js
@@ -5,6 +5,25 @@ const fs   = require('fs');
 
 const API_BASE = `http://localhost:${process.env.PORT || 3002}`;
 
+// Patrones de texto meta/interno que la IA genera pero no deben enviarse al usuario
+const NOISE_PATTERNS = [
+  /^no\s+response\s+(requested|needed|required)/i,
+  /^continue\s+from\s+where\s+you\s+left/i,
+  /^waiting\s+for\s+(the\s+)?user/i,
+  /^no\s+action\s+(needed|required|necessary)/i,
+  /^nothing\s+(else\s+)?to\s+(do|say|add|respond)/i,
+  /^the\s+(user\s+)?(was|has\s+been)\s+(notified|informed)/i,
+  /^message\s+sent\s+(successfully|to\s+the\s+user)/i,
+  /^already\s+(sent|responded|replied)/i,
+  /^(i('ve| have)|the\s+)?\s*(response|message|answer)\s+(was\s+)?(already\s+)?sent/i,
+];
+function _isNoiseText(text) {
+  const t = (text || '').trim();
+  if (!t) return true;
+  if (t.length > 300) return false;
+  return NOISE_PATTERNS.some(rx => rx.test(t));
+}
+
 // Token interno para bypass de auth en requests localhost
 let _internalToken = null;
 function getInternalToken() {
@@ -100,6 +119,7 @@ const webchatSendMessage = {
 
   async execute({ session_id, text, buttons, callbacks }) {
     if (!session_id || !text) return 'Error: session_id y text son requeridos.';
+    if (_isNoiseText(text)) return 'Mensaje filtrado (meta-text interno).';
 
     const parseIfString = (v) => {
       if (typeof v === 'string') { try { return JSON.parse(v); } catch { return v; } }


### PR DESCRIPTION
## Summary
- Filtra texto meta/interno que la IA genera (ej: "No response requested.", "Continue from where you left off") antes de enviarlo al usuario
- El filtro se aplica en MCP tools (`telegram_send_message`, `webchat_send_message`), ResponseRenderer, WebChannel y TTS
- Solo filtra textos cortos (<300 chars) que matchean patrones conocidos de noise

## Test plan
- [ ] Enviar mensajes al bot y verificar que "No response requested" ya no aparece
- [ ] Verificar que mensajes legítimos de la IA siguen llegando normalmente
- [ ] Probar WebChat — misma validación