### PR TITLE
fix(claude-session): detectar comm tools con prefijo MCP

### DIFF
--- a/server/core/ClaudePrintSession.js
+++ b/server/core/ClaudePrintSession.js
@@ -89,6 +89,8 @@ class ClaudePrintSession {
         'webchat_send_message', 'webchat_send_photo', 'webchat_send_document',
         'webchat_send_voice', 'webchat_send_video', 'webchat_edit_message',
       ];
+      // MCP tools llegan prefijadas (ej: mcp__clawmint__telegram_send_message)
+      const isCommTool = (name) => COMM_TOOLS.some(t => name === t || name.endsWith('__' + t));
 
       const emitStatus = (status, detail = null) => {
         if (onStatus) onStatus(status, detail);
@@ -117,8 +119,8 @@ class ClaudePrintSession {
             // Detectar inicio de tool_use para status
             if (inner.type === 'content_block_start' && inner.content_block?.type === 'tool_use') {
               const toolName = inner.content_block.name || 'herramienta';
-              if (COMM_TOOLS.includes(toolName)) usedMcpTools = true;
-              cpdbg('event', `#${eventCount} tool_use start: ${toolName} isTelegramTool=${COMM_TOOLS.includes(toolName)}`);
+              if (isCommTool(toolName)) usedMcpTools = true;
+              cpdbg('event', `#${eventCount} tool_use start: ${toolName} isCommTool=${isCommTool(toolName)}`);
               emitStatus('tool_use', toolName);
             }
             // Detectar inicio de bloque de texto
@@ -143,7 +145,7 @@ class ClaudePrintSession {
             cpdbg('event', `#${eventCount} assistant content=${Array.isArray(content) ? content.length + ' blocks' : 'none'} fullText=${fullText.length}`);
             if (Array.isArray(content)) {
               // Detectar tool_use de telegram en bloques de assistant
-              const hasTelegramTool = content.some(b => b.type === 'tool_use' && COMM_TOOLS.includes(b.name));
+              const hasTelegramTool = content.some(b => b.type === 'tool_use' && isCommTool(b.name));
               if (hasTelegramTool) usedMcpTools = true;
 
               const textBlock = content.find(b => b.type === 'text');


### PR DESCRIPTION
## Summary
- `COMM_TOOLS.includes(toolName)` no matcheaba nombres MCP prefijados como `mcp__clawmint__telegram_send_message`
- `usedMcpTools` quedaba en `false`, causando que MessageProcessor enviara el texto como segundo mensaje duplicado
- Fix: `isCommTool(name)` usa `endsWith('__' + t)` para matchear con o sin prefijo MCP

## Test plan
- [ ] Enviar mensaje a chibi2026_bot y verificar que solo llega UNA respuesta
- [ ] Verificar que el status message se borra correctamente después de usar tools